### PR TITLE
feat: TLS SNI-based host filtering for non-HTTP protocols

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,8 @@ jobs:
           docker build -t kloak-demo-python:latest ./examples/demo-python/
           docker build -t kloak-demo-js:latest ./examples/demo-js/
           docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
-          k3d image import kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest -c kloak-e2e
+          docker build -t kloak-demo-python-sni:latest ./examples/demo-python-sni/
+          k3d image import kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-python-sni:latest -c kloak-e2e
           docker pull bitnami/kubectl:latest
           k3d image import bitnami/kubectl:latest -c kloak-e2e
 
@@ -331,6 +332,8 @@ jobs:
           kubectl logs -n kloak-e2e -l app=demo-js --tail=50 2>/dev/null || true
           echo "=== Demo Go BoringSSL Logs ==="
           kubectl logs -n kloak-e2e -l app=demo-go-boring --tail=50 2>/dev/null || true
+          echo "=== Demo Python SNI Logs ==="
+          kubectl logs -n kloak-e2e -l app=demo-python-sni --tail=50 2>/dev/null || true
           echo "=== All Pods ==="
           kubectl get pods -A 2>/dev/null || true
           echo "=== Events ==="

--- a/.github/workflows/e2e-ebpf.yml
+++ b/.github/workflows/e2e-ebpf.yml
@@ -39,10 +39,14 @@ jobs:
         run: |
           docker build --build-arg TARGETARCH=amd64 -t kloak:e2e .
           docker build -t kloak-demo-go:e2e -t kloak-demo-go:latest ./examples/demo-go/
+          docker build -t kloak-demo-python:latest ./examples/demo-python/
+          docker build -t kloak-demo-js:latest ./examples/demo-js/
+          docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
+          docker build -t kloak-demo-python-sni:latest ./examples/demo-python-sni/
 
       - name: Import images into k3d
         run: |
-          k3d image import kloak:e2e kloak-demo-go:e2e kloak-demo-go:latest -c kloak-ebpf
+          k3d image import kloak:e2e kloak-demo-go:e2e kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-python-sni:latest -c kloak-ebpf
           docker pull bitnami/kubectl:latest
           k3d image import bitnami/kubectl:latest -c kloak-ebpf
 

