### PR TITLE
fix: collect e2e coverage before controller pod is deleted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,7 @@ jobs:
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
           KUBECONFIG: /tmp/kubeconfig-e2e.yaml
+          KLOAK_SKIP_TEARDOWN: "1"
 
       - name: Collect e2e coverage from controller pod
         if: always()
@@ -261,10 +262,15 @@ jobs:
           mkdir -p /tmp/e2e-covdata
           CTRL_POD=$(kubectl get pods -n kloak-system -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
           if [ -n "$CTRL_POD" ]; then
+            echo "Found controller pod: $CTRL_POD"
             # SIGTERM triggers graceful shutdown which flushes GOCOVERDIR
             kubectl exec -n kloak-system "$CTRL_POD" -- kill -TERM 1 2>/dev/null || true
-            sleep 5
-            kubectl cp "kloak-system/$CTRL_POD:/tmp/coverage" /tmp/e2e-covdata/ 2>/dev/null || true
+            echo "Waiting for coverage flush..."
+            sleep 10
+            # Copy coverage files from the pod
+            kubectl cp "kloak-system/$CTRL_POD:/tmp/coverage/." /tmp/e2e-covdata/ 2>/dev/null || true
+          else
+            echo "Controller pod not found"
           fi
           echo "E2E coverage files:"
           ls -la /tmp/e2e-covdata/ 2>/dev/null || echo "No coverage files collected"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -122,7 +122,13 @@ func TestMain(m *testing.M) {
 func teardown() {
 	// Delete test namespace (cascade deletes all resources in it)
 	_ = clientset.CoreV1().Namespaces().Delete(context.Background(), testNamespace, metav1.DeleteOptions{})
-	// Remove kloak deployment
+
+	// When KLOAK_SKIP_TEARDOWN=1, leave kloak running so CI can collect
+	// coverage data from the controller pod before the cluster is deleted.
+	if os.Getenv("KLOAK_SKIP_TEARDOWN") == "1" {
+		fmt.Println("KLOAK_SKIP_TEARDOWN=1: skipping kloak deployment deletion (CI will clean up)")
+		return
+	}
 	overlayPath := filepath.Join(repoRoot, "config", "overlays", overlayDir)
 	_, _ = kubectl("delete", "-k", overlayPath, "--ignore-not-found")
 }


### PR DESCRIPTION
## Problem

The e2e coverage collection step found an empty directory because `TestMain`'s `teardown()` deleted the kloak deployment (including the controller pod) before CI could SIGTERM it and copy the coverage files.

## Fix

- Set `KLOAK_SKIP_TEARDOWN=1` in the CI e2e test step
- `teardown()` skips deleting kloak when this env var is set
- CI collects coverage from the still-running controller pod
- The k3d cluster deletion (always runs) handles final cleanup
- Fixed `kubectl cp` path to copy directory contents (`.` suffix)
- Increased coverage flush wait from 5s to 10s

## Expected result

After this fix, the `combined-coverage.out` artifact should include both unit test AND e2e integration test coverage, increasing the badge percentage beyond the current 69.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)