### PR TITLE
feat: add GnuTLS uprobe support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ e2e-setup:
 	@k3d cluster create $(E2E_CLUSTER) --wait --timeout 120s \
 		--volume /sys/kernel/btf:/sys/kernel/btf:ro@server:0 \
 		--volume /sys/fs/bpf:/sys/fs/bpf:rw@server:0 \
+		--volume /sys/kernel/tracing:/sys/kernel/tracing:ro@server:0 \
 		2>/dev/null || true
 	@echo "==> Building kloak image..."
 	@docker build -t $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) .

--- a/Makefile
+++ b/Makefile
@@ -95,8 +95,9 @@ e2e-setup:
 	@docker build -t kloak-demo-python:latest ./examples/demo-python/
 	@docker build -t kloak-demo-js:latest ./examples/demo-js/
 	@docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
+	@docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
 	@echo "==> Importing images into k3d..."
-	@k3d image import $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest -c $(E2E_CLUSTER)
+	@k3d image import $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest -c $(E2E_CLUSTER)
 	@docker pull bitnami/kubectl:latest
 	@k3d image import bitnami/kubectl:latest -c $(E2E_CLUSTER)
 	@echo "==> E2E environment ready."

--- a/Makefile
+++ b/Makefile
@@ -97,8 +97,9 @@ e2e-setup:
 	@docker build -t kloak-demo-js:latest ./examples/demo-js/
 	@docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
 	@docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
+	@docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
 	@echo "==> Importing images into k3d..."
-	@k3d image import $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest -c $(E2E_CLUSTER)
+	@k3d image import $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest -c $(E2E_CLUSTER)
 	@docker pull bitnami/kubectl:latest
 	@k3d image import bitnami/kubectl:latest -c $(E2E_CLUSTER)
 	@echo "==> E2E environment ready."

--- a/examples/demo-gnutls/Dockerfile
+++ b/examples/demo-gnutls/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:bookworm-slim AS builder
+RUN apt-get update && apt-get install -y --no-install-recommends gcc libc6-dev libgnutls28-dev && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY main.c .
+RUN gcc -o demo-app main.c -lgnutls -Wall
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends libgnutls30 ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/demo-app .
+CMD ["./demo-app"]

--- a/examples/demo-gnutls/deployment.yaml
+++ b/examples/demo-gnutls/deployment.yaml
@@ -1,0 +1,45 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-gnutls
+  labels:
+    app: demo-gnutls
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-gnutls
+  template:
+    metadata:
+      labels:
+        app: demo-gnutls
+      annotations:
+        getkloak.io/enabled: "true"
+    spec:
+      containers:
+        - name: demo-app
+          image: kloak-demo-gnutls:latest
+          imagePullPolicy: Never
+          env:
+            - name: SECRET_ALLOWED_FILE
+              value: "/etc/secrets/allowed/api-key"
+            - name: SECRET_BLOCKED_FILE
+              value: "/etc/secrets/blocked/api-key"
+            - name: TARGET_URL
+              value: "https://httpbin.org/headers"
+            - name: REQUEST_INTERVAL
+              value: "5"
+          volumeMounts:
+            - name: secret-allowed-vol
+              mountPath: "/etc/secrets/allowed"
+              readOnly: true
+            - name: secret-blocked-vol
+              mountPath: "/etc/secrets/blocked"
+              readOnly: true
+      volumes:
+        - name: secret-allowed-vol
+          secret:
+            secretName: secret-allowed
+        - name: secret-blocked-vol
+          secret:
+            secretName: secret-blocked

