### PR TITLE
fix: wait for controller termination before collecting e2e coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,11 +268,18 @@ jobs:
 
       - name: Collect e2e coverage
         if: always()
+        env:
+          KUBECONFIG: /tmp/kubeconfig-e2e.yaml
         run: |
           mkdir -p /tmp/e2e-covdata
-          # Coverage files are on the k3d node's hostPath (/tmp/kloak-coverage).
-          # The test teardown deleted kloak, which triggered a clean controller
-          # shutdown that flushed covcounters to the hostPath volume.
+          # Wait for the controller pod to fully terminate after helm uninstall
+          # (triggered by test teardown). The Go coverage runtime writes
+          # covcounters on clean exit, which needs time to flush to the
+          # hostPath volume.
+          echo "Waiting for controller pod to terminate..."
+          kubectl wait --for=delete pod -l app.kubernetes.io/component=controller \
+            -n kloak-system --timeout=30s 2>/dev/null || true
+          # Copy coverage files from the k3d node's hostPath
           docker cp k3d-kloak-e2e-server-0:/tmp/kloak-coverage/. /tmp/e2e-covdata/ 2>/dev/null || true
           echo "E2E coverage files:"
           ls -la /tmp/e2e-covdata/ 2>/dev/null || echo "No coverage files collected"


### PR DESCRIPTION
## Summary

The e2e coverage `covcounters` file was missing because `docker cp` ran before the controller finished flushing coverage data on shutdown.

## Root cause

1. Test teardown calls `helm uninstall` which triggers pod deletion
2. `helm uninstall` returns immediately (doesn't wait for pod termination)
3. CI runs `docker cp` to collect coverage from the k3d node
4. The controller hasn't finished handling SIGTERM yet — `covcounters` not written

Result: only `covmeta` (written at startup) was collected, not `covcounters` (written at shutdown). The coverage merge step saw "No e2e coverage data" and fell back to unit-only coverage.

## Fix

Add `kubectl wait --for=delete pod` before `docker cp` to ensure the controller has fully terminated and flushed coverage data to the hostPath volume.

## Test plan

- [x] CI runs and `covcounters` file appears in coverage collection step
- [ ] Combined coverage includes `cmd/kloak`, `pkg/ebpf`, `pkg/cgroups`
- [ ] Coverage badge updates with accurate combined percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)