### PR TITLE
ci: push multi-arch Docker images to Docker Hub

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
           git push
 
   docker:
-    name: Docker Build
+    name: Docker Build & Push
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [lint, build, test]
@@ -195,15 +195,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build multi-arch image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: false
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v4
         with:
@@ -211,7 +202,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Push to GHCR
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKER_PAT_USER }}
+          password: ${{ secrets.DOCKER_PAT_PASS }}
+
+      - name: Build and push multi-arch image
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -220,7 +217,10 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:latest
             ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
+            ${{ secrets.DOCKER_PAT_USER }}/kloak:dev
+            ${{ secrets.DOCKER_PAT_USER }}/kloak:${{ github.sha }}
           cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   e2e:
     name: E2E Tests


### PR DESCRIPTION
## Summary
- Add Docker Hub push to CI alongside existing GHCR push
- Tags on Docker Hub: `dev` (overwritten each main push) + commit SHA
- Uses `DOCKER_PAT_USER` and `DOCKER_PAT_PASS` repository secrets
- Consolidates two separate build-push steps into one (build once, push to both registries)
- Multi-arch: `linux/amd64` + `linux/arm64`

## Test plan
- [ ] Verify `DOCKER_PAT_USER` and `DOCKER_PAT_PASS` secrets are configured in repo settings
- [ ] Merge to main and confirm images appear on Docker Hub with `dev` and SHA tags
- [ ] Confirm GHCR push still works with `latest` and `sha-` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)