--- a/examples/demo-gnutls/main.c
+++ b/examples/demo-gnutls/main.c
@@ -1,0 +1,215 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+#include <gnutls/gnutls.h>
+
+#define MAX_BUF 8192
+#define DEFAULT_URL "https://httpbin.org/headers"
+#define DEFAULT_INTERVAL "5"
+
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "r");
+    if (!f) {
+        fprintf(stderr, "Failed to open file: %s\n", path);
+        return NULL;
+    }
+    fseek(f, 0, SEEK_END);
+    long len = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc(len + 1);
+    if (!buf) {
+        fclose(f);
+        return NULL;
+    }
+    fread(buf, 1, len, f);
+    fclose(f);
+    buf[len] = '\0';
+    /* Trim trailing newline */
+    while (len > 0 && (buf[len - 1] == '\n' || buf[len - 1] == '\r')) {
+        buf[--len] = '\0';
+    }
+    return buf;
+}
+
+/* Parse host and path from URL like https://host/path */
+static int parse_url(const char *url, char *host, size_t host_len, char *path, size_t path_len) {
+    if (strncmp(url, "https://", 8) != 0) {
+        fprintf(stderr, "URL must start with https://\n");
+        return -1;
+    }
+    const char *h = url + 8;
+    const char *slash = strchr(h, '/');
+    if (slash) {
+        size_t hlen = slash - h;
+        if (hlen >= host_len) hlen = host_len - 1;
+        strncpy(host, h, hlen);
+        host[hlen] = '\0';
+        strncpy(path, slash, path_len - 1);
+        path[path_len - 1] = '\0';
+    } else {
+        strncpy(host, h, host_len - 1);
+        host[host_len - 1] = '\0';
+        strncpy(path, "/", path_len - 1);
+        path[path_len - 1] = '\0';
+    }
+    return 0;
+}
+
+static int tcp_connect(const char *host, const char *port) {
+    struct addrinfo hints, *res, *rp;
+    int sockfd = -1;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    int err = getaddrinfo(host, port, &hints, &res);
+    if (err != 0) {
+        fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(err));
+        return -1;
+    }
+
+    for (rp = res; rp != NULL; rp = rp->ai_next) {
+        sockfd = socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (sockfd < 0) continue;
+        if (connect(sockfd, rp->ai_addr, rp->ai_addrlen) == 0) break;
+        close(sockfd);
+        sockfd = -1;
+    }
+
+    freeaddrinfo(res);
+    if (sockfd < 0) {
+        fprintf(stderr, "Failed to connect to %s:%s\n", host, port);
+    }
+    return sockfd;
+}
+
+int main(void) {
+    const char *allowed_file = getenv("SECRET_ALLOWED_FILE");
+    const char *blocked_file = getenv("SECRET_BLOCKED_FILE");
+    const char *target_url = getenv("TARGET_URL");
+    const char *interval_str = getenv("REQUEST_INTERVAL");
+
+    if (!allowed_file || !blocked_file) {
+        fprintf(stderr, "SECRET_ALLOWED_FILE and SECRET_BLOCKED_FILE must be set\n");
+        return 1;
+    }
+    if (!target_url) target_url = DEFAULT_URL;
+    if (!interval_str) interval_str = DEFAULT_INTERVAL;
+    int interval = atoi(interval_str);
+    if (interval <= 0) interval = 5;
+
+    char *secret_allowed = read_file(allowed_file);
+    char *secret_blocked = read_file(blocked_file);
+    if (!secret_allowed || !secret_blocked) {
+        fprintf(stderr, "Failed to read secret files\n");
+        return 1;
+    }
+
+    char host[256], path[1024];
+    if (parse_url(target_url, host, sizeof(host), path, sizeof(path)) != 0) {
+        return 1;
+    }
+
+    printf("=== Kloak GnuTLS Demo ===\n");
+    printf("Target URL: %s\n", target_url);
+    printf("Request interval: %d seconds\n", interval);
+    printf("Secret (allowed): %s\n", secret_allowed);
+    printf("Secret (blocked): %s\n", secret_blocked);
+    printf("Using GnuTLS for TLS (gnutls_record_send)\n");
+    printf("\n");
+
+    printf("Waiting 15 seconds for kloak controller to sync...\n");
+    sleep(15);
+
+    gnutls_global_init();
+
+    gnutls_certificate_credentials_t cred;
+    gnutls_certificate_allocate_credentials(&cred);
+    gnutls_certificate_set_x509_system_trust(cred);
+
+    int iteration = 0;
+    while (1) {
+        iteration++;
+        printf("\n--- Request #%d ---\n", iteration);
+
+        int sockfd = tcp_connect(host, "443");
+        if (sockfd < 0) {
+            printf("Connection failed, retrying in %d seconds...\n", interval);
+            sleep(interval);
+            continue;
+        }
+
+        gnutls_session_t session;
+        gnutls_init(&session, GNUTLS_CLIENT);
+        gnutls_set_default_priority(session);
+        gnutls_credentials_set(session, GNUTLS_CRD_CERTIFICATE, cred);
+        gnutls_server_name_set(session, GNUTLS_NAME_DNS, host, strlen(host));
+        gnutls_transport_set_int(session, sockfd);
+
+        int ret = gnutls_handshake(session);
+        if (ret < 0) {
+            fprintf(stderr, "TLS handshake failed: %s\n", gnutls_strerror(ret));
+            gnutls_deinit(session);
+            close(sockfd);
+            sleep(interval);
+            continue;
+        }
+
+        printf("TLS handshake complete (version: %s)\n",
+               gnutls_protocol_get_name(gnutls_protocol_get_version(session)));
+
+        char request[MAX_BUF];
+        int req_len = snprintf(request, sizeof(request),
+            "GET %s HTTP/1.1\r\n"
+            "Host: %s\r\n"
+            "X-Secret-Allowed: %s\r\n"
+            "X-Secret-Blocked: %s\r\n"
+            "Connection: close\r\n"
+            "\r\n",
+            path, host, secret_allowed, secret_blocked);
+
+        ret = gnutls_record_send(session, request, req_len);
+        if (ret < 0) {
+            fprintf(stderr, "gnutls_record_send failed: %s\n", gnutls_strerror(ret));
+            gnutls_bye(session, GNUTLS_SHUT_RDWR);
+            gnutls_deinit(session);
+            close(sockfd);
+            sleep(interval);
+            continue;
+        }
+
+        printf("Response:\n");
+        char buf[MAX_BUF];
+        while (1) {
+            ret = gnutls_record_recv(session, buf, sizeof(buf) - 1);
+            if (ret == 0) break; /* EOF */
+            if (ret < 0) {
+                if (ret == GNUTLS_E_PREMATURE_TERMINATION) break;
+                fprintf(stderr, "gnutls_record_recv: %s\n", gnutls_strerror(ret));
+                break;
+            }
+            buf[ret] = '\0';
+            printf("%s", buf);
+        }
+        printf("\n");
+
+        gnutls_bye(session, GNUTLS_SHUT_RDWR);
+        gnutls_deinit(session);
+        close(sockfd);
+
+        printf("Sleeping %d seconds...\n", interval);
+        sleep(interval);
+    }
+
+    /* Unreachable, but good practice */
+    free(secret_allowed);
+    free(secret_blocked);
+    gnutls_certificate_free_credentials(cred);
+    gnutls_global_deinit();
+    return 0;
+}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,258 @@
+# mise.toml — Task runner for Kloak (feature-parity with Makefile)
+# Run `mise tasks` to see all available tasks.
+# Run `mise run <task>` or `mise <task>` to execute.
+
+[env]
+BINARY_NAME = "kloak"
+BUILD_DIR = "bin"
+CMD_DIR = "cmd"
+BPF_DIR = "pkg/ebpf"
+EBPF_PKG = "pkg/ebpf"
+DOCKER_IMAGE = "kloak"
+DOCKER_TAG = "latest"
+LIMA_VM = "kloak"
+LIMA_CONFIG = "lima.yaml"
+E2E_CLUSTER = "kloak-e2e"
+E2E_IMAGE_TAG = "e2e"
+
+# ============================================================================
+# Build targets
+# ============================================================================
+
+[tasks.build]
+description = "Build the kloak binary (native)"
+depends = ["deps"]
+run = """
+mkdir -p $BUILD_DIR
+go build -o $BUILD_DIR/$BINARY_NAME ./$CMD_DIR/kloak
+"""
+
+[tasks.build-linux]
+description = "Build for Linux (uses Lima on macOS)"
+depends = ["lima:ensure"]
+run = """
+if [ "$(uname)" = "Linux" ]; then
+  GOOS=linux GOARCH=amd64 go build -o $BUILD_DIR/$BINARY_NAME-linux ./$CMD_DIR/kloak
+else
+  limactl shell $LIMA_VM -- bash -lc "cd $(pwd) && go build -o $BUILD_DIR/$BINARY_NAME-linux ./$CMD_DIR/kloak"
+fi
+"""
+
+# ============================================================================
+# Test targets
+# ============================================================================
+
+[tasks.test]
+description = "Run unit tests"
+depends = ["deps"]
+run = "go test -v ./..."
+
+[tasks.test-linux]
+description = "Run tests in Linux VM (needed for eBPF)"
+depends = ["lima:ensure"]
+run = """
+limactl shell $LIMA_VM -- bash -lc "cd $(pwd) && go test -v ./..."
+"""
+
+[tasks.test-bpf-helpers]
+description = "Run pure C eBPF helper unit tests (no Linux/BPF required)"
+run = """
+gcc -Wall -Werror -o /tmp/helpers_test pkg/ebpf/bpf/helpers_test.c
+/tmp/helpers_test
+"""
+
+# ============================================================================
+# E2E targets
+# ============================================================================
+
+[tasks.e2e]
+description = "Full e2e: setup + run + cleanup"
+depends = ["e2e:setup"]
+run = """
+mise run e2e:run
+mise run e2e:cleanup
+"""
+
+[tasks."e2e:setup"]
+description = "Create k3d cluster with BPF mounts and import images"
+run = """
+set -e
+which k3d > /dev/null || { echo "Error: k3d not found. Install with: brew install k3d"; exit 1; }
+
+echo "==> Creating k3d cluster '$E2E_CLUSTER' with BPF mounts..."
+k3d cluster create $E2E_CLUSTER --wait --timeout 120s \
+  --volume /sys/kernel/btf:/sys/kernel/btf:ro@server:0 \
+  --volume /sys/fs/bpf:/sys/fs/bpf:rw@server:0 \
+  --volume /sys/kernel/tracing:/sys/kernel/tracing:ro@server:0 \
+  2>/dev/null || true
+
+echo "==> Building kloak image..."
+docker build -t $DOCKER_IMAGE:$E2E_IMAGE_TAG .
+
+echo "==> Building demo images..."
+docker build -t kloak-demo-go:$E2E_IMAGE_TAG -t kloak-demo-go:latest ./examples/demo-go/
+docker build -t kloak-demo-python:latest ./examples/demo-python/
+docker build -t kloak-demo-js:latest ./examples/demo-js/
+docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
+docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
+docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
+
+echo "==> Importing images into k3d..."
+k3d image import \
+  $DOCKER_IMAGE:$E2E_IMAGE_TAG \
+  kloak-demo-go:$E2E_IMAGE_TAG kloak-demo-go:latest \
+  kloak-demo-python:latest kloak-demo-js:latest \
+  kloak-demo-go-boring:latest kloak-demo-gnutls:latest \
+  kloak-demo-python-raw-tls:latest \
+  -c $E2E_CLUSTER
+
+docker pull bitnami/kubectl:latest
+k3d image import bitnami/kubectl:latest -c $E2E_CLUSTER
+
+echo "==> E2E environment ready."
+"""
+
+[tasks."e2e:run"]
+description = "Run e2e tests (requires e2e:setup first)"
+run = """
+KUBECONFIG=$(k3d kubeconfig write $E2E_CLUSTER) \
+go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
+"""
+
+[tasks."e2e:cleanup"]
+description = "Delete e2e k3d cluster"
+run = "k3d cluster delete $E2E_CLUSTER 2>/dev/null || true"
+
+# ============================================================================
+# Docker
+# ============================================================================
+
+[tasks.docker-build]
+description = "Build Docker image"
+depends = ["build"]
+run = "docker build -t $DOCKER_IMAGE:$DOCKER_TAG ."
+
+# ============================================================================
+# eBPF generation
+# ============================================================================
+
+[tasks.generate-ebpf]
+description = "Generate eBPF Go bindings (uses Lima on macOS)"
+depends = ["lima:ensure"]
+run = """
+ARCH=${KLOAK_TARGET_ARCH:-arm64}
+echo "Generating eBPF code (arch=$ARCH)..."
+if [ "$(uname)" = "Linux" ]; then
+  cd $EBPF_PKG && go generate
+else
+  echo "Using Lima VM for eBPF generation..."
+  limactl shell $LIMA_VM -- bash -lc "cd $(pwd)/$EBPF_PKG && KLOAK_TARGET_ARCH=$ARCH go generate"
+fi
+echo "eBPF generation complete."
+"""
+
+[tasks.generate-vmlinux]
+description = "Generate vmlinux.h from kernel BTF"
+depends = ["lima:ensure"]
+run = """
+echo "Generating vmlinux.h from kernel BTF..."
+if [ "$(uname)" = "Linux" ]; then
+  bpftool btf dump file /sys/kernel/btf/vmlinux format c > $BPF_DIR/vmlinux.h
+else
+  limactl shell $LIMA_VM -- bash -lc "bpftool btf dump file /sys/kernel/btf/vmlinux format c > $(pwd)/$BPF_DIR/vmlinux.h"
+fi
+"""
+
+# ============================================================================
+# Protobuf
+# ============================================================================
+
+[tasks.proto]
+description = "Generate protobuf code"
+run = "buf generate"
+
+# ============================================================================
+# Utility
+# ============================================================================
+
+[tasks.deps]
+description = "Download and tidy Go dependencies"
+run = """
+go mod download
+go mod tidy
+"""
+
+[tasks.run]
+description = "Build and run locally"
+depends = ["build"]
+run = "./$BUILD_DIR/$BINARY_NAME"
+
+[tasks.clean]
+description = "Clean build artifacts and generated eBPF files"
+run = """
+go clean
+rm -rf $BUILD_DIR
+rm -f $EBPF_PKG/tlsuprobe_bpfel.go $EBPF_PKG/tlsuprobe_bpfeb.go
+rm -f $EBPF_PKG/tlsuprobe_bpfel.o $EBPF_PKG/tlsuprobe_bpfeb.o
+"""
+
+# ============================================================================
+# Lima VM (for eBPF development on macOS)
+# ============================================================================
+
+[tasks."lima:check"]
+description = "Verify limactl is installed"
+run = """
+which limactl > /dev/null || { echo "Error: limactl not found. Install with: brew install lima"; exit 1; }
+"""
+
+[tasks."lima:ensure"]
+description = "Ensure Lima VM is running (idempotent)"
+depends = ["lima:check"]
+run = """
+if [ "$(uname)" = "Linux" ]; then
+  exit 0
+elif ! limactl list 2>/dev/null | grep -q "^$LIMA_VM"; then
+  echo "Creating Lima VM '$LIMA_VM'..."
+  limactl start --name=$LIMA_VM $LIMA_CONFIG
+elif limactl list | grep "^$LIMA_VM" | grep -q "Stopped"; then
+  echo "Starting Lima VM '$LIMA_VM'..."
+  limactl start $LIMA_VM
+fi
+"""
+
+[tasks."lima:start"]
+description = "Start the Lima VM"
+depends = ["lima:check"]
+run = """
+if ! limactl list 2>/dev/null | grep -q "^$LIMA_VM"; then
+  echo "Creating Lima VM '$LIMA_VM'..."
+  limactl start --name=$LIMA_VM $LIMA_CONFIG
+elif limactl list | grep "^$LIMA_VM" | grep -q "Stopped"; then
+  echo "Starting Lima VM '$LIMA_VM'..."
+  limactl start $LIMA_VM
+else
+  echo "Lima VM '$LIMA_VM' is already running"
+fi
+"""
+
+[tasks."lima:stop"]
+description = "Stop the Lima VM"
+run = "limactl stop $LIMA_VM 2>/dev/null || true"
+
+[tasks."lima:delete"]
+description = "Delete the Lima VM"
+depends = ["lima:stop"]
+run = "limactl delete $LIMA_VM 2>/dev/null || true"
+
+[tasks."lima:shell"]
+description = "Open shell in Lima VM"
+depends = ["lima:ensure"]
+run = "limactl shell $LIMA_VM"
+
+[tasks."lima:exec"]
+description = "Execute command in Lima VM (use: mise run lima:exec -- 'your command')"
+depends = ["lima:ensure"]
+run = """
+limactl shell $LIMA_VM -- bash -lc "$@"
+"""

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -159,7 +159,7 @@ func (m *TLSUprobeManager) UntrackTGID(tgid uint32) error {
 }
 
 // AttachTLS attempts to automatically detect the runtime language and attach
