### PR TITLE
fix: resolve handleDelete key mismatch between UID and namespaced name

### DIFF
--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -42,6 +42,11 @@ type Reconciler struct {
 
 	// trackedPods maps pod UID -> set of cgroup IDs (one per container)
 	trackedPods map[string]map[uint64]bool
+
+	// podKeyToUID maps "namespace/name" -> pod UID, so that on a NotFound
+	// delete event (where we only have the namespaced name) we can look up
+	// the UID and clean up trackedPods correctly.
+	podKeyToUID map[string]string
 }
 
 // NewReconciler creates a new pod reconciler.
@@ -57,6 +62,7 @@ func NewReconciler(c client.Client, log logr.Logger, scheme *runtime.Scheme, upr
 		CgroupRoot:    cgroupRoot,
 		NodeName:      nodeName,
 		trackedPods:   make(map[string]map[uint64]bool),
+		podKeyToUID:   make(map[string]string),
 	}
 }
 
@@ -70,15 +76,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, err
 		}
-		// Pod was deleted - clean up
-		return r.handleDelete(req.NamespacedName.String())
+		// Pod was deleted — look up the UID we stored on the last successful
+		// reconcile so we can find the entry in trackedPods (keyed by UID).
+		uid, known := r.podKeyToUID[req.NamespacedName.String()]
+		if !known {
+			return ctrl.Result{}, nil
+		}
+		return r.handleDelete(uid, req.NamespacedName.String())
 	}
 
 	// Check if Kloak is enabled
 	if !r.isEnabled(pod) {
 		// If was tracked before, clean up
 		if _, tracked := r.trackedPods[string(pod.UID)]; tracked {
-			return r.handleDelete(string(pod.UID))
+			return r.handleDelete(string(pod.UID), req.NamespacedName.String())
 		}
 		return ctrl.Result{}, nil
 	}
@@ -131,6 +142,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	r.trackedPods[string(pod.UID)] = existingCgroups
+	r.podKeyToUID[req.NamespacedName.String()] = string(pod.UID)
 
 	return ctrl.Result{}, nil
 }
@@ -190,9 +202,10 @@ func (r *Reconciler) attachUprobesToCgroup(cgroupID uint64, pod *corev1.Pod) {
 	r.Log.V(1).Info("could not find matching container for cgroup", "cgroupID", cgroupID)
 }
 
-// handleDelete removes a pod from tracking.
-func (r *Reconciler) handleDelete(podKey string) (ctrl.Result, error) {
-	cgroupIDs, tracked := r.trackedPods[podKey]
+// handleDelete removes a pod from tracking. uid is the pod UID (trackedPods key),
+// namespacedName is the "namespace/name" string (podKeyToUID key).
+func (r *Reconciler) handleDelete(uid, namespacedName string) (ctrl.Result, error) {
+	cgroupIDs, tracked := r.trackedPods[uid]
 	if !tracked {
 		return ctrl.Result{}, nil
 	}
@@ -200,8 +213,9 @@ func (r *Reconciler) handleDelete(podKey string) (ctrl.Result, error) {
 	// Uprobes will be automatically cleaned up by the uprobe component when
 	// the process dies, so we no longer have to detach them manually or remove cgroups from maps.
 	// Just remove the pod from our tracking.
-	delete(r.trackedPods, podKey)
-	r.Log.Info("stopped tracking pod", "podKey", podKey, "cgroupCount", len(cgroupIDs))
+	delete(r.trackedPods, uid)
+	delete(r.podKeyToUID, namespacedName)
+	r.Log.Info("stopped tracking pod", "pod", namespacedName, "uid", uid, "cgroupCount", len(cgroupIDs))
 
 	return ctrl.Result{}, nil
 }

--- a/pkg/controller/reconciler_test.go
+++ b/pkg/controller/reconciler_test.go
@@ -57,13 +57,15 @@ func TestIsEnabled(t *testing.T) {
 func TestHandleDelete(t *testing.T) {
 	r := &Reconciler{
 		trackedPods: make(map[string]map[uint64]bool),
+		podKeyToUID: make(map[string]string),
 	}
 
 	// Add a tracked pod with multiple container cgroups
 	r.trackedPods["test-pod-uid"] = map[uint64]bool{12345: true, 67890: true}
+	r.podKeyToUID["default/test-pod"] = "test-pod-uid"
 
 	// Handle delete
-	_, err := r.handleDelete("test-pod-uid")
+	_, err := r.handleDelete("test-pod-uid", "default/test-pod")
 	if err != nil {
 		t.Fatalf("handleDelete failed: %v", err)
 	}
@@ -71,6 +73,11 @@ func TestHandleDelete(t *testing.T) {
 	// Verify pod is no longer tracked
 	if _, exists := r.trackedPods["test-pod-uid"]; exists {
 		t.Error("Pod should no longer be tracked")
+	}
+
+	// Verify reverse map is also cleaned up
+	if _, exists := r.podKeyToUID["default/test-pod"]; exists {
+		t.Error("podKeyToUID entry should be removed on delete")
 	}
 }
 


### PR DESCRIPTION
## Problem

When a pod is deleted, `Reconcile` gets a `NotFound` error and only has `req.NamespacedName` (e.g. `"default/my-pod"`). But `trackedPods` is keyed by **pod UID** (e.g. `"a1b2c3d4-..."`).

The old code passed `req.NamespacedName.String()` directly to `handleDelete`, which looked it up in `trackedPods` — guaranteed miss. This means deleted pods were **never cleaned up** from the tracking map, causing a slow memory leak proportional to pod churn.

## Fix

Added a `podKeyToUID map[string]string` reverse map to `Reconciler`:

- **Populated** in `Reconcile` right after updating `trackedPods` — records `"namespace/name" → UID`
- **Used** on delete (NotFound path) — resolves the namespaced name to UID before looking up `trackedPods`
- **Cleaned up** in `handleDelete` — both `trackedPods[uid]` and `podKeyToUID[namespacedName]` are deleted together

Also updated the test to verify both maps are cleaned up.

## Test plan
- [x] `go test ./pkg/controller/...` passes
- [ ] Deploy and verify pods are properly removed from tracking on deletion (check logs for "stopped tracking pod" messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)