### PR TITLE
fix: set git config before orphan branch creation in helm publish

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Package chart
         run: helm package charts/kloak -d .helm-pkg
 
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Checkout or create gh-pages branch
         run: |
           git fetch origin gh-pages || true
@@ -49,8 +54,6 @@ jobs:
       - name: Push to gh-pages
         run: |
           cd gh-pages
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .
           git commit -m "publish helm chart ${VERSION}"
           git push origin gh-pages


### PR DESCRIPTION
## Summary
- The helm publish workflow fails on first run because `git commit --allow-empty` (for bootstrapping the `gh-pages` orphan branch) runs before `git config user.name/email` is set
- Moves git config to a dedicated early step so it's available for both the orphan branch bootstrap and the final push

## Test plan
- [ ] Merge and verify the Publish Helm Chart workflow succeeds on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)