-// the correct eBPF uprobes (Go crypto/tls or OpenSSL) to the given PID.
+// the correct eBPF uprobes (Go crypto/tls, OpenSSL, or GnuTLS) to the given PID.
 // Also registers the PID's TGID in tracked_tgids for DNS/connect tracking.
 func (m *TLSUprobeManager) AttachTLS(pid int) error {
 	exePath := fmt.Sprintf("/proc/%d/exe", pid)
@@ -224,6 +224,32 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 		}
 	}
 
+	// 3. Try GnuTLS (same C ABI as OpenSSL — reuse BpfUprobeSslWrite)
+	gnutlsSymbols := []string{"gnutls_record_send", "gnutls_record_send2"}
+	for _, sym := range gnutlsSymbols {
+		up, err := ex.Uprobe(sym, m.objs.BpfUprobeSslWrite, nil)
+		if err == nil {
+			m.log.Info("Attached GnuTLS uprobe to main exe", "pid", pid, "symbol", sym)
+			m.links = append(m.links, up)
+			attached = true
+		}
+	}
+
+	for _, libPath := range findTLSLibraries(pid) {
+		libEx, err := link.OpenExecutable(libPath)
+		if err != nil {
+			continue
+		}
+		for _, sym := range gnutlsSymbols {
+			up, err := libEx.Uprobe(sym, m.objs.BpfUprobeSslWrite, nil)
+			if err == nil {
+				m.log.Info("Attached GnuTLS uprobe to shared library", "pid", pid, "symbol", sym, "lib", libPath)
+				m.links = append(m.links, up)
+				attached = true
+			}
+		}
+	}
+
 	if attached {
 		return nil
 	}
