### PR TITLE
feat: Add port based filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,11 @@ generate-vmlinux: $(BPF_DIR)/vmlinux.h
 
 # Check if Lima is installed
 lima-check:
-	@which limactl > /dev/null || (echo "Error: limactl not found. Install with: brew install lima" && exit 1)
+	@if [ "$$(uname)" = "Linux" ]; then \
+		exit 0; \
+	else \
+		which limactl > /dev/null || (echo "Error: limactl not found. Install with: brew install lima" && exit 1); \
+	fi
 
 # Ensure Lima VM is running (idempotent)
 lima-ensure: lima-check $(LIMA_CONFIG)

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/oklog/ulid/v2 v2.1.1
 	github.com/spf13/cobra v1.10.2
 	golang.org/x/net v0.47.0
+	golang.org/x/sys v0.38.0
 	k8s.io/api v0.35.0
 	k8s.io/apimachinery v0.35.0
 	k8s.io/client-go v0.35.0
@@ -50,7 +51,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/oauth2 v0.32.0 // indirect
 	golang.org/x/sync v0.18.0 // indirect
-	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/term v0.37.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/time v0.9.0 // indirect

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"crypto/rand"
@@ -12,6 +13,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/oklog/ulid/v2"
 	"golang.org/x/net/http2/hpack"
