### PR TITLE
fix: honour --cert-mode=provided and skip certificate generation

### DIFF
--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -85,12 +85,16 @@ func runController(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	_, err = webhook.EnsureWebhookCerts(context.Background(), directClient, namespace)
-	if err != nil {
-		setupLog.Error(err, "failed to ensure webhook TLS certificates")
-		// The webhook might fail to start since the secret won't exist.
+	if certMode == "auto" {
+		_, err = webhook.EnsureWebhookCerts(context.Background(), directClient, namespace)
+		if err != nil {
+			setupLog.Error(err, "failed to ensure webhook TLS certificates")
+			// The webhook might fail to start since the secret won't exist.
+		} else {
+			setupLog.Info("Webhook TLS certificates ensured")
+		}
 	} else {
-		setupLog.Info("Webhook TLS certificates exist")
+		setupLog.Info("Cert mode is 'provided'; skipping certificate generation — expecting kloak-webhook-certs secret to exist")
 	}
 
 	// Create uprobe manager instances


### PR DESCRIPTION
## Problem
The \`--cert-mode\` flag advertises two modes (\`auto\` and \`provided\`) but \`runController\` always called \`webhook.EnsureWebhookCerts\` unconditionally. Operators who pre-provision the \`kloak-webhook-certs\` secret and pass \`--cert-mode=provided\` would still trigger a generation attempt, potentially conflicting with their cert management tooling.

## Fix
Gate the \`EnsureWebhookCerts\` call on \`certMode == "auto"\`. When \`provided\` is set, log that generation is skipped and expect the secret to already exist.