### PR TITLE
fix: skip server-mode SSL connections in BPF uprobe

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1853,6 +1853,23 @@ int bpf_uprobe_ssl_write(void *ctx) {
   return 0;
 #endif
 
+  // Skip server-mode SSL connections. Server sockets are created via accept(),
+  // which never populates conn_ip_map (only connect() does via tp_exit_connect).
+  // Without this check, the H extraction path runs against server-mode SSL*
+  // objects whose internal layout differs from client-mode, producing garbage
+  // GHASH keys that corrupt outbound TLS authentication tags ("bad record MAC").
+  {
+    __u32 bio_fd = ssl_read_fd((__u64)ssl_ptr);
+    if (bio_fd == 0)
+      return 0;
+    __u32 cur_tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+    struct conn_ip_key cik = {};
+    cik.tgid = cur_tgid;
+    cik.fd = bio_fd;
+    if (!bpf_map_lookup_elem(&conn_ip_map, &cik))
+      return 0;
+  }
+
 #ifdef KLOAK_DEBUG
   __u32 pid = bpf_get_current_pid_tgid();
   bpf_printk("kloak ssl: ssl=%llx ptr=%llx num=%d pid=%d", (__u64)ssl_ptr,

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1858,16 +1858,20 @@ int bpf_uprobe_ssl_write(void *ctx) {
   // Without this check, the H extraction path runs against server-mode SSL*
   // objects whose internal layout differs from client-mode, producing garbage
   // GHASH keys that corrupt outbound TLS authentication tags ("bad record MAC").
+  //
+  // If ssl_read_fd fails (returns 0), we cannot determine client vs server mode,
+  // so we fall through and let the existing logic handle it. We only bail when
+  // we have a valid fd that is positively NOT in conn_ip_map (server-mode).
   {
     __u32 bio_fd = ssl_read_fd((__u64)ssl_ptr);
-    if (bio_fd == 0)
-      return 0;
-    __u32 cur_tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
-    struct conn_ip_key cik = {};
-    cik.tgid = cur_tgid;
-    cik.fd = bio_fd;
-    if (!bpf_map_lookup_elem(&conn_ip_map, &cik))
-      return 0;
+    if (bio_fd != 0) {
+      __u32 cur_tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
+      struct conn_ip_key cik = {};
+      cik.tgid = cur_tgid;
+      cik.fd = bio_fd;
+      if (!bpf_map_lookup_elem(&conn_ip_map, &cik))
+        return 0;  // server-mode: fd exists but not from connect()
+    }
   }
 
 #ifdef KLOAK_DEBUG


### PR DESCRIPTION
## Summary
- Add conn_ip_map lookup in `bpf_uprobe_ssl_write` to distinguish client vs server SSL connections
- Server sockets (from `accept()`) are never in conn_ip_map — only `connect()` populates it via `tp_exit_connect`
- Prevents H extraction from running against server-mode SSL* objects, which have different internal layout and produce garbage GHASH keys corrupting outbound TLS ("bad record MAC")

## Test plan
- [ ] Deploy kloak with a TLS server pod in the same namespace (e.g. tls-echo-server) — verify no "bad record MAC" errors on readiness probes
- [ ] Run cipher e2e tests — verify client-side secret rewriting still works for all AES-GCM suites
- [ ] Check controller logs for skipped server-mode connections (debug logging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)