--- a/examples/demo-python-sni/Dockerfile
+++ b/examples/demo-python-sni/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# openssl CLI needed to generate self-signed certs for the echo server
+RUN apt-get update && apt-get install -y --no-install-recommends openssl && rm -rf /var/lib/apt/lists/*
+
+COPY app.py .
+
+CMD ["python", "-u", "app.py"]

--- a/examples/demo-python-sni/app.py
+++ b/examples/demo-python-sni/app.py
@@ -1,0 +1,141 @@
+"""
+Demo: SNI-based host filtering for non-HTTP TLS protocols.
+
+Tests that Kloak's eBPF uprobes capture the hostname from
+SSL_set_tlsext_host_name (SNI) and use it for host-based secret filtering,
+even when the TLS payload is NOT HTTP (no Host header to fall back on).
+
+Architecture:
+  1. A TLS echo server runs on localhost:8443 (self-signed cert)
+  2. A TLS client connects with server_hostname="httpbin.org" (sets SNI)
+  3. The client sends raw (non-HTTP) data containing the secret
+  4. The echo server sends it back
+  5. If eBPF rewrote the secret (SNI matched), the echo contains the real value
+
+The allowed secret (hosts=httpbin.org) should be rewritten because SNI = httpbin.org.
+The blocked secret (hosts=example.com) should NOT be rewritten.
+"""
+
+import os
+import socket
+import ssl
+import subprocess
+import sys
+import threading
+import time
+
+CERT_PATH = "/tmp/cert.pem"
+KEY_PATH = "/tmp/key.pem"
+LISTEN_PORT = 8443
+
+
+def generate_self_signed_cert():
+    """Generate a self-signed certificate for the local echo server."""
+    subprocess.run(
+        [
+            "openssl", "req", "-x509", "-newkey", "rsa:2048",
+            "-keyout", KEY_PATH, "-out", CERT_PATH,
+            "-days", "1", "-nodes", "-subj", "/CN=localhost",
+        ],
+        check=True,
+        capture_output=True,
+    )
+    print(f"Generated self-signed cert at {CERT_PATH}")
+
+
+def echo_server():
+    """TLS echo server that returns whatever it receives."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(CERT_PATH, KEY_PATH)
+    srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    srv.bind(("127.0.0.1", LISTEN_PORT))
+    srv.listen(5)
+    while True:
+        conn, _ = srv.accept()
+        try:
+            tls_conn = ctx.wrap_socket(conn, server_side=True)
+            data = tls_conn.recv(4096)
+            if data:
+                tls_conn.sendall(data)
+            tls_conn.shutdown(socket.SHUT_RDWR)
+            tls_conn.close()
+        except Exception:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def load_secret(env_var, default):
+    """Load a secret from a file path specified by an environment variable."""
+    path = os.getenv(env_var)
+    if path and os.path.exists(path):
+        with open(path) as f:
+            value = f.read().strip()
+        print(f"Loaded secret from {path}")
+        return value
+    return default
+
+
+def send_and_echo(secret_allowed, secret_blocked, sni_host):
+    """Connect to local echo server with SNI, send secrets, return echo."""
+    ctx = ssl.create_default_context()
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_NONE
+
+    # Python's wrap_socket calls SSL_set_tlsext_host_name(sni_host)
+    # which the eBPF uprobe intercepts and caches for host filtering.
+    with socket.create_connection(("127.0.0.1", LISTEN_PORT)) as sock:
+        with ctx.wrap_socket(sock, server_hostname=sni_host) as tls:
+            payload = f"ALLOWED={secret_allowed}\nBLOCKED={secret_blocked}\n"
+            tls.sendall(payload.encode())
+            return tls.recv(4096).decode()
+
+
+def main():
+    key_allowed = load_secret("SECRET_ALLOWED_FILE", "allowed-default-key")
+    key_blocked = load_secret("SECRET_BLOCKED_FILE", "blocked-default-key")
+    sni_host = os.getenv("SNI_HOST", "httpbin.org")
+    interval = int(os.getenv("REQUEST_INTERVAL", "5"))
+
+    print("=" * 60)
+    print("Kloak Demo: SNI Host Filtering (non-HTTP)")
+    print("=" * 60)
+    print(f"SNI hostname: {sni_host}")
+    print(f"Secret Allowed: {key_allowed[:30]}...")
+    print(f"Secret Blocked: {key_blocked[:30]}...")
+    print("=" * 60)
+    sys.stdout.flush()
+
+    generate_self_signed_cert()
+
+    # Start echo server in background
+    t = threading.Thread(target=echo_server, daemon=True)
+    t.start()
+    time.sleep(1)
+    print("Echo server started on port", LISTEN_PORT)
+
+    # Wait for Kloak eBPF to attach
+    startup_delay = int(os.getenv("STARTUP_DELAY", "15"))
+    print(f"Waiting {startup_delay}s for eBPF attachment...")
+    sys.stdout.flush()
+    time.sleep(startup_delay)
+
+    count = 0
+    while True:
+        count += 1
+        try:
+            echo = send_and_echo(key_allowed, key_blocked, sni_host)
+            print(f"\n--- Request #{count} (SNI={sni_host}) ---")
+            print(f"Echo: {echo.strip()}")
+            sys.stdout.flush()
+        except Exception as e:
+            print(f"\n--- Request #{count} ---")
+            print(f"Error: {e}")
+            sys.stdout.flush()
+        time.sleep(interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/demo-python-sni/deployment.yaml
+++ b/examples/demo-python-sni/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-python-sni
+  labels:
+    app: demo-python-sni
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-python-sni
+  template:
+    metadata:
+      labels:
+        app: demo-python-sni
+      annotations:
+        getkloak.io/enabled: "true"
+    spec:
+      containers:
+        - name: demo-app
+          image: kloak-demo-python-sni:latest
+          imagePullPolicy: Never
+          env:
+            - name: SECRET_ALLOWED_FILE
+              value: "/etc/secrets/allowed/api-key"
+            - name: SECRET_BLOCKED_FILE
+              value: "/etc/secrets/blocked/api-key"
+            - name: SNI_HOST
+              value: "httpbin.org"
+            - name: REQUEST_INTERVAL
+              value: "5"
+          volumeMounts:
+            - name: secret-allowed-vol
+              mountPath: "/etc/secrets/allowed"
+              readOnly: true
+            - name: secret-blocked-vol
+              mountPath: "/etc/secrets/blocked"
+              readOnly: true
+      volumes:
+        - name: secret-allowed-vol
+          secret:
+            secretName: secret-allowed
+        - name: secret-blocked-vol
+          secret:
+            secretName: secret-blocked

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -64,8 +64,9 @@ struct {
 // Uses LRU to auto-evict stale entries when connections close.
 // -----------------------------------------------------------------------------
 struct conn_key {
-  __u32 tgid;
   __u64 ssl_ptr; // pointer to SSL object (unique per connection)
+  __u32 tgid;
+  __u32 _pad;    // explicit padding — BPF hashes the full key including padding
 };
 
 struct conn_host {
@@ -155,11 +156,11 @@ int bpf_uprobe_ssl_set_host(void *ctx) {
   if (ret <= 1) // empty or error
     return 0;
 
-  // Store in conn_hosts map
-  struct conn_key key = {
-    .tgid = tgid,
-    .ssl_ptr = (__u64)ssl_ptr,
-  };
+  // Store in conn_hosts map — memset key to zero padding bytes
+  struct conn_key key;
+  __builtin_memset(&key, 0, sizeof(key));
+  key.tgid = tgid;
+  key.ssl_ptr = (__u64)ssl_ptr;
 
   struct conn_host host = {};
   // Copy up to MAX_HOST_LEN bytes
@@ -227,10 +228,10 @@ int bpf_uprobe_ssl_ctrl(void *ctx) {
   if (ret <= 1)
     return 0;
 
-  struct conn_key key = {
-    .tgid = tgid,
-    .ssl_ptr = (__u64)ssl_ptr,
-  };
+  struct conn_key key;
+  __builtin_memset(&key, 0, sizeof(key));
+  key.tgid = tgid;
+  key.ssl_ptr = (__u64)ssl_ptr;
 
   struct conn_host host = {};
   __u32 copy_len = ret - 1;
@@ -265,10 +266,10 @@ static __always_inline void resolve_host(struct scratch_buf *scratch,
     __u64 pid_tgid = bpf_get_current_pid_tgid();
     __u32 tgid = (__u32)(pid_tgid >> 32);
 
-    struct conn_key key = {
-      .tgid = tgid,
-      .ssl_ptr = ssl_ptr,
-    };
+    struct conn_key key;
+    __builtin_memset(&key, 0, sizeof(key));
+    key.tgid = tgid;
+    key.ssl_ptr = ssl_ptr;
 
     struct conn_host *cached = bpf_map_lookup_elem(&conn_hosts, &key);
     if (cached && cached->host_len > 0) {

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -35,6 +35,8 @@
 #define MAX_HOST_LEN 32
 // Max hostname to read from SNI
 #define MAX_SNI_LEN 64
+// OpenSSL SSL_ctrl cmd value for SSL_set_tlsext_host_name macro
+#define SSL_CTRL_SET_TLSEXT_HOSTNAME 55
 
 // BPF Map: shadow secret prefix -> real secret value
 struct secret_key {
@@ -172,6 +174,76 @@ int bpf_uprobe_ssl_set_host(void *ctx) {
 #ifdef KLOAK_DEBUG
   bpf_printk("kloak sni: tgid=%u ssl=%llx host=%s", tgid, (__u64)ssl_ptr,
              sni_buf);
+#endif
+
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// OpenSSL SSL_ctrl uprobe — catches SNI via the macro expansion.
+//
+// In OpenSSL, SSL_set_tlsext_host_name(ssl, name) is a macro that expands to:
+//   SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, TLSEXT_NAMETYPE_host_name, name)
+//
+// SSL_ctrl signature: long SSL_ctrl(SSL *ssl, int cmd, long larg, void *parg)
+//   x86_64: RDI=ssl, RSI=cmd, RDX=larg, RCX=parg
+//   ARM64:  X0=ssl,  X1=cmd,  X2=larg,  X3=parg
+//
+// BoringSSL exports SSL_set_tlsext_host_name as a real function, so it's
+// handled by bpf_uprobe_ssl_set_host above. This uprobe covers OpenSSL only.
+// -----------------------------------------------------------------------------
+SEC("uprobe/ssl_ctrl")
+int bpf_uprobe_ssl_ctrl(void *ctx) {
+  void *ssl_ptr;
+  int cmd;
+  void *parg;
+
+#if defined(bpf_target_x86)
+  // x86_64 C ABI: RDI=ssl, RSI=cmd, RDX=larg, RCX=parg
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 112);
+  bpf_probe_read_kernel(&cmd, sizeof(int), (char *)ctx + 104);
+  bpf_probe_read_kernel(&parg, sizeof(void *), (char *)ctx + 88);
+#elif defined(bpf_target_arm64)
+  // ARM64 C ABI: X0=ssl, X1=cmd, X2=larg, X3=parg
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 0);
+  bpf_probe_read_kernel(&cmd, sizeof(int), (char *)ctx + 8);
+  bpf_probe_read_kernel(&parg, sizeof(void *), (char *)ctx + 24);
+#else
+  return 0;
+#endif
+
+  // Only handle SSL_CTRL_SET_TLSEXT_HOSTNAME (55)
+  if (cmd != SSL_CTRL_SET_TLSEXT_HOSTNAME)
+    return 0;
+
+  if (!ssl_ptr || !parg)
+    return 0;
+
+  __u64 pid_tgid = bpf_get_current_pid_tgid();
+  __u32 tgid = (__u32)(pid_tgid >> 32);
+
+  char sni_buf[MAX_SNI_LEN] = {};
+  long ret = bpf_probe_read_user_str(sni_buf, sizeof(sni_buf), parg);
+  if (ret <= 1)
+    return 0;
+
+  struct conn_key key = {
+    .tgid = tgid,
+    .ssl_ptr = (__u64)ssl_ptr,
+  };
+
+  struct conn_host host = {};
+  __u32 copy_len = ret - 1;
+  if (copy_len > MAX_HOST_LEN)
+    copy_len = MAX_HOST_LEN;
+  __builtin_memcpy(host.hostname, sni_buf, MAX_HOST_LEN);
+  host.host_len = copy_len;
+
+  bpf_map_update_elem(&conn_hosts, &key, &host, BPF_ANY);
+
+#ifdef KLOAK_DEBUG
+  bpf_printk("kloak ssl_ctrl sni: tgid=%u ssl=%llx host=%s", tgid,
+             (__u64)ssl_ptr, sni_buf);
 #endif
 
   return 0;

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -4,6 +4,7 @@
 // Uses a per-CPU array as scratch buffer (not ringbuf) to avoid verifier
 // issues with ringbuf_mem pointer tracking in loops.
 // Supports both x86_64 and ARM64 architectures.
+// Host filtering uses TLS SNI (protocol-agnostic) with HTTP Host fallback.
 
 #include "vmlinux.h"
 #include <bpf/bpf_helpers.h>
@@ -32,6 +33,8 @@
 #define SECRET_MAX_LEN 128
 // Max host length for matching (compared as 4 x uint64, no loop needed)
 #define MAX_HOST_LEN 32
+// Max hostname to read from SNI
+#define MAX_SNI_LEN 64
 
 // BPF Map: shadow secret prefix -> real secret value
 struct secret_key {
@@ -52,13 +55,36 @@ struct {
   __type(value, struct secret_value);
 } secret_map SEC(".maps");
 
+// -----------------------------------------------------------------------------
+// SNI hostname cache: {tgid, ssl_ptr} → hostname
+// Populated by SSL_set_tlsext_host_name uprobe (runs once per connection).
+// Looked up by SSL_write uprobe to get the destination hostname.
+// Uses LRU to auto-evict stale entries when connections close.
+// -----------------------------------------------------------------------------
+struct conn_key {
+  __u32 tgid;
+  __u64 ssl_ptr; // pointer to SSL object (unique per connection)
+};
+
+struct conn_host {
+  __u32 host_len;
+  char hostname[MAX_HOST_LEN];
+};
+
+struct {
+  __uint(type, BPF_MAP_TYPE_LRU_HASH);
+  __uint(max_entries, 4096);
+  __type(key, struct conn_key);
+  __type(value, struct conn_host);
+} conn_hosts SEC(".maps");
+
 // Per-CPU array used as scratch space for reading and scanning data.
 struct scratch_buf {
   __u64 user_data_ptr;
   __u32 read_len;
   __u32 host_offset;
   __u32 host_value_len; // length of extracted host value
-  char host_value[MAX_HOST_LEN]; // extracted host bytes from HTTP header
+  char host_value[MAX_HOST_LEN]; // host from SNI cache or HTTP header
   char data[MAX_DATA_SIZE];
 };
 
@@ -91,21 +117,102 @@ struct tls_event {
 };
 
 // -----------------------------------------------------------------------------
-// Phase 1: Parse Host header and extract its value into scratch buffer.
-// This runs inline in the uprobe entry points (before tail-calling phase 2).
-// By extracting host bytes here, phase 2 can compare using fixed-size
-// uint64 comparisons with zero loops, staying under verifier limits.
+// SNI hostname extraction uprobe.
+// Hooks SSL_set_tlsext_host_name(SSL *ssl, const char *name).
+// Called once per connection before SSL_connect/handshake.
+// Caches {tgid, ssl_ptr} → hostname for later lookup in SSL_write.
+// Works for OpenSSL, BoringSSL, and any compatible TLS library.
 // -----------------------------------------------------------------------------
-static __always_inline void parse_host(struct scratch_buf *scratch) {
+SEC("uprobe/ssl_set_host")
+int bpf_uprobe_ssl_set_host(void *ctx) {
+  void *ssl_ptr;
+  void *name_ptr;
+
+#if defined(bpf_target_x86)
+  // x86_64 C ABI: RDI=ssl, RSI=name
+  // pt_regs offsets: rdi=112, rsi=104
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 112);
+  bpf_probe_read_kernel(&name_ptr, sizeof(void *), (char *)ctx + 104);
+#elif defined(bpf_target_arm64)
+  // ARM64 C ABI: X0=ssl, X1=name
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 0);
+  bpf_probe_read_kernel(&name_ptr, sizeof(void *), (char *)ctx + 8);
+#else
+  return 0;
+#endif
+
+  if (!ssl_ptr || !name_ptr)
+    return 0;
+
+  __u64 pid_tgid = bpf_get_current_pid_tgid();
+  __u32 tgid = (__u32)(pid_tgid >> 32);
+
+  // Read the hostname string from user space
+  char sni_buf[MAX_SNI_LEN] = {};
+  long ret = bpf_probe_read_user_str(sni_buf, sizeof(sni_buf), name_ptr);
+  if (ret <= 1) // empty or error
+    return 0;
+
+  // Store in conn_hosts map
+  struct conn_key key = {
+    .tgid = tgid,
+    .ssl_ptr = (__u64)ssl_ptr,
+  };
+
+  struct conn_host host = {};
+  // Copy up to MAX_HOST_LEN bytes
+  __u32 copy_len = ret - 1; // ret includes null terminator
+  if (copy_len > MAX_HOST_LEN)
+    copy_len = MAX_HOST_LEN;
+  __builtin_memcpy(host.hostname, sni_buf, MAX_HOST_LEN);
+  host.host_len = copy_len;
+
+  bpf_map_update_elem(&conn_hosts, &key, &host, BPF_ANY);
+
+#ifdef KLOAK_DEBUG
+  bpf_printk("kloak sni: tgid=%u ssl=%llx host=%s", tgid, (__u64)ssl_ptr,
+             sni_buf);
+#endif
+
+  return 0;
+}
+
+// -----------------------------------------------------------------------------
+// Resolve host for the current SSL connection.
+// First tries SNI cache (works for all protocols).
+// Falls back to HTTP Host header parsing (for Go and connections without SNI).
+// -----------------------------------------------------------------------------
+static __always_inline void resolve_host(struct scratch_buf *scratch,
+                                         __u64 ssl_ptr) {
   scratch->host_offset = 0;
   scratch->host_value_len = 0;
   __builtin_memset(scratch->host_value, 0, MAX_HOST_LEN);
 
+  // Try SNI cache first (protocol-agnostic)
+  if (ssl_ptr != 0) {
+    __u64 pid_tgid = bpf_get_current_pid_tgid();
+    __u32 tgid = (__u32)(pid_tgid >> 32);
+
+    struct conn_key key = {
+      .tgid = tgid,
+      .ssl_ptr = ssl_ptr,
+    };
+
+    struct conn_host *cached = bpf_map_lookup_elem(&conn_hosts, &key);
+    if (cached && cached->host_len > 0) {
+      __builtin_memcpy(scratch->host_value, cached->hostname, MAX_HOST_LEN);
+      scratch->host_value_len = cached->host_len;
+      return;
+    }
+  }
+
+  // Fallback: parse HTTP "Host: " header from the plaintext data.
+  // This handles Go connections (which don't call SSL_set_tlsext_host_name)
+  // and any connection where SNI wasn't captured.
   __u32 read_len = scratch->read_len;
   if (read_len > MAX_DATA_SIZE)
     read_len = MAX_DATA_SIZE;
 
-  // Scan the first 256 bytes to find "Host: "
   __u32 host_start = 0;
   for (__u32 i = 0; i < 256; i++) {
     if (i + 6 > read_len)
@@ -123,8 +230,6 @@ static __always_inline void parse_host(struct scratch_buf *scratch) {
   if (host_start == 0)
     return;
 
-  // Extract host value bytes into scratch->host_value (up to MAX_HOST_LEN)
-  // Stop at \r, \n, or : (end of host value)
   __u32 host_len = 0;
   for (__u32 j = 0; j < MAX_HOST_LEN; j++) {
     __u32 idx = host_start + j;
@@ -174,7 +279,7 @@ int bpf_phase2_rewrite(void *ctx) {
       struct secret_value *val = bpf_map_lookup_elem(&secret_map, &key);
       if (val && val->len > 0 && val->len <= SECRET_MAX_LEN) {
 
-        // Host-based filtering: compare pre-extracted host against allowed_host
+        // Host-based filtering: compare resolved host against allowed_host
         // using fixed-size uint64 comparisons (no loop, no verifier complexity)
         if (val->host_len > 0 && val->host_len < MAX_HOST_LEN) {
           if (scratch_data->host_value_len == 0)
@@ -234,6 +339,9 @@ int bpf_phase2_rewrite(void *ctx) {
 // Go register ABI (1.17+):
 //   x86_64: RAX=receiver, RBX=data, RCX=len  (pt_regs offsets: bx=40, cx=88)
 //   ARM64:  R0=receiver,  R1=data,  R2=len    (pt_regs: regs[1], regs[2])
+//
+// Go doesn't call SSL_set_tlsext_host_name, so SNI cache won't have an entry.
+// Falls back to HTTP Host header parsing in resolve_host().
 // -----------------------------------------------------------------------------
 
 SEC("uprobe/go_tls_write")
@@ -249,8 +357,6 @@ int bpf_uprobe_go_tls_write(void *ctx) {
 #elif defined(bpf_target_arm64)
   // ARM64 Go register ABI: R0=receiver, R1=data, R2=len
   // user_pt_regs offsets: regs[1]=8, regs[2]=16
-  // Use raw offsets instead of PT_REGS_PARMx to avoid CO-RE relocation
-  // failures (kernel BTF may expose user_pt_regs, not pt_regs).
   bpf_probe_read_kernel(&data_ptr, sizeof(void *), (char *)ctx + 8);
   bpf_probe_read_kernel(&data_len, sizeof(__u64), (char *)ctx + 16);
 #else
@@ -266,7 +372,6 @@ int bpf_uprobe_go_tls_write(void *ctx) {
   if (!data_ptr || data_len == 0)
     return 0;
 
-  // Get scratch buffer from per-CPU array
   __u32 zero = 0;
   struct scratch_buf *scratch_data = bpf_map_lookup_elem(&scratch, &zero);
   if (!scratch_data)
@@ -276,7 +381,6 @@ int bpf_uprobe_go_tls_write(void *ctx) {
   if (read_len > MAX_DATA_SIZE)
     read_len = MAX_DATA_SIZE;
 
-  // Read plaintext into scratch buffer (per-CPU array, not ringbuf)
   long ret __attribute__((unused)) =
       bpf_probe_read_user(scratch_data->data, read_len, data_ptr);
 #ifdef KLOAK_DEBUG
@@ -287,7 +391,8 @@ int bpf_uprobe_go_tls_write(void *ctx) {
   scratch_data->user_data_ptr = (__u64)data_ptr;
   scratch_data->read_len = read_len;
 
-  parse_host(scratch_data);
+  // Go doesn't use OpenSSL, no ssl_ptr for SNI lookup — pass 0.
+  resolve_host(scratch_data, 0);
 
   // Jump to Phase 2
   bpf_tail_call(ctx, &prog_array, 0);
@@ -299,25 +404,24 @@ int bpf_uprobe_go_tls_write(void *ctx) {
 // OpenSSL/BoringSSL SSL_write uprobe
 //
 // C calling convention:  SSL_write(SSL *ssl, const void *buf, int num)
-//   x86_64: RDI=ssl, RSI=buf, RDX=num  (pt_regs offsets: si=104, dx=96)
-//   ARM64:  X0=ssl,  X1=buf,  X2=num   (pt_regs: regs[1], regs[2])
+//   x86_64: RDI=ssl, RSI=buf, RDX=num  (pt_regs offsets: di=112, si=104, dx=96)
+//   ARM64:  X0=ssl,  X1=buf,  X2=num   (pt_regs: regs[0]=0, regs[1]=8, regs[2]=16)
 // -----------------------------------------------------------------------------
 
 SEC("uprobe/ssl_write")
 int bpf_uprobe_ssl_write(void *ctx) {
+  void *ssl_ptr;
   void *data_ptr;
   int num;
 
 #if defined(bpf_target_x86)
   // x86_64 C ABI: RDI=ssl, RSI=buf, RDX=num
-  // pt_regs offsets: rsi=104, rdx=96
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 112);
   bpf_probe_read_kernel(&data_ptr, sizeof(void *), (char *)ctx + 104);
   bpf_probe_read_kernel(&num, sizeof(int), (char *)ctx + 96);
 #elif defined(bpf_target_arm64)
   // ARM64 C ABI: X0=ssl, X1=buf, X2=num
-  // user_pt_regs offsets: regs[1]=8, regs[2]=16
-  // Use raw offsets instead of PT_REGS_PARMx to avoid CO-RE relocation
-  // failures (kernel BTF may expose user_pt_regs, not pt_regs).
+  bpf_probe_read_kernel(&ssl_ptr, sizeof(void *), (char *)ctx + 0);
   bpf_probe_read_kernel(&data_ptr, sizeof(void *), (char *)ctx + 8);
   bpf_probe_read_kernel(&num, sizeof(int), (char *)ctx + 16);
 #else
@@ -326,7 +430,8 @@ int bpf_uprobe_ssl_write(void *ctx) {
 
 #ifdef KLOAK_DEBUG
   __u32 pid = bpf_get_current_pid_tgid();
-  bpf_printk("kloak ssl: ptr=%llx num=%d pid=%d", (__u64)data_ptr, num, pid);
+  bpf_printk("kloak ssl: ssl=%llx ptr=%llx num=%d pid=%d", (__u64)ssl_ptr,
+             (__u64)data_ptr, num, pid);
 #endif
 
   if (!data_ptr || num <= 0)
@@ -351,7 +456,8 @@ int bpf_uprobe_ssl_write(void *ctx) {
   scratch_data->user_data_ptr = (__u64)data_ptr;
   scratch_data->read_len = read_len;
 
-  parse_host(scratch_data);
+  // Look up SNI-cached hostname using the ssl pointer, fall back to HTTP Host
+  resolve_host(scratch_data, (__u64)ssl_ptr);
 
   // Jump to Phase 2
   bpf_tail_call(ctx, &prog_array, 0);

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -130,7 +130,10 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 	sslWriteSymbols := []string{"SSL_write", "SSL_write_ex"}
 	// SNI hostname capture — called once per connection before handshake.
 	// Populates the conn_hosts BPF map for protocol-agnostic host filtering.
+	// SSL_set_tlsext_host_name is a real function in BoringSSL but a macro in
+	// OpenSSL that expands to SSL_ctrl(ssl, 55, 0, name). Try both.
 	sniSymbols := []string{"SSL_set_tlsext_host_name"}
+	sniCtrlSymbols := []string{"SSL_ctrl"}
 	attached := false
 
 	// Try main executable first (catches statically linked BoringSSL/OpenSSL)
@@ -146,6 +149,13 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 		up, err := ex.Uprobe(sym, m.objs.BpfUprobeSslSetHost, nil)
 		if err == nil {
 			m.log.Info("Attached SNI uprobe to main exe", "pid", pid, "symbol", sym)
+			m.links = append(m.links, up)
+		}
+	}
+	for _, sym := range sniCtrlSymbols {
+		up, err := ex.Uprobe(sym, m.objs.BpfUprobeSslCtrl, nil)
+		if err == nil {
+			m.log.Info("Attached SNI ctrl uprobe to main exe", "pid", pid, "symbol", sym)
 			m.links = append(m.links, up)
 		}
 	}
@@ -168,6 +178,13 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 			up, err := libEx.Uprobe(sym, m.objs.BpfUprobeSslSetHost, nil)
 			if err == nil {
 				m.log.Info("Attached SNI uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
+				m.links = append(m.links, up)
+			}
+		}
+		for _, sym := range sniCtrlSymbols {
+			up, err := libEx.Uprobe(sym, m.objs.BpfUprobeSslCtrl, nil)
+			if err == nil {
+				m.log.Info("Attached SNI ctrl uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
 				m.links = append(m.links, up)
 			}
 		}

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -127,16 +127,26 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 	// 2. Try OpenSSL / BoringSSL (Node.js, Python, Rust, Envoy, gRPC)
 	// Modern OpenSSL 3.x and BoringSSL export both SSL_write and SSL_write_ex
 	// with identical C ABI calling convention.
-	sslSymbols := []string{"SSL_write", "SSL_write_ex"}
+	sslWriteSymbols := []string{"SSL_write", "SSL_write_ex"}
+	// SNI hostname capture — called once per connection before handshake.
+	// Populates the conn_hosts BPF map for protocol-agnostic host filtering.
+	sniSymbols := []string{"SSL_set_tlsext_host_name"}
 	attached := false
 
 	// Try main executable first (catches statically linked BoringSSL/OpenSSL)
-	for _, sym := range sslSymbols {
+	for _, sym := range sslWriteSymbols {
 		up, err := ex.Uprobe(sym, m.objs.BpfUprobeSslWrite, nil)
 		if err == nil {
-			m.log.Info("Attached SSL uprobe to main exe", "pid", pid, "symbol", sym)
+			m.log.Info("Attached SSL write uprobe to main exe", "pid", pid, "symbol", sym)
 			m.links = append(m.links, up)
 			attached = true
+		}
+	}
+	for _, sym := range sniSymbols {
+		up, err := ex.Uprobe(sym, m.objs.BpfUprobeSslSetHost, nil)
+		if err == nil {
+			m.log.Info("Attached SNI uprobe to main exe", "pid", pid, "symbol", sym)
+			m.links = append(m.links, up)
 		}
 	}
 
@@ -146,12 +156,19 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 		if err != nil {
 			continue
 		}
-		for _, sym := range sslSymbols {
+		for _, sym := range sslWriteSymbols {
 			up, err := libEx.Uprobe(sym, m.objs.BpfUprobeSslWrite, nil)
 			if err == nil {
-				m.log.Info("Attached SSL uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
+				m.log.Info("Attached SSL write uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
 				m.links = append(m.links, up)
 				attached = true
+			}
+		}
+		for _, sym := range sniSymbols {
+			up, err := libEx.Uprobe(sym, m.objs.BpfUprobeSslSetHost, nil)
+			if err == nil {
+				m.log.Info("Attached SNI uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
+				m.links = append(m.links, up)
 			}
 		}
 	}

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -55,6 +55,73 @@ var ebpfTests = []ebpfRewriteTest{
 	},
 }
 
+// TestEBPFSNIHostFiltering tests that SNI-based host filtering works for
+// non-HTTP TLS protocols. The demo app uses raw TLS sockets (no HTTP)
+// with a local echo server. The only hostname source is SSL_set_tlsext_host_name.
+func TestEBPFSNIHostFiltering(t *testing.T) {
+	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-KEY-12345")}
+	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-KEY-67890")}
+
+	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+		"getkloak.io/hosts": "httpbin.org",
+	})
+	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+		"getkloak.io/hosts": "example.com",
+	})
+
+	assertShadowSecret(t, "secret-allowed", allowedData)
+	assertShadowSecret(t, "secret-blocked", blockedData)
+
+	tc := ebpfRewriteTest{
+		name:           "python-sni",
+		demoDir:        "demo-python-sni",
+		deploymentName: "demo-python-sni",
+		appLabel:       "app=demo-python-sni",
+		startupWait:    45 * time.Second,
+	}
+
+	demoManifest := filepath.Join(repoRoot, "examples", tc.demoDir, "deployment.yaml")
+	_, err := kubectl("apply", "-f", demoManifest, "-n", testNamespace)
+	if err != nil {
+		t.Fatalf("failed to deploy %s: %v", tc.demoDir, err)
+	}
+	t.Cleanup(func() {
+		_, _ = kubectl("delete", "-f", demoManifest, "-n", testNamespace, "--ignore-not-found")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	if err := waitForDeploymentReady(ctx, testNamespace, tc.deploymentName); err != nil {
+		demoDesc, _ := kubectl("describe", "deployment", "-n", testNamespace, tc.deploymentName)
+		t.Logf("deployment describe:\n%s", demoDesc)
+		t.Fatalf("%s not ready: %v", tc.deploymentName, err)
+	}
+
+	ctrlLogs, _ := kubectl("logs", "-n", kloakNamespace, "-l", "app.kubernetes.io/component=controller", "--tail=50")
+	t.Logf("=== Controller logs (after deploy %s) ===\n%s", tc.name, ctrlLogs)
+
+	t.Logf("Waiting %s for %s to make requests...", tc.startupWait, tc.name)
+	time.Sleep(tc.startupWait)
+
+	out, err := kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=50")
+	if err != nil {
+		t.Fatalf("failed to read %s logs: %v", tc.name, err)
+	}
+	t.Logf("=== %s demo app logs ===\n%s", tc.name, out)
+
+	ctrlLogsAfter, _ := kubectl("logs", "-n", kloakNamespace, "-l", "app.kubernetes.io/component=controller", "--tail=50")
+	t.Logf("=== Controller logs (after %s requests) ===\n%s", tc.name, ctrlLogsAfter)
+
+	// The payload is raw TLS (non-HTTP), so there's no Host header fallback.
+	// Host filtering can only work via SNI captured from SSL_set_tlsext_host_name.
+	if !strings.Contains(out, "REAL-ALLOWED-KEY-12345") {
+		t.Errorf("[%s] allowed secret should be rewritten via SNI host filtering (SNI=httpbin.org matches hosts=httpbin.org)", tc.name)
+	}
+	if strings.Contains(out, "REAL-BLOCKED-KEY-67890") {
+		t.Errorf("[%s] blocked secret should NOT be rewritten (SNI=httpbin.org does not match hosts=example.com)", tc.name)
+	}
+}
+
 func TestEBPFSecretRewrite(t *testing.T) {
 	// Create secrets shared by all demo apps.
 	// Key must be "api-key" to match deployment volume mount paths.

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -132,4 +132,3 @@ func runEBPFRewriteTest(t *testing.T, tc ebpfRewriteTest) {
 	// Brief wait for pod termination
 	time.Sleep(5 * time.Second)
 }
-


### PR DESCRIPTION
## Summary

Replaces HTTP-only `Host:` header parsing with protocol-agnostic TLS SNI hostname resolution. This enables host-based secret filtering for **any** TLS protocol — PostgreSQL, Redis, MySQL, gRPC, AMQP, etc.

## How It Works

```
Before (HTTP-only):
  SSL_write → read plaintext → parse "Host: " header → compare → rewrite

After (any TLS protocol):
  SSL_set_tlsext_host_name("api.stripe.com")  → SNI uprobe caches hostname
  SSL_write(ssl, data, len)                    → lookup cached hostname by ssl ptr
  Phase 2                                       → compare → rewrite
```

### New eBPF components

| Component | Purpose |
|-----------|---------|
| `conn_hosts` map (LRU hash) | Caches `{tgid, ssl_ptr}` → hostname. LRU auto-evicts stale entries. |
| `bpf_uprobe_ssl_set_host` | Hooks `SSL_set_tlsext_host_name(ssl, name)`. Reads SNI hostname, stores in `conn_hosts`. |
| `resolve_host()` | Replaces `parse_host()`. Checks SNI cache first, falls back to HTTP Host parsing for Go. |

### Protocol support matrix

| Protocol | Host filtering before | Host filtering after |
|----------|----------------------|---------------------|
| HTTP/1.1 | Yes (Host header) | Yes (SNI + Host fallback) |
| HTTP/2 | No (HPACK compressed) | Yes (SNI) |
| PostgreSQL TLS | No | **Yes** (SNI) |
| Redis TLS | No | **Yes** (SNI) |
| MySQL TLS | No | **Yes** (SNI) |
| gRPC | No | **Yes** (SNI) |
| Go crypto/tls | Yes (Host header) | Yes (Host header fallback, Go doesn't call SSL_set_tlsext_host_name) |

### Go changes

`AttachTLS()` now also probes `SSL_set_tlsext_host_name` symbol alongside `SSL_write`/`SSL_write_ex` — on both the main executable and shared TLS libraries.

## Test plan
- [ ] Existing HTTP e2e tests pass (Go, Python, JS, BoringSSL)
- [ ] Host-restricted secrets still work for HTTP (SNI provides hostname)
- [ ] Wildcard secrets continue to work for all protocols

🤖 Generated with [Claude Code](https://claude.com/claude-code)