### PR TITLE
fix: use custom domain for helm repo index URL

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Update Helm repo
         run: |
           cp .helm-pkg/*.tgz gh-pages/
-          helm repo index gh-pages --url https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          helm repo index gh-pages --url https://chart.getkloak.io
 
       - name: Push to gh-pages
         run: |


### PR DESCRIPTION
## Summary
- The `helm repo index` was using `https://spinningfactory.github.io/kloak` as the chart URL, but GitHub Pages is served via the custom domain `chart.getkloak.io`
- Helm was failing to download the `.tgz` because the URL in `index.yaml` didn't match the actual host
- Changed the `--url` flag to `https://chart.getkloak.io`

## Test plan
- [ ] Merge and wait for the helm publish workflow to run
- [ ] `helm repo update && helm show values kloak/kloak --devel` should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)