### PR TITLE
fix: create local gh-pages branch before worktree add

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -37,7 +37,8 @@ jobs:
         run: |
           git fetch origin gh-pages || true
           if git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
-            git worktree add gh-pages origin/gh-pages
+            git branch gh-pages origin/gh-pages
+            git worktree add gh-pages gh-pages
           else
             git worktree add --detach gh-pages
             cd gh-pages


### PR DESCRIPTION
## Summary
- `git worktree add gh-pages origin/gh-pages` creates a detached HEAD, so `git push origin gh-pages` fails with `src refspec gh-pages does not match any`
- Fix: create a local `gh-pages` branch tracking `origin/gh-pages` before adding the worktree

## Test plan
- [ ] Merge and verify the Publish Helm Chart workflow pushes to gh-pages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)