### PR TITLE
fix: attach TLS uprobes to all PIDs in container cgroup, not just first

### DIFF
--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -177,12 +177,16 @@ func (r *Reconciler) attachUprobesToCgroup(cgroupID uint64, pod *corev1.Pod) {
 			return
 		}
 
-		// Attach uprobes to the first PID (main process)
-		pid := pids[0]
-		if err := r.UprobeManager.AttachTLS(pid); err != nil {
-			r.Log.Error(err, "failed to attach TLS uprobes", "pid", pid, "container", status.Name)
-		} else {
-			r.Log.Info("Successfully attached TLS uprobes", "pid", pid, "container", status.Name)
+		// Attempt to attach uprobes to every PID in the cgroup.
+		// Containers may run multiple processes; we probe all of them so that
+		// whichever process makes TLS calls is instrumented. AttachTLS skips
+		// PIDs that have no compatible TLS symbols.
+		for _, pid := range pids {
+			if err := r.UprobeManager.AttachTLS(pid); err != nil {
+				r.Log.V(1).Info("could not attach TLS uprobes to pid (no compatible symbols or already attached)", "pid", pid, "container", status.Name, "err", err)
+			} else {
+				r.Log.Info("Successfully attached TLS uprobes", "pid", pid, "container", status.Name)
+			}
 		}
 		return
 	}


### PR DESCRIPTION
## Problem
\`attachUprobesToCgroup\` read all PIDs from \`cgroup.procs\` but only called \`AttachTLS(pids[0])\`. Containers that run a supervisor, shell, or multiple workers alongside the main app would miss instrumentation if the TLS-making process was not first in the list.

## Fix
Iterate all PIDs and attempt \`AttachTLS\` on each. \`AttachTLS\` returns an error when no compatible TLS symbol is found (Go \`crypto/tls\` or OpenSSL), so probing non-TLS helper processes is harmless. Per-PID failures are logged at \`V(1)\` to avoid log spam from processes that legitimately have no TLS symbols.