### PR TITLE
fix: clean up conn_ip_map on close() to prevent fd reuse race

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -817,6 +817,27 @@ int tp_exit_connect(struct trace_event_raw_sys_exit *ctx) {
   return 0;
 }
 
+// tp/syscalls/sys_enter_close: clean up connection state when an fd is closed.
+// Prevents stale conn_ip_map entries from being used after fd reuse.
+// close(int fd)
+SEC("tracepoint/syscalls/sys_enter_close")
+int tp_enter_close(struct trace_event_raw_sys_enter *ctx) {
+  __u64 pid_tgid = bpf_get_current_pid_tgid();
+  __u32 tgid = (__u32)(pid_tgid >> 32);
+  __u32 fd = (__u32)ctx->args[0];
+
+  // Clean up conn_ip_map entry for this fd (no-op if fd wasn't a tracked connection)
+  struct conn_ip_key cik = {.tgid = tgid, .fd = fd};
+  bpf_map_delete_elem(&conn_ip_map, &cik);
+
+  // Clean up last_verified_fd if it pointed to this fd
+  __u32 *vfd = bpf_map_lookup_elem(&last_verified_fd, &tgid);
+  if (vfd && *vfd == fd)
+    bpf_map_delete_elem(&last_verified_fd, &tgid);
+
+  return 0;
+}
+
 // =============================================================================
 // Resolve host for the current SSL/TLS connection using DNS chain.
 //

--- a/pkg/ebpf/load_test.go
+++ b/pkg/ebpf/load_test.go
@@ -43,6 +43,9 @@ func TestLoadObjects(t *testing.T) {
 	if objs.TpExitConnect == nil {
 		t.Error("TpExitConnect program not loaded")
 	}
+	if objs.TpEnterClose == nil {
+		t.Error("TpEnterClose program not loaded")
+	}
 }
 
 func TestTailCallWiring(t *testing.T) {

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -116,6 +116,7 @@ func (m *TLSUprobeManager) attachTracepoints() error {
 	tracepoints := []tp{
 		{"syscalls", "sys_enter_connect", m.objs.TpEnterConnect},
 		{"syscalls", "sys_exit_connect", m.objs.TpExitConnect},
+		{"syscalls", "sys_enter_close", m.objs.TpEnterClose},
 	}
 
 	for _, t := range tracepoints {


### PR DESCRIPTION
## Summary

- Add `sys_enter_close` tracepoint to delete `conn_ip_map` entries when an fd is closed
- Also cleans up `last_verified_fd` if the closed fd was the cached verified fd

## Problem

`resolve_host` scans fds 3-30 in `conn_ip_map` to find DNS-verified connections. File descriptors are reused by the kernel after `close()`, so a stale `conn_ip_map` entry from a previous connection could cause the host filter to pass for the wrong destination.

## How it works

1. `connect(fd=7, 1.2.3.4)` → `conn_ip_map[{tgid, 7}] = 1.2.3.4`
2. `close(fd=7)` → **delete** `conn_ip_map[{tgid, 7}]` + clean up `last_verified_fd`
3. `connect(fd=7, 5.6.7.8)` → `conn_ip_map[{tgid, 7}] = 5.6.7.8` (fresh entry)
4. fd scan finds the new IP, not stale

The close tracepoint is lightweight — `bpf_map_delete_elem` is a no-op if the fd wasn't a tracked connection.

## Test plan

- [ ] `make generate-ebpf` compiles
- [ ] CI e2e tests pass
- [ ] Local demo: all runtimes show secret rewrite

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)