### PR TITLE
fix(ebpf): correctly extract pid and tgid from bpf_get_current_pid_tgid

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -205,8 +205,9 @@ int bpf_phase2_rewrite(struct pt_regs *ctx) {
     struct tls_event *event =
         bpf_ringbuf_reserve(&tls_events, sizeof(struct tls_event), 0);
     if (event) {
-      event->pid = bpf_get_current_pid_tgid();
-      event->tgid = bpf_get_current_pid_tgid() >> 32;
+      __u64 pid_tgid = bpf_get_current_pid_tgid();
+      event->pid  = (__u32)(pid_tgid & 0xFFFFFFFF);
+      event->tgid = (__u32)(pid_tgid >> 32);
       event->len = read_len;
       event->is_rewritten = 1;
       bpf_ringbuf_submit(event, 0);


### PR DESCRIPTION
## Problem
\`event->pid = bpf_get_current_pid_tgid()\` assigns the raw 64-bit combined value (truncated to u32) to the pid field. The correct PID is the **lower 32 bits**; the upper 32 bits are the TGID. The userspace log was printing a meaningless number for every rewrite event.

## Fix
Capture the return value once and use bitwise extraction:
\`\`\`c
__u64 pid_tgid = bpf_get_current_pid_tgid();
event->pid  = (__u32)(pid_tgid & 0xFFFFFFFF);
event->tgid = (__u32)(pid_tgid >> 32);
\`\`\`
This also eliminates the redundant second call to the helper.