### PR TITLE
fix: use hostPath for e2e coverage, simplify collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,12 +282,23 @@ jobs:
             echo "No e2e coverage data found, using unit coverage only"
           fi
 
-          # Merge: start with unit coverage, overlay e2e coverage
+          # Merge: start with unit coverage, overlay e2e coverage.
+          # Only include e2e lines for packages that exist in unit coverage
+          # (generated files like tlsuprobe_bpfel.go aren't on the runner).
           cp /tmp/unit-coverage/coverage.out /tmp/combined-coverage.out
 
           if [ -f /tmp/e2e-coverage.out ]; then
-            # Append e2e coverage lines (skip the mode line) to combined file
-            tail -n +2 /tmp/e2e-coverage.out >> /tmp/combined-coverage.out
+            # Extract package prefixes from unit coverage
+            UNIT_PKGS=$(grep -oP 'github\.com/spinningfactory/kloak/[^/]+/[^/]+' /tmp/unit-coverage/coverage.out | sort -u)
+            # Append only matching e2e lines (skip mode line)
+            while IFS= read -r line; do
+              for pkg in $UNIT_PKGS; do
+                if echo "$line" | grep -q "$pkg"; then
+                  echo "$line" >> /tmp/combined-coverage.out
+                  break
+                fi
+              done
+            done < <(tail -n +2 /tmp/e2e-coverage.out)
             echo "Combined unit + e2e coverage"
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,26 +252,15 @@ jobs:
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
           KUBECONFIG: /tmp/kubeconfig-e2e.yaml
-          KLOAK_SKIP_TEARDOWN: "1"
 
-      - name: Collect e2e coverage from controller pod
+      - name: Collect e2e coverage
         if: always()
-        env:
-          KUBECONFIG: /tmp/kubeconfig-e2e.yaml
         run: |
           mkdir -p /tmp/e2e-covdata
-          CTRL_POD=$(kubectl get pods -n kloak-system -l app.kubernetes.io/component=controller -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          if [ -n "$CTRL_POD" ]; then
-            echo "Found controller pod: $CTRL_POD"
-            # SIGTERM triggers graceful shutdown which flushes GOCOVERDIR
-            kubectl exec -n kloak-system "$CTRL_POD" -- kill -TERM 1 2>/dev/null || true
-            echo "Waiting for coverage flush..."
-            sleep 10
-            # Copy coverage files from the pod
-            kubectl cp "kloak-system/$CTRL_POD:/tmp/coverage/." /tmp/e2e-covdata/ 2>/dev/null || true
-          else
-            echo "Controller pod not found"
-          fi
+          # Coverage files are on the k3d node's hostPath (/tmp/kloak-coverage).
+          # The test teardown deleted kloak, which triggered a clean controller
+          # shutdown that flushed covcounters to the hostPath volume.
+          docker cp k3d-kloak-e2e-server-0:/tmp/kloak-coverage/. /tmp/e2e-covdata/ 2>/dev/null || true
           echo "E2E coverage files:"
           ls -la /tmp/e2e-covdata/ 2>/dev/null || echo "No coverage files collected"
 

--- a/config/overlays/e2e/kustomization.yaml
+++ b/config/overlays/e2e/kustomization.yaml
@@ -8,13 +8,27 @@ resources:
   - ../../manifests
 
 patches:
-  # Add GOCOVERDIR env var for coverage-instrumented binary
+  # Add GOCOVERDIR env var and hostPath volume for coverage data.
+  # hostPath persists coverage files after the controller exits
+  # (DaemonSet restart would overwrite in-container /tmp/coverage).
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/env/-
         value:
           name: GOCOVERDIR
-          value: /tmp/coverage
+          value: /coverage
+      - op: add
+        path: /spec/template/spec/containers/0/volumeMounts/-
+        value:
+          name: coverage
+          mountPath: /coverage
+      - op: add
+        path: /spec/template/spec/volumes/-
+        value:
+          name: coverage
+          hostPath:
+            path: /tmp/kloak-coverage
+            type: DirectoryOrCreate
     target:
       kind: DaemonSet
       name: kloak-controller

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -122,13 +122,9 @@ func TestMain(m *testing.M) {
 func teardown() {
 	// Delete test namespace (cascade deletes all resources in it)
 	_ = clientset.CoreV1().Namespaces().Delete(context.Background(), testNamespace, metav1.DeleteOptions{})
-
-	// When KLOAK_SKIP_TEARDOWN=1, leave kloak running so CI can collect
-	// coverage data from the controller pod before the cluster is deleted.
-	if os.Getenv("KLOAK_SKIP_TEARDOWN") == "1" {
-		fmt.Println("KLOAK_SKIP_TEARDOWN=1: skipping kloak deployment deletion (CI will clean up)")
-		return
-	}
+	// Remove kloak deployment. The controller exits cleanly, flushing
+	// coverage data to the hostPath volume (/tmp/kloak-coverage on the
+	// k3d node) which CI copies after teardown.
 	overlayPath := filepath.Join(repoRoot, "config", "overlays", overlayDir)
 	_, _ = kubectl("delete", "-k", overlayPath, "--ignore-not-found")
 }


### PR DESCRIPTION
## Problem

Coverage collection from the controller pod failed — only `covmeta` was found, not `covcounters`. The DaemonSet restarted the controller after SIGTERM, overwriting the in-container `/tmp/coverage` before CI could copy the files.

## Fix

Mount `GOCOVERDIR` as a **hostPath volume** (`/tmp/kloak-coverage` on the k3d node). Coverage files persist on the node filesystem regardless of pod lifecycle.

The flow is now simple:
1. Test teardown deletes kloak (normal behavior, no special env vars)
2. Controller exits cleanly → Go flushes covcounters to hostPath
3. CI runs `docker cp k3d-kloak-e2e-server-0:/tmp/kloak-coverage/. /tmp/e2e-covdata/`

Removes `KLOAK_SKIP_TEARDOWN` since it's no longer needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)