+	"golang.org/x/sys/unix"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,6 +29,12 @@ const (
 	// AnnotationSecretEnabled is the label/annotation to enable Kloak secret replication.
 	AnnotationSecretEnabled = "getkloak.io/enabled"
 
+	// AnnotationPort is the label/annotation to specify an allowed port for a secret.
+	AnnotationPort = "getkloak.io/port"
+
+	// AnnotationHosts is the label/annotation to specify allowed hosts for a secret.
+	AnnotationHosts = "getkloak.io/hosts"
+
 	// ShadowSecretSuffix is the suffix appended to the name of the shadow secret.
 	ShadowSecretSuffix = "-kloak"
 
@@ -34,6 +42,44 @@ const (
 	// Must match what the eBPF program expects.
 	ValuePrefix = "kloak:"
 )
+
+type PortSpec struct {
+	Port     uint16
+	Protocol uint8
+}
+
+func parsePortSpec(spec string) (PortSpec, error) {
+	spec = strings.TrimSpace(spec)
+	spec = strings.ToLower(spec)
+
+	protoStr := "tcp"
+	parts := strings.Split(spec, "/")
+	if len(parts) == 0 || len(parts) > 2 {
+		return PortSpec{}, fmt.Errorf("invalid port format: %s", spec)
+	} else if len(parts) == 2 {
+		protoStr = parts[1]
+	}
+	portStr := parts[0]
+
+	port, err := strconv.ParseUint(portStr, 10, 16)
+	if err != nil {
+		return PortSpec{}, err
+	} else if port == 0 || port > 65535 {
+		return PortSpec{}, fmt.Errorf("invalid port: %d", port)
+	}
+
+	var proto uint8
+	switch protoStr {
+	case "tcp":
+		proto = uint8(unix.IPPROTO_TCP)
+	case "udp":
+		proto = uint8(unix.IPPROTO_UDP)
+	default:
+		return PortSpec{}, fmt.Errorf("invalid proto: %s", protoStr)
+	}
+
+	return PortSpec{Port: uint16(port), Protocol: proto}, nil
+}
 
 // SecretReconciler reconciles a Secret object
 type SecretReconciler struct {
@@ -143,7 +189,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	for shadowVal, originalVal := range newMappings {
 		// Parse allowed hosts
 		allowedHosts := []string{"*"}
-		if hostsLabel, ok := secret.Labels["getkloak.io/hosts"]; ok && hostsLabel != "" {
+		if hostsLabel, ok := secret.Labels[AnnotationHosts]; ok && hostsLabel != "" {
 			// Split by comma and trim spaces
 			parts := strings.Split(hostsLabel, ",")
 			allowedHosts = make([]string, 0, len(parts))
@@ -154,10 +200,25 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			}
 		}
 
-		// Store mapping (uuid -> original + hosts)
+		var portSpec PortSpec
+		var err error
+		validPort := false
+		if v, ok := secret.Labels[AnnotationPort]; ok && v != "" {
+			portSpec, err = parsePortSpec(v)
+			if err != nil {
+				log.Error(err, "Invalid port specification, treating as wildcard", "secret", req.NamespacedName, "label", v)
+			} else {
+				validPort = true
+			}
+		}
+
 		entry := storage.Entry{
 			Value:        originalVal,
 			AllowedHosts: allowedHosts,
+		}
+		if validPort {
+			entry.Port = portSpec.Port
+			entry.Protocol = portSpec.Protocol
 		}
 		if err := r.Storage.Store(ctx, secretID, shadowVal, entry); err != nil {
 			log.Error(err, "failed to store mapping", "shadow", shadowVal)

--- a/pkg/ebpf/bpf/helpers.h
+++ b/pkg/ebpf/bpf/helpers.h
@@ -23,6 +23,8 @@ typedef uint64_t __u64;
 #ifndef MAX_DATA_SIZE
 #define MAX_DATA_SIZE 256
 #endif
+typedef uint16_t __u16;
+typedef int int32_t;
 #endif
 
 // Parse HTTP "Host: " header from a data buffer.

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -67,6 +67,8 @@ struct secret_value {
   char real_secret[SECRET_MAX_LEN];
   __u32 host_len;                      // 0 = wildcard (allow all hosts)
   char allowed_host[MAX_HOST_LEN];     // e.g. "httpbin.org"
+  __u16 port;                          // 0 = wildcard, otherwise port number (host byte order)
+  __u8 protocol;                       // IPPROTO_TCP (6) = TCP, IPPROTO_UDP (17) = UDP
   __u32 prefix_len;                    // actual prefix length (8..42)
   char full_prefix[SECRET_PREFIX_MAX]; // full kloak:UUID prefix for verification
 };
@@ -97,6 +99,7 @@ struct scratch_buf {
     struct secret_key key;        // 8-byte key prefix
   } xor_matches[XOR_MAX_MATCHES];
   char host_value[MAX_HOST_LEN]; // host from DNS chain
+  __u16 dest_port;      // destination port in host byte order
   char data[MAX_DATA_SIZE];
 };
 
@@ -232,7 +235,7 @@ struct {
   __type(value, struct dns_ip_val);
 } dns_ip_map SEC(".maps");
 
-// TCP connection fd -> peer IP per process.
+// TCP connection fd -> peer IP and port per process.
 // Populated by tp_exit_connect for every connect() call.
 struct conn_ip_key {
   __u32 tgid;
@@ -241,6 +244,7 @@ struct conn_ip_key {
 
 struct conn_ip_val {
   __u8 ip[16]; // IPv4-mapped-IPv6 or native IPv6
+  __u16 port;  // destination port (network byte order)
 };
 
 
@@ -295,10 +299,11 @@ struct {
   __type(value, struct udp_recv_pending);
 } udp_recv_scratch SEC(".maps");
 
-// Scratch for connect enter->exit correlation: save fd and sockaddr.
+// Scratch for connect enter->exit correlation: save fd, IP, and port.
 struct connect_pending_val {
   __u32 fd;
-  __u8 ip[16]; // destination IP (IPv4-mapped-IPv6)
+  __u8 ip[16];  // destination IP (IPv4-mapped-IPv6)
+  __u16 port;   // destination port (network byte order)
 };
 
 struct {
@@ -993,8 +998,16 @@ int tp_enter_connect(struct trace_event_raw_sys_enter *ctx) {
     __u8 ipv4[4] = {};
     bpf_probe_read_user(ipv4, 4, (void *)(addr_ptr + 4));
     ipv4_to_mapped(val.ip, ipv4);
+    // Port is at offset 2 in sockaddr_in (after sa_family)
+    __u16 port_be = 0;
+    bpf_probe_read_user(&port_be, sizeof(port_be), (void *)(addr_ptr + 2));
+    val.port = port_be;
   } else if (sa_family == 10) { // AF_INET6
     bpf_probe_read_user(val.ip, 16, (void *)(addr_ptr + 8));
+    // Port is at offset 2 in sockaddr_in6
+    __u16 port_be = 0;
+    bpf_probe_read_user(&port_be, sizeof(port_be), (void *)(addr_ptr + 2));
+    val.port = port_be;
   } else {
     return 0;
   }
@@ -1019,6 +1032,7 @@ int tp_exit_connect(struct trace_event_raw_sys_exit *ctx) {
   // Save before delete
   __u32 fd = pending->fd;
   __u8 ip[16];
+  __u16 port = pending->port;
   __builtin_memcpy(ip, pending->ip, 16);
 
   bpf_map_delete_elem(&connect_pending, &pid_tgid);
@@ -1028,10 +1042,11 @@ int tp_exit_connect(struct trace_event_raw_sys_exit *ctx) {
   if (ret != 0 && ret != -115)
     return 0;
 
-  // Always record fd -> IP and IP -> {tgid,fd}
+  // Always record fd -> IP, port, and IP -> {tgid,fd}
   struct conn_ip_key cik = {.tgid = tgid, .fd = fd};
   struct conn_ip_val civ;
   __builtin_memcpy(civ.ip, ip, 16);
+  civ.port = port;
   bpf_map_update_elem(&conn_ip_map, &cik, &civ, BPF_ANY);
 
   // Check if this IP was already DNS-verified
@@ -1094,7 +1109,7 @@ static __always_inline __u32 ssl_read_fd(__u64 ssl_ptr) {
 }
 
 // =============================================================================
-// Resolve host for the current SSL/TLS connection using DNS chain.
+// Resolve host and port for the current SSL/TLS connection using DNS chain.
 //
 // Chain: ssl_fd_map (cache) -> BIO fd read -> last_verified_fd -> conn_ip_map -> dns_ip_map
 // =============================================================================
@@ -1104,6 +1119,7 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
   scratch_data->host_value_len = 0;
   scratch_data->xor_fd = 0;
   __builtin_memset(scratch_data->host_value, 0, MAX_HOST_LEN);
+  scratch_data->dest_port = 0;
 
   __u64 pid_tgid = bpf_get_current_pid_tgid();
   __u32 tgid = (__u32)(pid_tgid >> 32);
@@ -1169,6 +1185,8 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
     struct conn_ip_key cik = {.tgid = tgid, .fd = fd};
     struct conn_ip_val *civ = bpf_map_lookup_elem(&conn_ip_map, &cik);
     if (!civ) { dbg_inc(DBG_RESOLVE_NO_CONN); return; }
+    // Store destination port (network byte order from connect)
+    scratch_data->dest_port = __bpf_ntohs(civ->port);
     struct dns_ip_key dik;
     __builtin_memset(&dik, 0, sizeof(dik));
     __builtin_memcpy(dik.ip, civ->ip, 16);
@@ -1190,6 +1208,8 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
     struct conn_ip_val *civ = bpf_map_lookup_elem(&conn_ip_map, &cik);
     if (!civ)
       continue;
+    // Store destination port (network byte order from connect)
+    scratch_data->dest_port = __bpf_ntohs(civ->port);
     struct dns_ip_key dik;
     __builtin_memset(&dik, 0, sizeof(dik));
     __builtin_memcpy(dik.ip, civ->ip, 16);
@@ -1386,14 +1406,27 @@ int bpf_xor_path(void *ctx) {
   // Host filtering: val is fresh, re-lookup sd for host_value.
   __u32 val_len = val->len;
   __u32 val_host_len = val->host_len;
-  if (val_host_len > 0 && val_host_len < MAX_HOST_LEN) {
-    if (sd_host_len == 0)
-      goto next;
-    // Re-lookup sd for host comparison (val stays in callee-saved reg).
+  __u16 val_port = val->port;
+  if (val_host_len > 0 || val_port > 0) {
+    // Single lookup for both host and port filtering.
     sd = bpf_map_lookup_elem(&scratch, &zero);
     if (!sd) return 0;
-    if (!hosts_match(sd->host_value, val->allowed_host))
-      goto next;
+
+    // Host filtering
+    if (val_host_len > 0 && val_host_len < MAX_HOST_LEN) {
+      if (sd_host_len == 0)
+        goto next;
+      if (!hosts_match(sd->host_value, val->allowed_host))
+        goto next;
+    }
+
+    // Port filtering: val->port == 0 means wildcard (allow all ports).
+    // val->port != 0 means only allow this specific port.
+    if (val_port != 0) {
+      // dest_port is 0 if resolution failed, which correctly fails the filter.
+      if (sd->dest_port != val_port)
+        goto next;
+    }
   }
 
   dbg_inc(DBG_XOR_SECRET_FOUND);

--- a/pkg/ebpf/sync.go
+++ b/pkg/ebpf/sync.go
@@ -11,9 +11,6 @@ import (
 	"github.com/spinningfactory/kloak/pkg/storage"
 )
 
-// syncSecrets updates the BPF secret_map with the latest shadow secret values
-// from the given storage, and syncs the watched_hosts map with unique hostnames
-// from secret entries (used for DNS filtering).
 func syncSecrets(secretMap, watchedHostsMap *ebpf.Map, store storage.Storage, log logr.Logger) error {
 	secrets, err := store.List(context.Background())
 	if err != nil {
@@ -82,10 +79,15 @@ func syncSecrets(secretMap, watchedHostsMap *ebpf.Map, store storage.Storage, lo
 		}
 		// HostLen == 0 means wildcard (allow all hosts)
 
+		// Set allowed port for port-based filtering
+		// Port == 0 means wildcard (allow all ports)
+		val.Port = entry.Port
+		val.Protocol = entry.Protocol
+
 		if err := secretMap.Update(&key, &val, 0); err != nil {
 			log.Error(err, "failed to update BPF secret_map", "hash", hash)
 		} else {
-			log.Info("Synced secret into eBPF map", "hash", hash, "hostLen", val.HostLen)
+			log.Info("Synced secret into eBPF map", "hash", hash, "hostLen", val.HostLen, "port", val.Port, "protocol", val.Protocol)
 		}
 
 		// Also store a Huffman-encoded variant for HTTP/2 HPACK interception.
@@ -122,6 +124,8 @@ func syncSecrets(secretMap, watchedHostsMap *ebpf.Map, store storage.Storage, lo
 				copy(huffVal.RealSecret[:], huffReal[:huffLen])
 				huffVal.HostLen = val.HostLen
 				huffVal.AllowedHost = val.AllowedHost
+				huffVal.Port = val.Port
+				huffVal.Protocol = val.Protocol
 				huffPrefixLen := len(huffShadow)
 				if huffPrefixLen > 42 {
 					huffPrefixLen = 42

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -53,9 +53,12 @@ type secretValue struct {
 	RealSecret  [128]byte
 	HostLen     uint32
 	AllowedHost [64]byte
+	Port        uint16  // 0 = wildcard, otherwise port number (host byte order)
+	Protocol    uint8   // IPPROTO_TCP (6) = TCP, IPPROTO_UDP (17) = UDP
+	_           [1]byte // padding to align PrefixLen (uint32)
 	PrefixLen   uint32
 	FullPrefix  [42]byte // SECRET_PREFIX_MAX
-	_           [2]byte  // padding to match C struct alignment
+	_           [2]byte  // trailing padding to match C struct alignment
 }
 
 // watchedHostKey matches C struct watched_host_key

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -10,6 +10,8 @@ import (
 type Entry struct {
 	Value        string   `json:"value"`
 	AllowedHosts []string `json:"allowed_hosts"`
+	Port         uint16   `json:"port"`
+	Protocol     uint8    `json:"protocol"`
 }
 
 // Storage defines the interface for hash-to-value storage.

--- a/test/e2e/port_filtering_test.go
+++ b/test/e2e/port_filtering_test.go
@@ -1,0 +1,81 @@
+//go:build e2e_ebpf
+
+package e2e
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestEBPFRawTLSPortFiltering tests that port-based filtering works with
+// raw TLS sockets. A TLS echo server runs as a sidecar behind a K8s Service.
+// The client connects on a specific port, and the port is verified at
+// connect() time to enable port-based secret filtering.
+func TestEBPFRawTLSPortFiltering(t *testing.T) {
+	echoHostFQDN := "tls." + testNamespace + ".svc.cluster.local"
+	// The echo server runs on port 8443
+	echoPort := "8443"
+	wrongPort := "443"
+
+	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-PORT-KEY")}
+	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-PORT-KEY")}
+
+	createEnabledSecret(t, "secret-port-allowed", allowedData, map[string]string{
+		"getkloak.io/hosts": echoHostFQDN,
+		"getkloak.io/port": echoPort,
+	})
+	createEnabledSecret(t, "secret-port-blocked", blockedData, map[string]string{
+		"getkloak.io/hosts": echoHostFQDN,
+		"getkloak.io/port": wrongPort,
+	})
+
+	assertShadowSecret(t, "secret-port-allowed", allowedData)
+	assertShadowSecret(t, "secret-port-blocked", blockedData)
+
+	demoManifest := filepath.Join(repoRoot, "examples", "demo-python-raw-tls", "deployment.yaml")
+	if err := applyManifest(t, demoManifest); err != nil {
+		t.Fatalf("failed to deploy demo-python-raw-tls: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = kubectl("delete", "-f", demoManifest, "-n", testNamespace, "--ignore-not-found")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	if err := waitForDeploymentReady(ctx, testNamespace, "demo-python-raw-tls"); err != nil {
+		t.Fatalf("demo-python-raw-tls not ready: %v", err)
+	}
+
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer pollCancel()
+	var out string
+	for {
+		select {
+		case <-pollCtx.Done():
+			t.Logf("=== demo-python-raw-tls final logs ===\n%s", out)
+			t.Logf("=== Controller logs ===\n%s", controllerLogs())
+			t.Fatalf("timed out waiting for allowed secret in raw TLS demo logs")
+		default:
+		}
+		out, _ = kubectl("logs", "-n", testNamespace, "-l", "app=demo-python-raw-tls", "--tail=200")
+		if strings.Contains(out, "REAL-ALLOWED-PORT-KEY") {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("=== demo-python-raw-tls logs ===\n%s", out)
+
+	if strings.Contains(out, "REAL-BLOCKED-PORT-KEY") {
+		t.Errorf("blocked secret should NOT be rewritten (port mismatch)")
+	}
+
+	// Also verify the blocked secret's placeholder appears in the output
+	// This confirms it was NOT rewritten (if it was, we'd see the real value)
+	if !strings.Contains(out, "BLOCKED=") {
+		t.Logf("output: %s", out)
+		t.Errorf("blocked secret should have its placeholder value in the echo output")
+	}
+}

--- a/test/e2e/port_filtering_test.go
+++ b/test/e2e/port_filtering_test.go
@@ -15,6 +15,14 @@ import (
 // The client connects on a specific port, and the port is verified at
 // connect() time to enable port-based secret filtering.
 func TestEBPFRawTLSPortFiltering(t *testing.T) {
+	// Wait for stale secrets from previous tests to be cleaned up.
+	gcCtx, gcCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer gcCancel()
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-allowed")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-blocked")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-allowed-kloak")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-blocked-kloak")
+
 	echoHostFQDN := "tls." + testNamespace + ".svc.cluster.local"
 	// The echo server runs on port 8443
 	echoPort := "8443"
@@ -23,17 +31,19 @@ func TestEBPFRawTLSPortFiltering(t *testing.T) {
 	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-PORT-KEY")}
 	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-PORT-KEY")}
 
-	createEnabledSecret(t, "secret-port-allowed", allowedData, map[string]string{
+	// Secret names must match the deployment manifest volume references
+	// (secret-allowed, secret-blocked) — not custom names.
+	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
 		"getkloak.io/hosts": echoHostFQDN,
-		"getkloak.io/port": echoPort,
+		"getkloak.io/port":  echoPort,
 	})
-	createEnabledSecret(t, "secret-port-blocked", blockedData, map[string]string{
+	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
 		"getkloak.io/hosts": echoHostFQDN,
-		"getkloak.io/port": wrongPort,
+		"getkloak.io/port":  wrongPort,
 	})
 
-	assertShadowSecret(t, "secret-port-allowed", allowedData)
-	assertShadowSecret(t, "secret-port-blocked", blockedData)
+	assertShadowSecret(t, "secret-allowed", allowedData)
+	assertShadowSecret(t, "secret-blocked", blockedData)
 
 	demoManifest := filepath.Join(repoRoot, "examples", "demo-python-raw-tls", "deployment.yaml")
 	if err := applyManifest(t, demoManifest); err != nil {


### PR DESCRIPTION
## Summary
This PR adds **port-based filtering** to Kloak, allowing secrets to be restricted to specific destination ports (e.g., HTTPS port 443) in addition to the existing host-based filtering.
## Changes
### New Features
- **Port-based secret filtering**: Secrets can now be restricted to specific destination ports using the `getkloak.io/port` label on Kubernetes Secrets
- **Protocol specification in label**: The port label supports protocol (e.g., `443/tcp`, `53/udp`), but **protocol is currently unused** — only TCP connections are rewritten. The protocol field is stored but ignored in this release, allowing future UDP support
- **Port capture on connect**: The eBPF program now captures the destination port from `connect()` syscalls and uses it during secret rewriting
### User-Facing Changes
- **New label**: `getkloak.io/port` - Specifies allowed port (and optionally protocol) for a secret
  - Examples: `"443"`, `"443/tcp"`, `"53/udp"`
  - Omitted or `0` means wildcard (allow all ports)
- **Backward compatible**: Port is optional; omitting it allows all ports on TCP
### Technical Details
- Extended `storage.Entry` struct with `Port` and `Protocol` fields
- Extended eBPF `secret_value` struct with `port` and `protocol` fields
- Added port capture in `tp_enter_connect`/`tp_exit_connect` tracepoints
- Added port matching logic in the rewrite phase (`bpf_phase2_rewrite`)
- Protocol parsing is implemented but not yet used in filtering (reserved for future UDP support)
### Files Modified
- `pkg/storage/storage.go` - Added Port/Protocol to Entry
- `pkg/controller/secret_reconciler.go` - Added port parsing and storage
- `pkg/ebpf/uprobe.go` - Added Port/Protocol to Go struct
- `pkg/ebpf/sync.go` - Sync port/protocol to BPF map
- `pkg/ebpf/bpf/tls_uprobe.c` - eBPF port capture and filtering
- `pkg/ebpf/bpf/helpers.h` - Added type definitions