@@ -232,8 +258,8 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 }
 
 // findTLSLibraries scans /proc/<pid>/maps for shared libraries that may export
-// SSL_write: OpenSSL (libssl.so), BoringSSL (libboringssl.so or libssl.so),
-// and libcrypto.so (some BoringSSL builds export SSL_write there).
+// TLS write functions: OpenSSL (libssl.so), BoringSSL (libboringssl.so or libssl.so),
+// libcrypto.so (some BoringSSL builds), and GnuTLS (libgnutls.so).
 // Returns deduplicated paths accessible via /proc/<pid>/root.
 func findTLSLibraries(pid int) []string {
 	mapsPath := fmt.Sprintf("/proc/%d/maps", pid)
@@ -280,6 +306,10 @@ func isTLSLibrary(name string) bool {
 	}
 	// Some BoringSSL builds export SSL_write from libcrypto
 	if strings.HasPrefix(name, "libcrypto.so") {
+		return true
+	}
+	// GnuTLS
+	if strings.HasPrefix(name, "libgnutls.so") {
 		return true
 	}
 	return false

--- a/pkg/ebpf/uprobe_test.go
+++ b/pkg/ebpf/uprobe_test.go
@@ -1,0 +1,38 @@
+//go:build linux
+
+package ebpf
+
+import "testing"
+
+func TestIsTLSLibrary(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// OpenSSL
+		{"libssl.so", true},
+		{"libssl.so.3", true},
+		{"libssl.so.1.1", true},
+		// BoringSSL
+		{"libboringssl.so", true},
+		{"libboringssl.so.1", true},
+		// libcrypto
+		{"libcrypto.so", true},
+		{"libcrypto.so.3", true},
+		// GnuTLS
+		{"libgnutls.so", true},
+		{"libgnutls.so.30", true},
+		{"libgnutls.so.30.34.2", true},
+		// Non-TLS libraries
+		{"libc.so.6", false},
+		{"libpthread.so.0", false},
+		{"libssl-extra.so", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTLSLibrary(tt.name); got != tt.want {
+				t.Errorf("isTLSLibrary(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -50,6 +50,12 @@ var ebpfTests = []ebpfRewriteTest{
 		deploymentName: "demo-go-boring",
 		appLabel:       "app=demo-go-boring",
 	},
+	{
+		name:           "gnutls",
+		demoDir:        "demo-gnutls",
+		deploymentName: "demo-gnutls",
+		appLabel:       "app=demo-gnutls",
+	},
 }
 
 // TestEBPFRawTLSHostFiltering tests that DNS-verified host filtering works with


### PR DESCRIPTION
## Summary
- Add GnuTLS TLS library interception alongside existing OpenSSL/BoringSSL support
- Hook `gnutls_record_send` and `gnutls_record_send2` using the existing `bpf_uprobe_ssl_write` eBPF program (same C ABI, no kernel code changes needed)
- Add `libgnutls.so*` to library discovery in `isTLSLibrary()`
- New `examples/demo-gnutls/` C demo app using GnuTLS API
- e2e test case + unit test for `isTLSLibrary`
- Fix pre-existing Makefile gaps (missing tracefs mount, missing demo-python-raw-tls image)
- Add `mise.toml` task runner with full Makefile feature parity

Closes #56

See also: #57 (rustls tracking issue)

## Test plan
- [x] Unit test `TestIsTLSLibrary` passes (13/13 cases)
- [x] BPF helper tests pass (`make test-bpf-helpers`, 23/23)
- [x] Full e2e suite passes (16/16 tests, 252s) including:
  - [x] `TestEBPFSecretRewrite/gnutls` -- GnuTLS demo sends secrets via `gnutls_record_send`, eBPF rewrites allowed secret, blocks disallowed
  - [x] `TestEBPFRawTLSHostFiltering` -- now passes with image fix
  - [x] All existing runtimes (Go, Python, JS, Go-BoringSSL) unaffected

## Additional fixes (pre-existing Makefile bugs)
- Mount `/sys/kernel/tracing` in k3d cluster (was in CI but missing from Makefile)
- Build and import `demo-python-raw-tls` image (was causing `ErrImageNeverPull`)
- Build and import `demo-gnutls` image