### PR TITLE
fix: replace opt-in namespaceSelector with opt-out

### DIFF
--- a/charts/kloak/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/kloak/templates/mutatingwebhookconfiguration.yaml
@@ -61,7 +61,10 @@ webhooks:
         resources: ["pods"]
     namespaceSelector:
       matchExpressions:
-        - key: getkloak.io/enabled
-          operator: In
-          values: ["true"]
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - {{ .Release.Namespace }}
+            - kube-system
+            - kube-public
     failurePolicy: Fail


### PR DESCRIPTION
## Summary
- The webhook's `namespaceSelector` previously required namespaces to have `getkloak.io/enabled=true` label. This meant pods with the pod-level annotation were silently ignored if their namespace wasn't labeled — the API server never sent the admission request to the webhook.
- Replaced with an opt-out selector that excludes only the release namespace (prevents chicken-and-egg deadlock during `helm install`), `kube-system`, and `kube-public`.
- The handler's `isEnabled()` logic (pod annotation → namespace label → owner workload) now actually gets to run for all namespaces.

## Test plan
- [ ] `helm install` completes without blocking
- [ ] Apply a pod with `getkloak.io/enabled: "true"` annotation in a namespace **without** the label — webhook should fire
- [ ] Verify kloak's own pods in the release namespace are not intercepted
- [ ] Verify kube-system pods are not intercepted

🤖 Generated with [Claude Code](https://claude.com/claude-code)