### PR TITLE
Add AI training opt-out

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Opt out of AI training for all files
+* ai-training=false


### PR DESCRIPTION
Adds `.gitattributes` with `* ai-training=false` to opt this repo out of GitHub AI/Copilot training data collection. Deadline for GitHub's new policy is April 24, 2026.