### PR TITLE
fix(ebpf): correct write_len verifier mask to handle 128-byte secrets

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -188,10 +188,14 @@ int bpf_phase2_rewrite(struct pt_regs *ctx) {
         char *target = (char *)scratch_data->user_data_ptr + safe_i;
 
         __u32 write_len = val->len;
-        write_len &= (SECRET_MAX_LEN - 1);
-
         if (write_len == 0)
           continue;
+        if (write_len > SECRET_MAX_LEN)
+          write_len = SECRET_MAX_LEN;
+        /* Use 2*SECRET_MAX_LEN-1 as the verifier mask: covers [1,128] safely
+         * since write_len <= 128 <= 255. The previous mask (SECRET_MAX_LEN-1 = 127)
+         * incorrectly zeroed write_len when val->len == 128. */
+        write_len &= (2 * SECRET_MAX_LEN - 1);
 
         bpf_probe_write_user(target, val->real_secret, write_len);
         rewritten = 1;


### PR DESCRIPTION
## Problem
In \`bpf_phase2_rewrite\`, the eBPF verifier bounds-check mask is:
\`\`\`c
write_len &= (SECRET_MAX_LEN - 1);  // 128 - 1 = 127 = 0x7F
\`\`\`
When \`val->len == 128\` (the maximum valid value, explicitly allowed by the preceding \`val->len <= SECRET_MAX_LEN\` check), \`128 & 127 == 0\`, triggering the \`if (write_len == 0) continue\` guard. 128-byte secrets are silently never rewritten.

## Fix
Move the zero-guard before the mask, add an explicit clamp to \`SECRET_MAX_LEN\`, and use \`2*SECRET_MAX_LEN-1 = 255\` as the verifier mask. Since \`write_len <= 128 <= 255\` after the clamp, the mask is safe and no longer drops 128-byte values.