### PR TITLE
chore: add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <div align="center">
 
+[![CI](https://github.com/spinningfactory/kloak/actions/workflows/ci.yml/badge.svg)](https://github.com/spinningfactory/kloak/actions/workflows/ci.yml)
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://go.dev/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.28+-326CE5?logo=kubernetes)](https://kubernetes.io/)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
Adds CI status badge to the README badges row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)