### PR TITLE
refactor: remove unused GetPodCgroupPath and CgroupManager dead code

### DIFF
--- a/pkg/cgroups/utils.go
+++ b/pkg/cgroups/utils.go
@@ -44,44 +44,6 @@ func FindContainerCgroupPath(cgroupRoot, podUID, containerID string) (string, er
 	return "", fmt.Errorf("cgroup path not found for container %s", containerID)
 }
 
-// GetPodCgroupPath returns the parent cgroup of a container, which corresponds to the Pod cgroup.
-// It uses FindContainerCgroupPath to locate the container first, and falls back to
-// searching for the pod-level cgroup slice directly if the container scope is not yet created.
-func GetPodCgroupPath(cgroupRoot, podUID, containerID string) (string, error) {
-	if cgroupRoot == "" {
-		cgroupRoot = DefaultCgroupRoot
-	}
-
-	podUIDUnderscored := strings.ReplaceAll(podUID, "-", "_")
-
-	// 1. Try finding container first (to get the exact slice)
-	if containerPath, err := FindContainerCgroupPath(cgroupRoot, podUID, containerID); err == nil {
-		return filepath.Dir(containerPath), nil
-	}
-
-	// 2. Fallback: Search for Pod-level cgroup slice directly (common when container scope isn't ready)
-	podPatterns := []string{
-		// containerd/systemd patterns
-		filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-burstable.slice",
-			fmt.Sprintf("kubepods-burstable-pod%s.slice", podUIDUnderscored)),
-		filepath.Join(cgroupRoot, "kubepods.slice", "kubepods-besteffort.slice",
-			fmt.Sprintf("kubepods-besteffort-pod%s.slice", podUIDUnderscored)),
-		filepath.Join(cgroupRoot, "kubepods.slice",
-			fmt.Sprintf("kubepods-pod%s.slice", podUIDUnderscored)),
-		// Alternative patterns
-		filepath.Join(cgroupRoot, "kubepods", "burstable", fmt.Sprintf("pod%s", podUID)),
-		filepath.Join(cgroupRoot, "kubepods", "pod"+podUID),
-	}
-
-	for _, path := range podPatterns {
-		if _, err := os.Stat(path); err == nil {
-			return path, nil
-		}
-	}
-
-	return "", fmt.Errorf("pod cgroup path not found for pod %s", podUID)
-}
-
 // ReadCgroupProcs reads the PIDs from a cgroup's cgroup.procs file.
 func ReadCgroupProcs(cgroupPath string) ([]int, error) {
 	procsPath := filepath.Join(cgroupPath, "cgroup.procs")

--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -24,12 +24,6 @@ const (
 	CgroupBasePath = "/sys/fs/cgroup"
 )
 
-// CgroupManager is the interface for managing cgroups in eBPF maps.
-type CgroupManager interface {
-	AddCgroup(cgroupID uint64) error
-	RemoveCgroup(cgroupID uint64) error
-}
-
 // Reconciler watches pods and manages eBPF cgroup tracking.
 type Reconciler struct {
 	client.Client


### PR DESCRIPTION
## What
- Remove \`GetPodCgroupPath\` from \`pkg/cgroups/utils.go\` — exported but never called
- Remove \`CgroupManager\` interface from \`pkg/controller/reconciler.go\` — defined but never implemented or used

## Why
Both are artifacts from earlier design iterations. Leaving exported dead code creates confusion for contributors and makes grep results noisy.

## Verification
\`go build ./...\` and \`go test ./pkg/...\` both pass.