### PR TITLE
fix: add contents:read permission to docker job for checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, build, test]
     permissions:
+      contents: read
       packages: write
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Problem

The Docker Build job fails on main with:
```
fatal: repository 'https://github.com/spinningfactory/kloak/' not found
```

Setting `permissions: packages: write` at job level **replaces** all default permissions, removing `contents: read` that `actions/checkout` needs.

## Fix

Add `contents: read` explicitly alongside `packages: write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)