### PR TITLE
fix: include all packages in combined CI coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,15 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      - name: Upload e2e coverage
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: e2e-coverage
+          path: /tmp/e2e-coverage.out
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Collect logs on failure
         if: failure()
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -295,24 +295,15 @@ jobs:
             echo "No e2e coverage data found, using unit coverage only"
           fi
 
-          # Merge: start with unit coverage, overlay e2e coverage.
-          # Only include e2e lines for packages that exist in unit coverage
-          # (generated files like tlsuprobe_bpfel.go aren't on the runner).
+          # Merge: start with unit coverage, append all e2e coverage lines.
+          # Exclude generated eBPF bindings (tlsuprobe_bpf*.go) which aren't
+          # on the runner, but include all other packages (cmd/, pkg/ebpf/, etc.).
           cp /tmp/unit-coverage/coverage.out /tmp/combined-coverage.out
 
           if [ -f /tmp/e2e-coverage.out ]; then
-            # Extract package prefixes from unit coverage
-            UNIT_PKGS=$(grep -oP 'github\.com/spinningfactory/kloak/[^/]+/[^/]+' /tmp/unit-coverage/coverage.out | sort -u)
-            # Append only matching e2e lines (skip mode line)
-            while IFS= read -r line; do
-              for pkg in $UNIT_PKGS; do
-                if echo "$line" | grep -q "$pkg"; then
-                  echo "$line" >> /tmp/combined-coverage.out
-                  break
-                fi
-              done
-            done < <(tail -n +2 /tmp/e2e-coverage.out)
-            echo "Combined unit + e2e coverage"
+            # Append all e2e lines except the mode line and generated eBPF files
+            tail -n +2 /tmp/e2e-coverage.out | grep -v 'tlsuprobe_bpf' >> /tmp/combined-coverage.out
+            echo "Combined unit + e2e coverage (all packages)"
           fi
 
           echo "=== Combined coverage summary ==="


### PR DESCRIPTION
## Summary

The CI coverage merge script was filtering e2e coverage lines to only packages that had unit tests. This excluded `cmd/kloak`, `pkg/ebpf`, and `pkg/cgroups` — all heavily exercised by e2e tests but with no unit tests (they require Linux/eBPF).

## What changed

Replace the package-filtering merge logic with a simple append that includes ALL e2e coverage lines (except generated eBPF bindings `tlsuprobe_bpf*.go` which don't exist on the runner).

## Impact

The reported coverage will now reflect the **actual** codebase coverage across all packages. The number may initially drop (since `cmd/kloak` and `pkg/ebpf` have many lines not covered by e2e), but it's accurate rather than artificially inflated by excluding those packages.

## Test plan

- [ ] CI passes and coverage badge updates
- [ ] `go tool cover -func` on the combined artifact shows `cmd/kloak`, `pkg/ebpf`, and `pkg/cgroups` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)