### PR TITLE
fix: add 2s startup delay to Go demos for uprobe attachment

### DIFF
--- a/examples/demo-go-boring/main.go
+++ b/examples/demo-go-boring/main.go
@@ -54,6 +54,10 @@ func main() {
 	fmt.Println("  - X-Secret-Blocked: Should show UUID in response (not replaced)")
 	fmt.Println(strings.Repeat("=", 60))
 
+	// Brief delay for eBPF uprobe attachment before the first TLS connection.
+	fmt.Println("Waiting 2s for Kloak controller to sync...")
+	time.Sleep(2 * time.Second)
+
 	// Force HTTP/1.1 — Go defaults to h2 via ALPN, but HTTP/2 uses binary
 	// HPACK-encoded frames that the eBPF uprobe scanner cannot parse.
 	// HTTP/1.1 sends plaintext headers through tls.Conn.Write in a single call.

--- a/examples/demo-go/main.go
+++ b/examples/demo-go/main.go
@@ -54,6 +54,10 @@ func main() {
 	fmt.Println("  - X-Secret-Blocked: Should show UUID in response (not replaced)")
 	fmt.Println(strings.Repeat("=", 60))
 
+	// Brief delay for eBPF uprobe attachment before the first TLS connection.
+	fmt.Println("Waiting 2s for Kloak controller to sync...")
+	time.Sleep(2 * time.Second)
+
 	// Force HTTP/1.1 — Go defaults to h2 via ALPN, but HTTP/2 uses binary
 	// HPACK-encoded frames that the eBPF uprobe scanner cannot parse.
 	// HTTP/1.1 sends plaintext headers through tls.Conn.Write in a single call.


### PR DESCRIPTION
## Summary
- Adds a 2s startup delay to Go and Go-boring demos to allow eBPF uprobe attachment before the first TLS connection
- Go starts faster than the reconciler can discover and instrument the process, causing the first connection to bypass interception

## Test plan
- [ ] Go demo e2e test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)