### PR TITLE
feat: Go native crypto/tls XOR-patch support

### DIFF
--- a/examples/demo-go/main.go
+++ b/examples/demo-go/main.go
@@ -56,8 +56,6 @@ func main() {
 	fmt.Println("Waiting 10s for Kloak controller to sync...")
 	time.Sleep(10 * time.Second)
 
-	// Use default HTTP/2 — the eBPF scanner supports both HTTP/1.1 plaintext
-	// and HTTP/2 HPACK Huffman-encoded headers.
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 	}

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -81,9 +81,10 @@ struct {
 // Per-CPU array used as scratch space for reading and scanning data.
 struct scratch_buf {
   __u64 user_data_ptr;
-  __u64 ssl_ptr;        // SSL* pointer (0 for Go); used by XOR path tail call
+  __u64 ssl_ptr;        // SSL* or Go *tls.Conn pointer; used by XOR path tail call
   __u32 read_len;       // bytes read into data[] (max 256, for host parsing)
   __u32 total_data_len; // full TLS write length (for bpf_loop scanning)
+  __u8  chain_type;     // 0=OpenSSL/BoringSSL, CHAIN_GO_TLS=Go crypto/tls
   __u32 host_offset;
   __u32 host_value_len; // length of extracted host value
   __u32 xor_fd;         // socket fd resolved by resolve_host (for tc_pending key)
@@ -424,7 +425,8 @@ struct xor_pending_val {
   __u32 patch_count;        // number of valid patches (0..XOR_MAX_PATCHES)
   struct xor_patch patches[XOR_MAX_PATCHES];
   __u8  active;
-  __u8  _pad[3];
+  __u8  chain_type;         // 0=OpenSSL/BoringSSL, CHAIN_GO_TLS=Go crypto/tls
+  __u8  _pad[2];
   __u32 plaintext_len;      // SSL_write data length (for TLS version detection in tc)
 };
 
@@ -456,6 +458,32 @@ struct {
   __type(key, __u32);
   __type(value, struct tls_offsets);
 } tls_offset_config SEC(".maps");
+
+// Go crypto/tls struct offsets for H extraction.
+// Keyed by TGID (per-process), allowing different Go versions to coexist.
+//
+// H extraction chain (3 pointer dereferences):
+//   Conn + conn_to_cipher → cipher interface data_ptr (1st deref)
+//     → prefixNonceAEAD/xorNonceAEAD + aead_iface_off → aead interface data_ptr (2nd deref)
+//       → GCM + gcm_to_h → H (16 bytes, direct read)
+//
+// conn_to_cipher combines Conn.out offset + halfConn.cipher offset + 8 (interface data_ptr).
+// aead_iface_off is the offset to the inner aead interface data_ptr within the AEAD wrapper.
+#define CHAIN_GO_TLS 2
+
+struct go_tls_offsets {
+  __u32 conn_to_cipher;   // Conn* + off → halfConn.cipher interface data_ptr (combined offset)
+  __u32 aead_iface_off;   // wrapper + off → inner aead interface data_ptr
+  __u32 gcm_to_h;         // GCM* + off → H (16 bytes, direct read from productTable)
+  __u32 _pad;
+};
+
+struct {
+  __uint(type, BPF_MAP_TYPE_HASH);
+  __uint(max_entries, 256);
+  __type(key, __u32);
+  __type(value, struct go_tls_offsets);
+} go_tls_offset_config SEC(".maps");
 
 // Per-CPU scratch space for XOR-path programs (bpf_xor_path + tcp_sendmsg kprobe).
 // tc egress struct definitions (needed by ghash_work below and tc maps further down).
@@ -1364,6 +1392,7 @@ int bpf_xor_path(void *ctx) {
     wi->staged_pending.ssl_ptr = sd->ssl_ptr;
     wi->staged_pending.tgid = (__u32)(bpf_get_current_pid_tgid() >> 32);
     wi->staged_pending.active = 1;
+    wi->staged_pending.chain_type = sd->chain_type;
     wi->staged_pending.plaintext_len = sd->total_data_len;
   }
 
@@ -1711,8 +1740,86 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
   tdk.src_port = __bpf_htons(src_port_h);
   tdk.cgroup_id = bpf_get_current_cgroup_id();
 
-  // Copy from xor_pending to tc_pending. Re-lookup pending after helper calls.
+  // Save values from xor_pending before helper calls invalidate the pointer.
   __u32 zero = 0;
+
+  pending = bpf_map_lookup_elem(&xor_pending, &pid_tgid);
+  if (!pending) return 0;
+
+  __u64 ssl_ptr = pending->ssl_ptr;
+  __u32 tgid = (__u32)(pid_tgid >> 32);
+  __u32 plaintext_len = pending->plaintext_len;
+  __u8 chain = pending->chain_type;
+
+  // Extract H BEFORE creating tc_pending. If H extraction fails, we must NOT
+  // create tc_pending — otherwise tc_egress would XOR-patch the ciphertext
+  // without being able to recompute the GHASH tag, causing "bad record MAC".
+  struct tls_conn_state new_conn;
+  __builtin_memset(&new_conn, 0, sizeof(new_conn));
+  __u64 wrl_val = 0;
+
+  if (chain == CHAIN_GO_TLS) {
+    // Go crypto/tls: H lives in gcmAES.productTable[reverseBits(1)].
+    struct go_tls_offsets *go_off = bpf_map_lookup_elem(&go_tls_offset_config, &tgid);
+    if (!go_off)
+      return 0; // No Go offsets — bail (fail-secure, no corruption).
+
+    __u64 cipher_data = 0;
+    if (bpf_probe_read_user(&cipher_data, 8,
+        (void *)(ssl_ptr + go_off->conn_to_cipher)) < 0 || !cipher_data)
+      return 0;
+    __u64 gcm_ptr = 0;
+    if (bpf_probe_read_user(&gcm_ptr, 8,
+        (void *)(cipher_data + go_off->aead_iface_off)) < 0 || !gcm_ptr)
+      return 0;
+
+    if (bpf_probe_read_user(new_conn.ghash_h, 16,
+        (void *)(gcm_ptr + go_off->gcm_to_h)) < 0)
+      return 0;
+
+    __u64 *h64 = (__u64 *)new_conn.ghash_h;
+    if (h64[0] == 0 && h64[1] == 0)
+      return 0;
+    // Go stores gcmFieldElement{low, high uint64} where low/high are the
+    // big-endian interpretation stored as native uint64. On LE machines the
+    // raw bytes are swapped — bswap64 recovers the GHASH big-endian form.
+    h64[0] = __builtin_bswap64(h64[0]);
+    h64[1] = __builtin_bswap64(h64[1]);
+    new_conn.cipher_type = KLOAK_CIPHER_AES_GCM;
+  } else {
+    // OpenSSL/BoringSSL: 4-hop pointer chain from SSL* to H.
+    struct tls_offsets *offsets = bpf_map_lookup_elem(&tls_offset_config, &zero);
+    if (!offsets || offsets->ssl_to_wrl == 0)
+      return 0;
+
+    __u64 ptr = 0;
+    if (bpf_probe_read_user(&ptr, 8, (void *)(ssl_ptr + offsets->ssl_to_wrl)) < 0 || !ptr)
+      return 0;
+    wrl_val = ptr;
+    if (bpf_probe_read_user(&ptr, 8, (void *)(ptr + offsets->wrl_to_enc_ctx)) < 0 || !ptr)
+      return 0;
+    if (bpf_probe_read_user(&ptr, 8, (void *)(ptr + offsets->enc_ctx_to_algctx)) < 0 || !ptr)
+      return 0;
+    if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0)
+      return 0;
+
+    __u64 *h64 = (__u64 *)new_conn.ghash_h;
+    if (h64[0] == 0 && h64[1] == 0)
+      return 0;
+    h64[0] = __builtin_bswap64(h64[0]);
+    h64[1] = __builtin_bswap64(h64[1]);
+
+    new_conn.cipher_type = KLOAK_CIPHER_AES_GCM;
+    new_conn.wrl_ptr = wrl_val;
+  }
+
+  // H extraction succeeded — store connection state.
+  struct tls_conn_key ck = {};
+  ck.tgid = tgid;
+  ck.ssl_ptr = ssl_ptr;
+  bpf_map_update_elem(&tls_conn_state, &ck, &new_conn, BPF_ANY);
+
+  // Now safe to create tc_pending — tc_egress can always find H.
   struct ghash_work *w = bpf_map_lookup_elem(&ghash_scratch, &zero);
   if (!w) return 0;
 
@@ -1720,58 +1827,21 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
   if (!pending) return 0;
 
   __builtin_memset(&w->staged_tc, 0, sizeof(w->staged_tc));
-  w->staged_tc.tgid = (__u32)(pid_tgid >> 32);
-  w->staged_tc.ssl_ptr = pending->ssl_ptr;
+  w->staged_tc.tgid = tgid;
+  w->staged_tc.ssl_ptr = ssl_ptr;
   w->staged_tc.active = 1;
-  w->staged_tc.plaintext_len = pending->plaintext_len;
+  w->staged_tc.plaintext_len = plaintext_len;
   w->staged_tc.patch_count = pending->patch_count;
   if (w->staged_tc.patch_count > XOR_MAX_PATCHES)
     w->staged_tc.patch_count = XOR_MAX_PATCHES;
   for (__u32 p = 0; p < XOR_MAX_PATCHES && p < w->staged_tc.patch_count; p++)
     w->staged_tc.patches[p] = pending->patches[p];
 
-  __u64 ssl_ptr = pending->ssl_ptr;
-  __u32 tgid = w->staged_tc.tgid;
-
   bpf_map_update_elem(&tc_pending, &tdk, &w->staged_tc, BPF_ANY);
   bpf_printk("kloak [2-KPROBE] sport=%u cg=%x", src_port_h, (__u32)tdk.cgroup_id);
 
   // Delete xor_pending — the entry has been bridged to tc_pending.
   bpf_map_delete_elem(&xor_pending, &pid_tgid);
-
-  // Extract H from the SSL struct. At tcp_sendmsg time, the TLS handshake
-  // has completed and the encryption context (with H) is available.
-  struct tls_offsets *offsets = bpf_map_lookup_elem(&tls_offset_config, &zero);
-  if (!offsets || offsets->ssl_to_wrl == 0)
-    return 0;
-
-  __u64 ptr = 0;
-  if (bpf_probe_read_user(&ptr, 8, (void *)(ssl_ptr + offsets->ssl_to_wrl)) < 0 || !ptr)
-    return 0;
-  __u64 wrl_val = ptr;
-  if (bpf_probe_read_user(&ptr, 8, (void *)(ptr + offsets->wrl_to_enc_ctx)) < 0 || !ptr)
-    return 0;
-  if (bpf_probe_read_user(&ptr, 8, (void *)(ptr + offsets->enc_ctx_to_algctx)) < 0 || !ptr)
-    return 0;
-
-  struct tls_conn_state new_conn;
-  __builtin_memset(&new_conn, 0, sizeof(new_conn));
-  if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0)
-    return 0;
-
-  __u64 *h64 = (__u64 *)new_conn.ghash_h;
-  if (h64[0] == 0 && h64[1] == 0)
-    return 0;
-  h64[0] = __builtin_bswap64(h64[0]);
-  h64[1] = __builtin_bswap64(h64[1]);
-
-  new_conn.cipher_type = KLOAK_CIPHER_AES_GCM;
-  new_conn.wrl_ptr = wrl_val;
-
-  struct tls_conn_key ck = {};
-  ck.tgid = tgid;
-  ck.ssl_ptr = ssl_ptr;
-  bpf_map_update_elem(&tls_conn_state, &ck, &new_conn, BPF_ANY);
 
   return 0;
 }
@@ -1792,17 +1862,20 @@ int bpf_uprobe_go_tls_write(void *ctx) {
   // No cgroup filter — Go uprobes use PID-scoped attachment because
   // Go binaries are statically linked (unique per container).
 
+  void *conn_ptr; // *tls.Conn receiver — used as connection ID and for H extraction
   void *data_ptr;
   __u64 data_len;
 
 #if defined(bpf_target_x86)
   // x86_64 Go register ABI: RAX=receiver, RBX=data, RCX=len
-  // pt_regs offsets: rbx=40, rcx=88
+  // pt_regs offsets: rax=80, rbx=40, rcx=88
+  bpf_probe_read_kernel(&conn_ptr, sizeof(void *), (char *)ctx + 80);
   bpf_probe_read_kernel(&data_ptr, sizeof(void *), (char *)ctx + 40);
   bpf_probe_read_kernel(&data_len, sizeof(__u64), (char *)ctx + 88);
 #elif defined(bpf_target_arm64)
   // ARM64 Go register ABI: R0=receiver, R1=data, R2=len
-  // user_pt_regs offsets: regs[1]=8, regs[2]=16
+  // user_pt_regs offsets: regs[0]=0, regs[1]=8, regs[2]=16
+  bpf_probe_read_kernel(&conn_ptr, sizeof(void *), (char *)ctx + 0);
   bpf_probe_read_kernel(&data_ptr, sizeof(void *), (char *)ctx + 8);
   bpf_probe_read_kernel(&data_len, sizeof(__u64), (char *)ctx + 16);
 #else
@@ -1811,8 +1884,8 @@ int bpf_uprobe_go_tls_write(void *ctx) {
 
 #ifdef KLOAK_DEBUG
   __u32 pid = bpf_get_current_pid_tgid();
-  bpf_printk("kloak go_tls: ptr=%llx len=%llu pid=%d", (__u64)data_ptr,
-             data_len, pid);
+  bpf_printk("kloak go_tls: conn=%llx ptr=%llx len=%llu pid=%d",
+             (__u64)conn_ptr, (__u64)data_ptr, data_len, pid);
 #endif
 
   if (!data_ptr || data_len == 0)
@@ -1838,13 +1911,28 @@ int bpf_uprobe_go_tls_write(void *ctx) {
   scratch_data->read_len = read_len;
   scratch_data->total_data_len = (__u32)data_len;
 
-  // Go doesn't use OpenSSL, no ssl_ptr — pass 0.
-  // resolve_host will use last_verified_fd -> conn_ip_map -> dns_ip_map.
+  // resolve_host uses last_verified_fd -> conn_ip_map -> dns_ip_map for Go.
   resolve_host(scratch_data, 0);
 
-  // XOR-patch path not yet supported for Go (needs Go struct offset work).
-  // Secret is NOT rewritten (fail-secure).
-  // TODO: implement Go crypto/tls key extraction to enable XOR path.
+  // Pre-scan for kloak: prefix and tail-call to xor_path.
+  // Same flow as SSL_write — the downstream pipeline is generic.
+  dbg_inc(DBG_XOR_CONN_CHECK);
+  scratch_data->ssl_ptr = (__u64)conn_ptr; // reuse ssl_ptr field as connection ID
+  scratch_data->chain_type = CHAIN_GO_TLS;
+  scratch_data->xor_match_count = 0;
+  scratch_data->xor_current_match = 0;
+
+  {
+    struct prescan_ctx pctx = {
+      .user_data_ptr = scratch_data->user_data_ptr,
+      .total_len = scratch_data->total_data_len,
+    };
+    __u32 num_chunks = (pctx.total_len + CHUNK_STRIDE - 1) / CHUNK_STRIDE;
+    bpf_loop(num_chunks, prescan_chunk, &pctx, 0);
+  }
+
+  // H extraction is deferred to the tcp_sendmsg kprobe (same as OpenSSL).
+  bpf_tail_call(ctx, &prog_array, 1);
 
   return 0;
 }
@@ -1939,6 +2027,7 @@ int bpf_uprobe_ssl_write(void *ctx) {
   // h_extract and xor_path have the match position in scratch_buf.
   dbg_inc(DBG_XOR_CONN_CHECK);
   scratch_data->ssl_ptr = (__u64)ssl_ptr;
+  scratch_data->chain_type = 0; // OpenSSL/BoringSSL
   scratch_data->xor_match_count = 0;
   scratch_data->xor_current_match = 0;
 

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -111,9 +111,10 @@ struct {
 // Tail-call program array:
 //   index 1 = bpf_xor_path (AES-GCM ciphertext patching path)
 //   index 2 = bpf_h_extract (GHASH key H extraction on first SSL_write)
+//   index 3 = bpf_go_write_path (Go plaintext patching — writes real secrets directly)
 struct {
   __uint(type, BPF_MAP_TYPE_PROG_ARRAY);
-  __uint(max_entries, 3); // indices 1 and 2 used
+  __uint(max_entries, 4); // indices 1, 2, and 3 used
   __type(key, __u32);
   __type(value, __u32);
 } prog_array SEC(".maps");
@@ -462,10 +463,15 @@ struct {
 // Go crypto/tls struct offsets for H extraction.
 // Keyed by TGID (per-process), allowing different Go versions to coexist.
 //
-// H extraction chain (3 pointer dereferences):
+// H extraction chain (3 pointer dereferences + GF halving):
 //   Conn + conn_to_cipher → cipher interface data_ptr (1st deref)
 //     → prefixNonceAEAD/xorNonceAEAD + aead_iface_off → aead interface data_ptr (2nd deref)
-//       → GCM + gcm_to_h → H (16 bytes, direct read)
+//       → GCM + h2_hi_off / h2_lo_off → H×2 (two 64-bit words from productTable[224])
+//
+// Go's gcmAesInit assembly computes H = AES_K(0^128), byte-swaps, then doubles
+// in GF(2^128) before storing in productTable at offset 224. We read the two
+// 64-bit words (arch-dependent order: AMD64 PSHUFB vs ARM64 VREV64) and apply
+// GF(2^128) halving to recover the standard big-endian GHASH H key.
 //
 // conn_to_cipher combines Conn.out offset + halfConn.cipher offset + 8 (interface data_ptr).
 // aead_iface_off is the offset to the inner aead interface data_ptr within the AEAD wrapper.
@@ -474,8 +480,8 @@ struct {
 struct go_tls_offsets {
   __u32 conn_to_cipher;   // Conn* + off → halfConn.cipher interface data_ptr (combined offset)
   __u32 aead_iface_off;   // wrapper + off → inner aead interface data_ptr
-  __u32 gcm_to_h;         // GCM* + off → H (16 bytes, direct read from productTable)
-  __u32 _pad;
+  __u32 h2_hi_off;        // GCM* + off → high 64 bits of H×2 (byte-swapped, arch-dependent)
+  __u32 h2_lo_off;        // GCM* + off → low 64 bits of H×2 (byte-swapped, arch-dependent)
 };
 
 struct {
@@ -1759,7 +1765,9 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
   __u64 wrl_val = 0;
 
   if (chain == CHAIN_GO_TLS) {
-    // Go crypto/tls: H lives in gcmAES.productTable[reverseBits(1)].
+    // Go crypto/tls: H×2 stored at productTable offset 224 (entry 14).
+    // gcmAesInit computes H = AES_K(0^128), byte-swaps, doubles in GF(2^128).
+    // We read the two 64-bit words and apply GF halving to recover H.
     struct go_tls_offsets *go_off = bpf_map_lookup_elem(&go_tls_offset_config, &tgid);
     if (!go_off)
       return 0; // No Go offsets — bail (fail-secure, no corruption).
@@ -1773,18 +1781,49 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
         (void *)(cipher_data + go_off->aead_iface_off)) < 0 || !gcm_ptr)
       return 0;
 
-    if (bpf_probe_read_user(new_conn.ghash_h, 16,
-        (void *)(gcm_ptr + go_off->gcm_to_h)) < 0)
+    // Read H×2 as two separate 64-bit words (arch-aware offsets from userspace).
+    // h2_hi_off points to the GF "high" word (contains the GF MSB at bit 63).
+    // h2_lo_off points to the GF "low" word (contains the GF LSB at bit 0).
+    __u64 hi = 0, lo = 0;
+    if (bpf_probe_read_user(&hi, 8, (void *)(gcm_ptr + go_off->h2_hi_off)) < 0)
+      return 0;
+    if (bpf_probe_read_user(&lo, 8, (void *)(gcm_ptr + go_off->h2_lo_off)) < 0)
       return 0;
 
-    __u64 *h64 = (__u64 *)new_conn.ghash_h;
-    if (h64[0] == 0 && h64[1] == 0)
+    if (hi == 0 && lo == 0)
       return 0;
-    // Go stores gcmFieldElement{low, high uint64} where low/high are the
-    // big-endian interpretation stored as native uint64. On LE machines the
-    // raw bytes are swapped — bswap64 recovers the GHASH big-endian form.
-    h64[0] = __builtin_bswap64(h64[0]);
-    h64[1] = __builtin_bswap64(h64[1]);
+
+    // GF(2^128) halving: recover H from H×2.
+    //
+    // Go's gcmAesInit computes H×2 as a 128-bit GF(2^128) left shift with
+    // conditional reduction. The 128-bit value V = hi * 2^64 + lo, where:
+    //   - AMD64: hi = XMM[64:127], lo = XMM[0:63]
+    //   - ARM64: hi = D[0], lo = D[1]
+    //
+    // The doubling was: V' = (V << 1) ^ (V.MSB ? poly : 0)
+    //   poly = {hi: 0xC200000000000000, lo: 0x0000000000000001}
+    //
+    // Reduction indicator: lo.bit0. During left-shift, lo.bit0 becomes 0.
+    // If reduction happened, poly.lo.bit0 = 1 is XORed in, so lo.bit0 = 1.
+    // The carry from hi to lo doesn't affect lo.bit0 (it goes to lo.bit63).
+    int reduced = lo & 1;
+    if (reduced) {
+      hi ^= 0xC200000000000000ULL;
+      lo ^= 0x0000000000000001ULL;
+    }
+    // V is now (H << 1) without reduction. Undo the 128-bit left shift:
+    // Carry from hi.bit0 → lo.bit63 (the bit that crossed the word boundary).
+    __u64 carry = hi & 1;
+    hi >>= 1;
+    lo = (lo >> 1) | (carry << 63);
+    if (reduced)
+      hi |= (1ULL << 63); // Restore GF MSB that was shifted out.
+
+    // Convert from register representation (byte-reversed per 8-byte lane
+    // by PSHUFB/VREV64) to standard big-endian GHASH H.
+    *(__u64 *)&new_conn.ghash_h[0] = __builtin_bswap64(hi);
+    *(__u64 *)&new_conn.ghash_h[8] = __builtin_bswap64(lo);
+
     new_conn.cipher_type = KLOAK_CIPHER_AES_GCM;
   } else {
     // OpenSSL/BoringSSL: 4-hop pointer chain from SSL* to H.

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1852,11 +1852,16 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
     new_conn.wrl_ptr = wrl_val;
   }
 
-  // H extraction succeeded — store connection state.
+  // H extraction succeeded — store connection state (only if H changed).
   struct tls_conn_key ck = {};
   ck.tgid = tgid;
   ck.ssl_ptr = ssl_ptr;
-  bpf_map_update_elem(&tls_conn_state, &ck, &new_conn, BPF_ANY);
+  struct tls_conn_state *existing = bpf_map_lookup_elem(&tls_conn_state, &ck);
+  if (!existing ||
+      ((__u64 *)existing->ghash_h)[0] != ((__u64 *)new_conn.ghash_h)[0] ||
+      ((__u64 *)existing->ghash_h)[1] != ((__u64 *)new_conn.ghash_h)[1]) {
+    bpf_map_update_elem(&tls_conn_state, &ck, &new_conn, BPF_ANY);
+  }
 
   // Now safe to create tc_pending — tc_egress can always find H.
   struct ghash_work *w = bpf_map_lookup_elem(&ghash_scratch, &zero);
@@ -1877,7 +1882,9 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
     w->staged_tc.patches[p] = pending->patches[p];
 
   bpf_map_update_elem(&tc_pending, &tdk, &w->staged_tc, BPF_ANY);
+#ifdef KLOAK_DEBUG
   bpf_printk("kloak [2-KPROBE] sport=%u cg=%x", src_port_h, (__u32)tdk.cgroup_id);
+#endif
 
   // Delete xor_pending — the entry has been bridged to tc_pending.
   bpf_map_delete_elem(&xor_pending, &pid_tgid);

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -2262,10 +2262,14 @@ int tc_egress_patch(struct __sk_buff *skb) {
   // the pending entry. This avoids map lookups on non-TLS packets.
   struct tc_pending_val *pending = bpf_map_lookup_elem(&tc_pending, &key);
   if (!pending || !pending->active) {
+#ifdef KLOAK_DEBUG
     bpf_printk("kloak [3-TC] MISS sport=%u cg=%x", __bpf_ntohs(sport), (__u32)key.cgroup_id);
+#endif
     return 0 /* TC_ACT_OK */;
   }
+#ifdef KLOAK_DEBUG
   bpf_printk("kloak [3-TC] HIT sport=%u cg=%x", __bpf_ntohs(sport), (__u32)key.cgroup_id);
+#endif
 
   __u32 tls_total = 5 + record_len; // header + body
 
@@ -2352,11 +2356,15 @@ int tc_egress_patch(struct __sk_buff *skb) {
     dbg_inc(DBG_TC_PATCHED);
   }
 
+#ifdef KLOAK_DEBUG
   bpf_printk("kloak [4-PATCH] sport=%u pc=%u ct=%u", __bpf_ntohs(sport), pc, ct_len);
+#endif
 
   // Tail-call to tc GHASH program.
   bpf_tail_call(skb, &tc_prog_array, 0);
+#ifdef KLOAK_DEBUG
   bpf_printk("kloak [4-PATCH] TAILCALL_FAILED");
+#endif
   return 0 /* TC_ACT_OK */;
 }
 

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -5,6 +5,7 @@ import (
 	"debug/dwarf"
 	"debug/elf"
 	"fmt"
+	"runtime"
 	"strings"
 )
 
@@ -12,32 +13,70 @@ import (
 // Go's crypto/tls internal structures. The layout must match struct
 // go_tls_offsets in tls_uprobe.c exactly.
 //
-// H extraction chain (3 pointer dereferences):
+// H extraction chain (3 pointer dereferences + GF(2^128) halving):
 //
 //	Conn + ConnToCipher → cipher interface data_ptr → AEAD wrapper
 //	  + AEADIfaceOff → inner aead interface data_ptr → GCM struct
-//	    + GCMToH → H (16 bytes from productTable[reverseBits(1)])
+//	    + H2HiOff / H2LoOff → H×2 (two 64-bit words from productTable[224])
+//
+// Go's gcmAesInit assembly computes H = AES_K(0^128), byte-swaps, then
+// doubles in GF(2^128) before storing at productTable offset 224. The BPF
+// code reads the two words and applies GF halving to recover standard H.
+//
+// The word order at offset 224 is architecture-dependent:
+//   - AMD64 (PSHUFB full reversal): hi word at +8, lo word at +0
+//   - ARM64 (VREV64 per-lane reversal): hi word at +0, lo word at +8
 type GoTLSOffsets struct {
 	ConnToCipher uint32 // Conn.out offset + halfConn.cipher offset + 8 (interface data_ptr)
 	AEADIfaceOff uint32 // prefixNonceAEAD.aead offset + 8 (interface data_ptr)
-	GCMToH       uint32 // GCM.gcmPlatformData + productTable offset + 128 (H index)
-	_            uint32 // padding to match BPF struct
+	H2HiOff      uint32 // GCM + off → high 64 bits of H×2 (byte-swapped)
+	H2LoOff      uint32 // GCM + off → low 64 bits of H×2 (byte-swapped)
 }
 
-// goTLSOffsetTable maps Go major.minor versions to struct offsets.
+// goTLSOffsetTableBase stores architecture-independent offsets plus the
+// productTable base offset. The arch-dependent H2 word offsets are computed
+// at lookup time by goTLSOffsetsForArch.
+type goTLSOffsetEntry struct {
+	ConnToCipher uint32
+	AEADIfaceOff uint32
+	PDBase       uint32 // GCM + gcmPlatformData + productTable + 224 (H×2 entry)
+}
+
+// goTLSOffsetTableBase maps Go major.minor versions to base struct offsets.
 // Discovered by running tools/go-tls-offsets against binaries built
 // with each Go version.
 //
 // TODO: Populate with offsets for Go 1.21, 1.22, 1.23 via the offset tool.
-var goTLSOffsetTable = map[string]GoTLSOffsets{
+var goTLSOffsetTableBase = map[string]goTLSOffsetEntry{
 	// Go 1.25/1.26 (FIPS module, gcmPlatformData):
 	//   Conn.out=520, halfConn.cipher=32, prefixNonceAEAD.aead=16
-	//   GCM.gcmPlatformData=504, gcmPlatformData.productTable=0, H at [8]=128
+	//   GCM.gcmPlatformData=504, gcmPlatformData.productTable=0
+	//   H×2 at productTable offset 224 → PDBase = 504 + 0 + 224 = 728
 	//   ConnToCipher = 520 + 32 + 8 = 560
 	//   AEADIfaceOff = 16 + 8 = 24
-	//   GCMToH = 504 + 0 + 128 = 632
-	"1.25": {ConnToCipher: 560, AEADIfaceOff: 24, GCMToH: 632},
-	"1.26": {ConnToCipher: 560, AEADIfaceOff: 24, GCMToH: 632},
+	"1.25": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728},
+	"1.26": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728},
+}
+
+// goTLSOffsetsForArch converts a base entry to arch-specific GoTLSOffsets
+// by applying the correct word order for the H×2 entry.
+//
+// AMD64 PSHUFB (full 16-byte reversal): hi word at +8, lo word at +0
+// ARM64 VREV64 (per-lane 8-byte reversal): hi word at +0, lo word at +8
+func goTLSOffsetsForArch(entry goTLSOffsetEntry, goarch string) GoTLSOffsets {
+	o := GoTLSOffsets{
+		ConnToCipher: entry.ConnToCipher,
+		AEADIfaceOff: entry.AEADIfaceOff,
+	}
+	switch goarch {
+	case "amd64":
+		o.H2HiOff = entry.PDBase + 8
+		o.H2LoOff = entry.PDBase + 0
+	default: // arm64 and others with per-lane byte reversal
+		o.H2HiOff = entry.PDBase + 0
+		o.H2LoOff = entry.PDBase + 8
+	}
+	return o
 }
 
 // DetectGoTLSOffsets reads a Go binary and returns the struct offsets needed
@@ -60,12 +99,35 @@ func detectGoTLSByVersion(exePath string) (string, GoTLSOffsets, error) {
 	}
 
 	majorMinor := extractGoMajorMinor(bi.GoVersion)
-	offsets, ok := goTLSOffsetTable[majorMinor]
+	entry, ok := goTLSOffsetTableBase[majorMinor]
 	if !ok {
 		return bi.GoVersion, GoTLSOffsets{}, fmt.Errorf("unsupported Go version %s (major.minor=%s)", bi.GoVersion, majorMinor)
 	}
 
-	return bi.GoVersion, offsets, nil
+	// Determine target architecture from the ELF binary, not the host.
+	goarch, err := elfGoArch(exePath)
+	if err != nil {
+		goarch = runtime.GOARCH // fallback to host arch
+	}
+
+	return bi.GoVersion, goTLSOffsetsForArch(entry, goarch), nil
+}
+
+// elfGoArch returns the GOARCH string for an ELF binary.
+func elfGoArch(path string) (string, error) {
+	f, err := elf.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	switch f.Machine {
+	case elf.EM_X86_64:
+		return "amd64", nil
+	case elf.EM_AARCH64:
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unknown ELF machine %v", f.Machine)
+	}
 }
 
 func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
@@ -149,27 +211,45 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 		missing = append(missing, "prefixNonceAEAD.aead")
 	}
 
-	// 3. GCMToH = path to productTable + 128 (H at index reverseBits(1)=8)
-	gcmH, foundH := uint32(0), false
+	// 3. H×2 word offsets from productTable offset 224.
+	// gcmAesInit stores H×2 (H doubled in GF(2^128)) at productTable[224].
+	// The two 64-bit words are in different order on AMD64 vs ARM64.
+	pdBase, foundPD := uint32(0), false
 
 	// Go 1.24+: GCM.gcmPlatformData → gcmPlatformData.productTable
 	gcmPD, okPD := getField(structFields, "crypto/internal/fips140/aes/gcm.GCM", "gcmPlatformData")
 	pdPT, okPT := getField(structFields, "crypto/internal/fips140/aes/gcm.gcmPlatformData", "productTable")
 	if okPD && okPT {
-		gcmH = gcmPD + pdPT + 128
-		foundH = true
+		pdBase = gcmPD + pdPT + 224 // H×2 at entry 14 (offset 224 within productTable)
+		foundPD = true
 	}
 
 	// Go <1.24: crypto/cipher.gcmAES.productTable
-	if !foundH {
+	if !foundPD {
 		if pt, ok := getField(structFields, "crypto/cipher.gcmAES", "productTable"); ok {
-			gcmH = pt + 128
-			foundH = true
+			pdBase = pt + 224
+			foundPD = true
 		}
 	}
 
-	if foundH {
-		result.GCMToH = gcmH
+	if foundPD {
+		// Determine target architecture from the ELF binary.
+		goarch := ""
+		switch f.Machine {
+		case elf.EM_X86_64:
+			goarch = "amd64"
+		case elf.EM_AARCH64:
+			goarch = "arm64"
+		}
+		if goarch == "amd64" {
+			// PSHUFB full 16-byte reversal: hi word at +8, lo word at +0
+			result.H2HiOff = pdBase + 8
+			result.H2LoOff = pdBase + 0
+		} else {
+			// ARM64 VREV64 per-lane reversal: hi word at +0, lo word at +8
+			result.H2HiOff = pdBase + 0
+			result.H2LoOff = pdBase + 8
+		}
 	} else {
 		missing = append(missing, "gcmAES.productTable")
 	}

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -1,0 +1,219 @@
+package ebpf
+
+import (
+	"debug/buildinfo"
+	"debug/dwarf"
+	"debug/elf"
+	"fmt"
+	"strings"
+)
+
+// GoTLSOffsets contains struct offsets for extracting the GHASH H key from
+// Go's crypto/tls internal structures. The layout must match struct
+// go_tls_offsets in tls_uprobe.c exactly.
+//
+// H extraction chain (3 pointer dereferences):
+//
+//	Conn + ConnToCipher → cipher interface data_ptr → AEAD wrapper
+//	  + AEADIfaceOff → inner aead interface data_ptr → GCM struct
+//	    + GCMToH → H (16 bytes from productTable[reverseBits(1)])
+type GoTLSOffsets struct {
+	ConnToCipher uint32 // Conn.out offset + halfConn.cipher offset + 8 (interface data_ptr)
+	AEADIfaceOff uint32 // prefixNonceAEAD.aead offset + 8 (interface data_ptr)
+	GCMToH       uint32 // GCM.gcmPlatformData + productTable offset + 128 (H index)
+	_            uint32 // padding to match BPF struct
+}
+
+// goTLSOffsetTable maps Go major.minor versions to struct offsets.
+// Discovered by running tools/go-tls-offsets against binaries built
+// with each Go version.
+//
+// TODO: Populate with offsets for Go 1.21, 1.22, 1.23 via the offset tool.
+var goTLSOffsetTable = map[string]GoTLSOffsets{
+	// Go 1.25/1.26 (FIPS module, gcmPlatformData):
+	//   Conn.out=520, halfConn.cipher=32, prefixNonceAEAD.aead=16
+	//   GCM.gcmPlatformData=504, gcmPlatformData.productTable=0, H at [8]=128
+	//   ConnToCipher = 520 + 32 + 8 = 560
+	//   AEADIfaceOff = 16 + 8 = 24
+	//   GCMToH = 504 + 0 + 128 = 632
+	"1.25": {ConnToCipher: 560, AEADIfaceOff: 24, GCMToH: 632},
+	"1.26": {ConnToCipher: 560, AEADIfaceOff: 24, GCMToH: 632},
+}
+
+// DetectGoTLSOffsets reads a Go binary and returns the struct offsets needed
+// for H extraction. Tries DWARF first, then falls back to version-based lookup.
+func DetectGoTLSOffsets(exePath string) (version string, offsets GoTLSOffsets, err error) {
+	// Try DWARF-based detection first.
+	version, offsets, err = detectGoTLSFromDWARF(exePath)
+	if err == nil {
+		return version, offsets, nil
+	}
+
+	// Fall back to buildinfo version lookup.
+	return detectGoTLSByVersion(exePath)
+}
+
+func detectGoTLSByVersion(exePath string) (string, GoTLSOffsets, error) {
+	bi, err := buildinfo.ReadFile(exePath)
+	if err != nil {
+		return "", GoTLSOffsets{}, fmt.Errorf("reading buildinfo from %s: %w", exePath, err)
+	}
+
+	majorMinor := extractGoMajorMinor(bi.GoVersion)
+	offsets, ok := goTLSOffsetTable[majorMinor]
+	if !ok {
+		return bi.GoVersion, GoTLSOffsets{}, fmt.Errorf("unsupported Go version %s (major.minor=%s)", bi.GoVersion, majorMinor)
+	}
+
+	return bi.GoVersion, offsets, nil
+}
+
+func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
+	f, err := elf.Open(exePath)
+	if err != nil {
+		return "", GoTLSOffsets{}, fmt.Errorf("opening ELF %s: %w", exePath, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	dw, err := f.DWARF()
+	if err != nil {
+		return "", GoTLSOffsets{}, fmt.Errorf("reading DWARF from %s: %w", exePath, err)
+	}
+
+	// Get Go version from buildinfo.
+	var goVersion string
+	bi, err := buildinfo.ReadFile(exePath)
+	if err == nil {
+		goVersion = bi.GoVersion
+	}
+
+	// Walk DWARF to find our target structs.
+	structFields := map[string]map[string]uint32{}
+	reader := dw.Reader()
+	for {
+		entry, err := reader.Next()
+		if err != nil || entry == nil {
+			break
+		}
+		if entry.Tag != dwarf.TagStructType {
+			continue
+		}
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if !isGoTLSTargetStruct(name) {
+			reader.SkipChildren()
+			continue
+		}
+
+		fields := map[string]uint32{}
+		for {
+			child, err := reader.Next()
+			if err != nil || child == nil || child.Tag == 0 {
+				break
+			}
+			if child.Tag != dwarf.TagMember {
+				continue
+			}
+			fieldName, _ := child.Val(dwarf.AttrName).(string)
+			if loc, ok := child.Val(dwarf.AttrDataMemberLoc).(int64); ok {
+				fields[fieldName] = uint32(loc)
+			}
+		}
+		structFields[name] = fields
+	}
+
+	// Extract the 3 combined offsets.
+	var result GoTLSOffsets
+	var missing []string
+
+	// 1. ConnToCipher = Conn.out + halfConn.cipher + 8 (interface data_ptr)
+	connOut, ok1 := getField(structFields, "crypto/tls.Conn", "out")
+	cipherOff, ok2 := getField(structFields, "crypto/tls.halfConn", "cipher")
+	if ok1 && ok2 {
+		result.ConnToCipher = connOut + cipherOff + 8
+	} else {
+		missing = append(missing, "Conn.out or halfConn.cipher")
+	}
+
+	// 2. AEADIfaceOff = prefixNonceAEAD.aead (or xorNonceAEAD.aead) + 8
+	aeadOff, found := uint32(0), false
+	for _, sn := range []string{"crypto/tls.prefixNonceAEAD", "crypto/tls.xorNonceAEAD"} {
+		if off, ok := getField(structFields, sn, "aead"); ok {
+			aeadOff = off
+			found = true
+			break
+		}
+	}
+	if found {
+		result.AEADIfaceOff = aeadOff + 8
+	} else {
+		missing = append(missing, "prefixNonceAEAD.aead")
+	}
+
+	// 3. GCMToH = path to productTable + 128 (H at index reverseBits(1)=8)
+	gcmH, foundH := uint32(0), false
+
+	// Go 1.24+: GCM.gcmPlatformData → gcmPlatformData.productTable
+	gcmPD, okPD := getField(structFields, "crypto/internal/fips140/aes/gcm.GCM", "gcmPlatformData")
+	pdPT, okPT := getField(structFields, "crypto/internal/fips140/aes/gcm.gcmPlatformData", "productTable")
+	if okPD && okPT {
+		gcmH = gcmPD + pdPT + 128
+		foundH = true
+	}
+
+	// Go <1.24: crypto/cipher.gcmAES.productTable
+	if !foundH {
+		if pt, ok := getField(structFields, "crypto/cipher.gcmAES", "productTable"); ok {
+			gcmH = pt + 128
+			foundH = true
+		}
+	}
+
+	if foundH {
+		result.GCMToH = gcmH
+	} else {
+		missing = append(missing, "gcmAES.productTable")
+	}
+
+	if len(missing) > 0 {
+		return goVersion, result, fmt.Errorf("missing DWARF offsets: %s", strings.Join(missing, ", "))
+	}
+
+	return goVersion, result, nil
+}
+
+func getField(structFields map[string]map[string]uint32, structName, fieldName string) (uint32, bool) {
+	fields, ok := structFields[structName]
+	if !ok {
+		return 0, false
+	}
+	off, ok := fields[fieldName]
+	return off, ok
+}
+
+func isGoTLSTargetStruct(name string) bool {
+	targets := []string{
+		"crypto/tls.Conn",
+		"crypto/tls.halfConn",
+		"crypto/tls.prefixNonceAEAD",
+		"crypto/tls.xorNonceAEAD",
+		"crypto/cipher.gcmAES",
+		"crypto/internal/fips140/aes/gcm.GCM",
+		"crypto/internal/fips140/aes/gcm.gcmPlatformData",
+	}
+	for _, t := range targets {
+		if name == t {
+			return true
+		}
+	}
+	return false
+}
+
+// extractGoMajorMinor returns "1.25" from "go1.25.1" or "go1.25".
+func extractGoMajorMinor(version string) string {
+	v := strings.TrimPrefix(version, "go")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) >= 2 {
+		return parts[0] + "." + parts[1]
+	}
+	return v
+}

--- a/pkg/ebpf/go_tls_offsets_test.go
+++ b/pkg/ebpf/go_tls_offsets_test.go
@@ -1,0 +1,36 @@
+package ebpf
+
+import "testing"
+
+func TestExtractGoMajorMinor(t *testing.T) {
+	tests := []struct {
+		input, want string
+	}{
+		{"go1.25.1", "1.25"},
+		{"go1.22", "1.22"},
+		{"go1.21.0", "1.21"},
+		{"go1.26.1", "1.26"},
+		{"1.25", "1.25"},
+	}
+	for _, tt := range tests {
+		got := extractGoMajorMinor(tt.input)
+		if got != tt.want {
+			t.Errorf("extractGoMajorMinor(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestGoTLSOffsetTableEntries(t *testing.T) {
+	// Verify all entries have non-zero H offset.
+	for version, offsets := range goTLSOffsetTable {
+		if offsets.ConnToCipher == 0 {
+			t.Errorf("goTLSOffsetTable[%q].ConnToCipher is 0", version)
+		}
+		if offsets.AEADIfaceOff == 0 {
+			t.Errorf("goTLSOffsetTable[%q].AEADIfaceOff is 0", version)
+		}
+		if offsets.GCMToH == 0 {
+			t.Errorf("goTLSOffsetTable[%q].GCMToH is 0", version)
+		}
+	}
+}

--- a/pkg/ebpf/go_tls_offsets_test.go
+++ b/pkg/ebpf/go_tls_offsets_test.go
@@ -21,16 +21,49 @@ func TestExtractGoMajorMinor(t *testing.T) {
 }
 
 func TestGoTLSOffsetTableEntries(t *testing.T) {
-	// Verify all entries have non-zero H offset.
-	for version, offsets := range goTLSOffsetTable {
-		if offsets.ConnToCipher == 0 {
-			t.Errorf("goTLSOffsetTable[%q].ConnToCipher is 0", version)
+	// Verify all entries have non-zero offsets when resolved for amd64.
+	for version, entry := range goTLSOffsetTableBase {
+		if entry.ConnToCipher == 0 {
+			t.Errorf("goTLSOffsetTableBase[%q].ConnToCipher is 0", version)
 		}
-		if offsets.AEADIfaceOff == 0 {
-			t.Errorf("goTLSOffsetTable[%q].AEADIfaceOff is 0", version)
+		if entry.AEADIfaceOff == 0 {
+			t.Errorf("goTLSOffsetTableBase[%q].AEADIfaceOff is 0", version)
 		}
-		if offsets.GCMToH == 0 {
-			t.Errorf("goTLSOffsetTable[%q].GCMToH is 0", version)
+		if entry.PDBase == 0 {
+			t.Errorf("goTLSOffsetTableBase[%q].PDBase is 0", version)
 		}
+
+		// Verify arch-specific resolution produces non-zero H2 offsets.
+		for _, arch := range []string{"amd64", "arm64"} {
+			offsets := goTLSOffsetsForArch(entry, arch)
+			if offsets.H2HiOff == 0 {
+				t.Errorf("goTLSOffsetsForArch(%q, %q).H2HiOff is 0", version, arch)
+			}
+			if offsets.H2LoOff == 0 {
+				t.Errorf("goTLSOffsetsForArch(%q, %q).H2LoOff is 0", version, arch)
+			}
+			// Hi and Lo should differ by exactly 8 bytes.
+			diff := int(offsets.H2HiOff) - int(offsets.H2LoOff)
+			if diff != 8 && diff != -8 {
+				t.Errorf("goTLSOffsetsForArch(%q, %q): H2HiOff=%d H2LoOff=%d, expected 8-byte difference",
+					version, arch, offsets.H2HiOff, offsets.H2LoOff)
+			}
+		}
+	}
+}
+
+func TestGoTLSOffsetsForArch(t *testing.T) {
+	entry := goTLSOffsetEntry{ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728}
+
+	amd64 := goTLSOffsetsForArch(entry, "amd64")
+	// AMD64 PSHUFB: hi at +8, lo at +0
+	if amd64.H2HiOff != 736 || amd64.H2LoOff != 728 {
+		t.Errorf("amd64: H2HiOff=%d (want 736), H2LoOff=%d (want 728)", amd64.H2HiOff, amd64.H2LoOff)
+	}
+
+	arm64 := goTLSOffsetsForArch(entry, "arm64")
+	// ARM64 VREV64: hi at +0, lo at +8
+	if arm64.H2HiOff != 728 || arm64.H2LoOff != 736 {
+		t.Errorf("arm64: H2HiOff=%d (want 728), H2LoOff=%d (want 736)", arm64.H2HiOff, arm64.H2LoOff)
 	}
 }

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -625,7 +625,8 @@ func (m *TLSUprobeManager) pushGoTLSOffsets(pid int) {
 		"pid", pid, "goVersion", version,
 		"connToCipher", offsets.ConnToCipher,
 		"aeadIfaceOff", offsets.AEADIfaceOff,
-		"gcmToH", offsets.GCMToH)
+		"h2HiOff", offsets.H2HiOff,
+		"h2LoOff", offsets.H2LoOff)
 
 	// Get TGID for the per-process BPF map key.
 	tgid := uint32(pid) // PID == TGID for the main thread

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -504,6 +504,13 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 	if up, err := ex.Uprobe(goWriteSym, m.objs.BpfUprobeGoTlsWrite, &link.UprobeOptions{PID: pid}); err == nil {
 		m.log.Info("Attached Go uprobe", "pid", pid, "symbol", goWriteSym)
 		m.links = append(m.links, up)
+
+		// Push Go-specific struct offsets for H extraction and attach tc egress
+		// for ciphertext patching. Both are required for the XOR-patch path.
+		m.pushGoTLSOffsets(pid)
+		if err := m.attachTCEgress(pid); err != nil {
+			m.log.Error(err, "Failed to attach tc egress for Go TLS — secrets will not be rewritten", "pid", pid)
+		}
 		return nil
 	}
 
@@ -591,6 +598,44 @@ func (m *TLSUprobeManager) pushTLSOffsets(pid int, containerLibs []string) {
 			"offsets", fmt.Sprintf("%+v", offsets))
 		return // Only need one successful push.
 	}
+}
+
+// pushGoTLSOffsets detects Go struct offsets from the binary's DWARF or
+// buildinfo and pushes them to the go_tls_offset_config BPF map (per-TGID).
+func (m *TLSUprobeManager) pushGoTLSOffsets(pid int) {
+	exePath := fmt.Sprintf("/proc/%d/exe", pid)
+
+	// Try DWARF-based detection first.
+	version, offsets, err := DetectGoTLSOffsets(exePath)
+	if err != nil {
+		m.log.Info("Go TLS offset detection failed — trying version fallback",
+			"pid", pid, "dwarfError", err)
+		// Try reading just the Go version for the hardcoded table.
+		version2, offsets2, err2 := detectGoTLSByVersion(exePath)
+		if err2 != nil {
+			m.log.Error(err2, "Go TLS offset detection failed completely — Go secrets will NOT be rewritten",
+				"pid", pid, "dwarfError", err, "versionError", err2)
+			return
+		}
+		version = version2
+		offsets = offsets2
+	}
+
+	m.log.Info("Detected Go TLS offsets",
+		"pid", pid, "goVersion", version,
+		"connToCipher", offsets.ConnToCipher,
+		"aeadIfaceOff", offsets.AEADIfaceOff,
+		"gcmToH", offsets.GCMToH)
+
+	// Get TGID for the per-process BPF map key.
+	tgid := uint32(pid) // PID == TGID for the main thread
+	if err := m.objs.GoTlsOffsetConfig.Update(tgid, &offsets, 0); err != nil {
+		m.log.Error(err, "Failed to push Go TLS offsets to BPF map", "pid", pid)
+		return
+	}
+
+	m.log.Info("Pushed Go TLS offsets for XOR-patch path",
+		"pid", pid, "goVersion", version)
 }
 
 // findContainerTLSLibraries scans common library directories in the container's

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -409,8 +409,11 @@ func (m *TLSUprobeManager) TrackTGID(tgid uint32) error {
 	return m.objs.TrackedTgids.Update(tgid, &val, 0)
 }
 
-// UntrackTGID removes a process TGID from the tracked_tgids map.
+// UntrackTGID removes a process TGID from the tracked_tgids map
+// and cleans up any per-TGID Go TLS offset config.
 func (m *TLSUprobeManager) UntrackTGID(tgid uint32) error {
+	// Clean up Go TLS offsets (best-effort, ignore not-found).
+	_ = m.objs.GoTlsOffsetConfig.Delete(tgid)
 	return m.objs.TrackedTgids.Delete(tgid)
 }
 
@@ -605,20 +608,11 @@ func (m *TLSUprobeManager) pushTLSOffsets(pid int, containerLibs []string) {
 func (m *TLSUprobeManager) pushGoTLSOffsets(pid int) {
 	exePath := fmt.Sprintf("/proc/%d/exe", pid)
 
-	// Try DWARF-based detection first.
+	// DetectGoTLSOffsets tries DWARF first, then falls back to version-based lookup.
 	version, offsets, err := DetectGoTLSOffsets(exePath)
 	if err != nil {
-		m.log.Info("Go TLS offset detection failed — trying version fallback",
-			"pid", pid, "dwarfError", err)
-		// Try reading just the Go version for the hardcoded table.
-		version2, offsets2, err2 := detectGoTLSByVersion(exePath)
-		if err2 != nil {
-			m.log.Error(err2, "Go TLS offset detection failed completely — Go secrets will NOT be rewritten",
-				"pid", pid, "dwarfError", err, "versionError", err2)
-			return
-		}
-		version = version2
-		offsets = offsets2
+		m.log.Error(err, "Go TLS offset detection failed — Go secrets will NOT be rewritten", "pid", pid)
+		return
 	}
 
 	m.log.Info("Detected Go TLS offsets",

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -89,7 +89,6 @@ var ebpfTests = []ebpfRewriteTest{
 		demoDir:        "demo-go",
 		deploymentName: "demo-go",
 		appLabel:       "app=demo-go",
-		skip:           "Go crypto/tls H extraction not yet implemented",
 	},
 	{
 		name:           "go-boringssl",

--- a/tools/go-tls-offsets/main.go
+++ b/tools/go-tls-offsets/main.go
@@ -3,7 +3,13 @@
 //
 // It reads DWARF debug info from a Go binary and prints the offset chain:
 //
-//	tls.Conn → halfConn.cipher (interface) → concrete AEAD → gcmAES.productTable → H
+//	tls.Conn → halfConn.cipher (interface) → AEAD wrapper → GCM.productTable → H×2
+//
+// The output matches the go_tls_offsets struct in tls_uprobe.c:
+//   - conn_to_cipher: combined offset to cipher interface data_ptr
+//   - aead_iface_off: offset to inner aead interface data_ptr
+//   - h2_hi_off: GCM offset to high 64-bit word of H×2
+//   - h2_lo_off: GCM offset to low 64-bit word of H×2
 //
 // Usage:
 //
@@ -21,14 +27,24 @@ import (
 	"strings"
 )
 
+// OffsetResult matches the go_tls_offsets BPF struct layout.
 type OffsetResult struct {
-	GoVersion        string `json:"go_version"`
-	Arch             string `json:"arch"`
-	ConnToHalfConn   uint32 `json:"conn_to_half_conn"`
-	HalfConnToCipher uint32 `json:"half_conn_to_cipher"`
-	CipherDataToGCM  uint32 `json:"cipher_data_to_gcm"`
-	GCMToH           uint32 `json:"gcm_to_h"`
-	Notes            string `json:"notes,omitempty"`
+	GoVersion    string `json:"go_version"`
+	Arch         string `json:"arch"`
+	ConnToCipher uint32 `json:"conn_to_cipher"`  // Conn.out + halfConn.cipher + 8
+	AEADIfaceOff uint32 `json:"aead_iface_off"`  // prefixNonceAEAD.aead + 8
+	H2HiOff      uint32 `json:"h2_hi_off"`       // GCM + off → high 64 bits of H×2
+	H2LoOff      uint32 `json:"h2_lo_off"`       // GCM + off → low 64 bits of H×2
+	Notes        string `json:"notes,omitempty"`
+
+	// Raw offsets for debugging (not used by BPF).
+	Raw struct {
+		ConnOut      uint32 `json:"conn_out"`
+		CipherOff    uint32 `json:"cipher_off"`
+		AEADOff      uint32 `json:"aead_off"`
+		ProductTable uint32 `json:"product_table"`
+		PDBase       uint32 `json:"pd_base"` // productTable + 224 (H×2 entry)
+	} `json:"raw"`
 }
 
 func main() {
@@ -39,7 +55,6 @@ func main() {
 
 	fmt.Fprintf(os.Stderr, "Analyzing: %s\n", path)
 
-	// Read Go build info for version.
 	bi, err := buildinfo.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not read buildinfo: %v\n", err)
@@ -60,6 +75,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Binary may be stripped (-ldflags='-s -w'). DWARF is required.\n")
 		os.Exit(1)
 	}
+
 	result := OffsetResult{}
 	if bi != nil {
 		result.GoVersion = bi.GoVersion
@@ -73,19 +89,17 @@ func main() {
 		result.Arch = fmt.Sprintf("unknown(%d)", f.Machine)
 	}
 
-	// Walk DWARF entries to find our target structs.
-	structs := map[string]map[string]uint32{} // structName -> fieldName -> offset
+	// Walk DWARF entries to find target structs.
+	structs := map[string]map[string]uint32{}
 	reader := dw.Reader()
 	for {
 		entry, err := reader.Next()
 		if err != nil || entry == nil {
 			break
 		}
-
 		if entry.Tag != dwarf.TagStructType {
 			continue
 		}
-
 		name, _ := entry.Val(dwarf.AttrName).(string)
 		if !isTargetStruct(name) {
 			reader.SkipChildren()
@@ -94,7 +108,6 @@ func main() {
 
 		fmt.Fprintf(os.Stderr, "\nFound struct: %s\n", name)
 		fields := map[string]uint32{}
-
 		for {
 			child, err := reader.Next()
 			if err != nil || child == nil || child.Tag == 0 {
@@ -104,7 +117,6 @@ func main() {
 				continue
 			}
 			fieldName, _ := child.Val(dwarf.AttrName).(string)
-			// Try DW_AT_data_member_location
 			var offset uint32
 			if loc, ok := child.Val(dwarf.AttrDataMemberLoc).(int64); ok {
 				offset = uint32(loc)
@@ -112,76 +124,77 @@ func main() {
 			fields[fieldName] = offset
 			fmt.Fprintf(os.Stderr, "  .%s = %d\n", fieldName, offset)
 		}
-
 		structs[name] = fields
 	}
 
-	// Extract the offsets we need.
-	// 1. tls.Conn → out (halfConn, embedded struct)
-	if fields, ok := structs["crypto/tls.Conn"]; ok {
-		if off, ok := fields["out"]; ok {
-			result.ConnToHalfConn = off
-			fmt.Fprintf(os.Stderr, "\nConn.out offset: %d\n", off)
-		}
+	// Compute combined offsets matching BPF struct layout.
+	var missing []string
+
+	// 1. ConnToCipher = Conn.out + halfConn.cipher + 8 (interface data_ptr)
+	connOut, ok1 := getField(structs, "crypto/tls.Conn", "out")
+	cipherOff, ok2 := getField(structs, "crypto/tls.halfConn", "cipher")
+	if ok1 && ok2 {
+		result.Raw.ConnOut = connOut
+		result.Raw.CipherOff = cipherOff
+		result.ConnToCipher = connOut + cipherOff + 8
+		fmt.Fprintf(os.Stderr, "\nConnToCipher = %d + %d + 8 = %d\n", connOut, cipherOff, result.ConnToCipher)
+	} else {
+		missing = append(missing, "Conn.out or halfConn.cipher")
 	}
 
-	// 2. halfConn → cipher (interface)
-	if fields, ok := structs["crypto/tls.halfConn"]; ok {
-		if off, ok := fields["cipher"]; ok {
-			result.HalfConnToCipher = off
-			fmt.Fprintf(os.Stderr, "halfConn.cipher offset: %d\n", off)
+	// 2. AEADIfaceOff = prefixNonceAEAD.aead (or xorNonceAEAD.aead) + 8
+	for _, sn := range []string{"crypto/tls.prefixNonceAEAD", "crypto/tls.xorNonceAEAD"} {
+		if off, ok := getField(structs, sn, "aead"); ok {
+			result.Raw.AEADOff = off
+			result.AEADIfaceOff = off + 8
+			fmt.Fprintf(os.Stderr, "AEADIfaceOff = %d + 8 = %d (from %s)\n", off, result.AEADIfaceOff, sn)
+			break
 		}
 	}
-
-	// 3. prefixNonceAEAD → aead (the inner AEAD, typically gcmAES pointer)
-	// TLS 1.2 uses prefixNonceAEAD wrapping the actual GCM cipher.
-	// TLS 1.3 uses xorNonceAEAD wrapping it.
-	// Both have an 'aead' field that is a cipher.AEAD interface.
-	for _, structName := range []string{
-		"crypto/tls.prefixNonceAEAD",
-		"crypto/tls.xorNonceAEAD",
-	} {
-		if fields, ok := structs[structName]; ok {
-			if off, ok := fields["aead"]; ok {
-				result.CipherDataToGCM = off
-				fmt.Fprintf(os.Stderr, "%s.aead offset: %d\n", structName, off)
-				break
-			}
-		}
-	}
-
-	// 4. gcmAES → productTable (the precomputed H powers)
-	// productTable is [16][16]byte. H is at index reverseBits(1) = 8, so byte offset 128.
-	for _, structName := range []string{
-		"crypto/cipher.gcmAES",
-		"crypto/internal/fips140/aes/gcm.GCMForSSH",
-		"crypto/internal/fips140/aes/gcm.GCM",
-	} {
-		if fields, ok := structs[structName]; ok {
-			if off, ok := fields["productTable"]; ok {
-				// H is at productTable[reverseBits(1)] = productTable[8] = offset + 8*16 = offset + 128
-				result.GCMToH = off + 128
-				fmt.Fprintf(os.Stderr, "%s.productTable offset: %d (H at +128 = %d)\n",
-					structName, off, off+128)
-				break
-			}
-		}
-	}
-
-	// Check if we got all offsets.
-	missing := []string{}
-	if result.ConnToHalfConn == 0 {
-		missing = append(missing, "Conn.out")
-	}
-	if result.HalfConnToCipher == 0 {
-		missing = append(missing, "halfConn.cipher")
-	}
-	if result.CipherDataToGCM == 0 {
+	if result.AEADIfaceOff == 0 {
 		missing = append(missing, "prefixNonceAEAD.aead or xorNonceAEAD.aead")
 	}
-	if result.GCMToH == 0 {
-		missing = append(missing, "gcmAES.productTable")
+
+	// 3. H×2 word offsets from productTable.
+	// gcmAesInit stores H×2 (H doubled in GF(2^128)) at productTable offset 224.
+	// The two 64-bit words have architecture-dependent order:
+	//   AMD64 PSHUFB: hi at +8, lo at +0
+	//   ARM64 VREV64: hi at +0, lo at +8
+	pdBase, foundPD := uint32(0), false
+
+	// Go 1.24+: GCM.gcmPlatformData → gcmPlatformData.productTable
+	gcmPD, okPD := getField(structs, "crypto/internal/fips140/aes/gcm.GCM", "gcmPlatformData")
+	pdPT, okPT := getField(structs, "crypto/internal/fips140/aes/gcm.gcmPlatformData", "productTable")
+	if okPD && okPT {
+		pdBase = gcmPD + pdPT + 224
+		foundPD = true
+		fmt.Fprintf(os.Stderr, "PDBase = GCM.gcmPlatformData(%d) + productTable(%d) + 224 = %d\n", gcmPD, pdPT, pdBase)
 	}
+
+	// Go <1.24: crypto/cipher.gcmAES.productTable
+	if !foundPD {
+		if pt, ok := getField(structs, "crypto/cipher.gcmAES", "productTable"); ok {
+			pdBase = pt + 224
+			foundPD = true
+			fmt.Fprintf(os.Stderr, "PDBase = gcmAES.productTable(%d) + 224 = %d\n", pt, pdBase)
+		}
+	}
+
+	if foundPD {
+		result.Raw.ProductTable = pdBase - 224
+		result.Raw.PDBase = pdBase
+		if result.Arch == "amd64" {
+			result.H2HiOff = pdBase + 8
+			result.H2LoOff = pdBase
+		} else {
+			result.H2HiOff = pdBase
+			result.H2LoOff = pdBase + 8
+		}
+		fmt.Fprintf(os.Stderr, "H2HiOff = %d, H2LoOff = %d (arch=%s)\n", result.H2HiOff, result.H2LoOff, result.Arch)
+	} else {
+		missing = append(missing, "productTable")
+	}
+
 	if len(missing) > 0 {
 		result.Notes = fmt.Sprintf("Missing: %s", strings.Join(missing, ", "))
 		fmt.Fprintf(os.Stderr, "\nWARNING: missing offsets: %s\n", result.Notes)
@@ -191,7 +204,6 @@ func main() {
 		}
 	}
 
-	// Output JSON.
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(result); err != nil {
@@ -202,6 +214,15 @@ func main() {
 	_ = f.Close()
 }
 
+func getField(structs map[string]map[string]uint32, structName, fieldName string) (uint32, bool) {
+	fields, ok := structs[structName]
+	if !ok {
+		return 0, false
+	}
+	off, ok := fields[fieldName]
+	return off, ok
+}
+
 func isTargetStruct(name string) bool {
 	targets := []string{
 		"crypto/tls.Conn",
@@ -209,7 +230,6 @@ func isTargetStruct(name string) bool {
 		"crypto/tls.prefixNonceAEAD",
 		"crypto/tls.xorNonceAEAD",
 		"crypto/cipher.gcmAES",
-		// Go 1.24+ moved gcm into FIPS module
 		"crypto/internal/fips140/aes/gcm.GCMForSSH",
 		"crypto/internal/fips140/aes/gcm.GCM",
 		"crypto/internal/fips140/aes/gcm.gcmAES",
@@ -220,7 +240,7 @@ func isTargetStruct(name string) bool {
 			return true
 		}
 	}
-	// Also match any struct containing "gcm" or "GCM" for discovery
+	// Also match any struct containing "gcm" or "GCM" for discovery.
 	if strings.Contains(name, "gcm") || strings.Contains(name, "GCM") {
 		return true
 	}

--- a/tools/go-tls-offsets/main.go
+++ b/tools/go-tls-offsets/main.go
@@ -1,0 +1,222 @@
+// go-tls-offsets discovers the struct offsets needed by kloak's eBPF code
+// to extract the GHASH H key from Go's crypto/tls internal structures.
+//
+// It reads DWARF debug info from a Go binary and prints the offset chain:
+//   tls.Conn → halfConn.cipher (interface) → concrete AEAD → gcmAES.productTable → H
+//
+// Usage:
+//   go run ./tools/go-tls-offsets /path/to/go-binary
+//   go run ./tools/go-tls-offsets  # uses itself as the binary
+package main
+
+import (
+	"debug/buildinfo"
+	"debug/dwarf"
+	"debug/elf"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+type OffsetResult struct {
+	GoVersion        string `json:"go_version"`
+	Arch             string `json:"arch"`
+	ConnToHalfConn   uint32 `json:"conn_to_half_conn"`
+	HalfConnToCipher uint32 `json:"half_conn_to_cipher"`
+	CipherDataToGCM  uint32 `json:"cipher_data_to_gcm"`
+	GCMToH           uint32 `json:"gcm_to_h"`
+	Notes            string `json:"notes,omitempty"`
+}
+
+func main() {
+	path := os.Args[0]
+	if len(os.Args) > 1 {
+		path = os.Args[1]
+	}
+
+	fmt.Fprintf(os.Stderr, "Analyzing: %s\n", path)
+
+	// Read Go build info for version.
+	bi, err := buildinfo.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not read buildinfo: %v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "Go version: %s\n", bi.GoVersion)
+	}
+
+	f, err := elf.Open(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening ELF: %v\n", err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	dw, err := f.DWARF()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading DWARF: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Binary may be stripped (-ldflags='-s -w'). DWARF is required.\n")
+		os.Exit(1)
+	}
+
+	result := OffsetResult{}
+	if bi != nil {
+		result.GoVersion = bi.GoVersion
+	}
+	switch f.Machine {
+	case elf.EM_X86_64:
+		result.Arch = "amd64"
+	case elf.EM_AARCH64:
+		result.Arch = "arm64"
+	default:
+		result.Arch = fmt.Sprintf("unknown(%d)", f.Machine)
+	}
+
+	// Walk DWARF entries to find our target structs.
+	structs := map[string]map[string]uint32{} // structName -> fieldName -> offset
+	reader := dw.Reader()
+	for {
+		entry, err := reader.Next()
+		if err != nil || entry == nil {
+			break
+		}
+
+		if entry.Tag != dwarf.TagStructType {
+			continue
+		}
+
+		name, _ := entry.Val(dwarf.AttrName).(string)
+		if !isTargetStruct(name) {
+			reader.SkipChildren()
+			continue
+		}
+
+		fmt.Fprintf(os.Stderr, "\nFound struct: %s\n", name)
+		fields := map[string]uint32{}
+
+		for {
+			child, err := reader.Next()
+			if err != nil || child == nil || child.Tag == 0 {
+				break
+			}
+			if child.Tag != dwarf.TagMember {
+				continue
+			}
+			fieldName, _ := child.Val(dwarf.AttrName).(string)
+			// Try DW_AT_data_member_location
+			var offset uint32
+			if loc, ok := child.Val(dwarf.AttrDataMemberLoc).(int64); ok {
+				offset = uint32(loc)
+			}
+			fields[fieldName] = offset
+			fmt.Fprintf(os.Stderr, "  .%s = %d\n", fieldName, offset)
+		}
+
+		structs[name] = fields
+	}
+
+	// Extract the offsets we need.
+	// 1. tls.Conn → out (halfConn, embedded struct)
+	if fields, ok := structs["crypto/tls.Conn"]; ok {
+		if off, ok := fields["out"]; ok {
+			result.ConnToHalfConn = off
+			fmt.Fprintf(os.Stderr, "\nConn.out offset: %d\n", off)
+		}
+	}
+
+	// 2. halfConn → cipher (interface)
+	if fields, ok := structs["crypto/tls.halfConn"]; ok {
+		if off, ok := fields["cipher"]; ok {
+			result.HalfConnToCipher = off
+			fmt.Fprintf(os.Stderr, "halfConn.cipher offset: %d\n", off)
+		}
+	}
+
+	// 3. prefixNonceAEAD → aead (the inner AEAD, typically gcmAES pointer)
+	// TLS 1.2 uses prefixNonceAEAD wrapping the actual GCM cipher.
+	// TLS 1.3 uses xorNonceAEAD wrapping it.
+	// Both have an 'aead' field that is a cipher.AEAD interface.
+	for _, structName := range []string{
+		"crypto/tls.prefixNonceAEAD",
+		"crypto/tls.xorNonceAEAD",
+	} {
+		if fields, ok := structs[structName]; ok {
+			if off, ok := fields["aead"]; ok {
+				result.CipherDataToGCM = off
+				fmt.Fprintf(os.Stderr, "%s.aead offset: %d\n", structName, off)
+				break
+			}
+		}
+	}
+
+	// 4. gcmAES → productTable (the precomputed H powers)
+	// productTable is [16][16]byte. H is at index reverseBits(1) = 8, so byte offset 128.
+	for _, structName := range []string{
+		"crypto/cipher.gcmAES",
+		"crypto/internal/fips140/aes/gcm.GCMForSSH",
+		"crypto/internal/fips140/aes/gcm.GCM",
+	} {
+		if fields, ok := structs[structName]; ok {
+			if off, ok := fields["productTable"]; ok {
+				// H is at productTable[reverseBits(1)] = productTable[8] = offset + 8*16 = offset + 128
+				result.GCMToH = off + 128
+				fmt.Fprintf(os.Stderr, "%s.productTable offset: %d (H at +128 = %d)\n",
+					structName, off, off+128)
+				break
+			}
+		}
+	}
+
+	// Check if we got all offsets.
+	missing := []string{}
+	if result.ConnToHalfConn == 0 {
+		missing = append(missing, "Conn.out")
+	}
+	if result.HalfConnToCipher == 0 {
+		missing = append(missing, "halfConn.cipher")
+	}
+	if result.CipherDataToGCM == 0 {
+		missing = append(missing, "prefixNonceAEAD.aead or xorNonceAEAD.aead")
+	}
+	if result.GCMToH == 0 {
+		missing = append(missing, "gcmAES.productTable")
+	}
+	if len(missing) > 0 {
+		result.Notes = fmt.Sprintf("Missing: %s", strings.Join(missing, ", "))
+		fmt.Fprintf(os.Stderr, "\nWARNING: missing offsets: %s\n", result.Notes)
+		fmt.Fprintf(os.Stderr, "Available structs found:\n")
+		for name := range structs {
+			fmt.Fprintf(os.Stderr, "  %s\n", name)
+		}
+	}
+
+	// Output JSON.
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(result)
+}
+
+func isTargetStruct(name string) bool {
+	targets := []string{
+		"crypto/tls.Conn",
+		"crypto/tls.halfConn",
+		"crypto/tls.prefixNonceAEAD",
+		"crypto/tls.xorNonceAEAD",
+		"crypto/cipher.gcmAES",
+		// Go 1.24+ moved gcm into FIPS module
+		"crypto/internal/fips140/aes/gcm.GCMForSSH",
+		"crypto/internal/fips140/aes/gcm.GCM",
+		"crypto/internal/fips140/aes/gcm.gcmAES",
+		"crypto/internal/fips140/aes/gcm.gcmPlatformData",
+	}
+	for _, t := range targets {
+		if name == t {
+			return true
+		}
+	}
+	// Also match any struct containing "gcm" or "GCM" for discovery
+	if strings.Contains(name, "gcm") || strings.Contains(name, "GCM") {
+		return true
+	}
+	return false
+}

--- a/tools/go-tls-offsets/main.go
+++ b/tools/go-tls-offsets/main.go
@@ -2,11 +2,13 @@
 // to extract the GHASH H key from Go's crypto/tls internal structures.
 //
 // It reads DWARF debug info from a Go binary and prints the offset chain:
-//   tls.Conn → halfConn.cipher (interface) → concrete AEAD → gcmAES.productTable → H
+//
+//	tls.Conn → halfConn.cipher (interface) → concrete AEAD → gcmAES.productTable → H
 //
 // Usage:
-//   go run ./tools/go-tls-offsets /path/to/go-binary
-//   go run ./tools/go-tls-offsets  # uses itself as the binary
+//
+//	go run ./tools/go-tls-offsets /path/to/go-binary
+//	go run ./tools/go-tls-offsets  # uses itself as the binary
 package main
 
 import (
@@ -50,14 +52,15 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error opening ELF: %v\n", err)
 		os.Exit(1)
 	}
-	defer f.Close()
 
 	dw, err := f.DWARF()
 	if err != nil {
+		_ = f.Close()
 		fmt.Fprintf(os.Stderr, "Error reading DWARF: %v\n", err)
 		fmt.Fprintf(os.Stderr, "Binary may be stripped (-ldflags='-s -w'). DWARF is required.\n")
 		os.Exit(1)
 	}
+	defer func() { _ = f.Close() }()
 
 	result := OffsetResult{}
 	if bi != nil {
@@ -193,7 +196,10 @@ func main() {
 	// Output JSON.
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
-	enc.Encode(result)
+	if err := enc.Encode(result); err != nil {
+		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
+		os.Exit(1)
+	}
 }
 
 func isTargetStruct(name string) bool {

--- a/tools/go-tls-offsets/main.go
+++ b/tools/go-tls-offsets/main.go
@@ -60,8 +60,6 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Binary may be stripped (-ldflags='-s -w'). DWARF is required.\n")
 		os.Exit(1)
 	}
-	defer func() { _ = f.Close() }()
-
 	result := OffsetResult{}
 	if bi != nil {
 		result.GoVersion = bi.GoVersion
@@ -197,9 +195,11 @@ func main() {
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(result); err != nil {
+		_ = f.Close()
 		fmt.Fprintf(os.Stderr, "Error encoding JSON: %v\n", err)
 		os.Exit(1)
 	}
+	_ = f.Close()
 }
 
 func isTargetStruct(name string) bool {

--- a/tools/go-tls-offsets/main.go
+++ b/tools/go-tls-offsets/main.go
@@ -31,10 +31,10 @@ import (
 type OffsetResult struct {
 	GoVersion    string `json:"go_version"`
 	Arch         string `json:"arch"`
-	ConnToCipher uint32 `json:"conn_to_cipher"`  // Conn.out + halfConn.cipher + 8
-	AEADIfaceOff uint32 `json:"aead_iface_off"`  // prefixNonceAEAD.aead + 8
-	H2HiOff      uint32 `json:"h2_hi_off"`       // GCM + off → high 64 bits of H×2
-	H2LoOff      uint32 `json:"h2_lo_off"`       // GCM + off → low 64 bits of H×2
+	ConnToCipher uint32 `json:"conn_to_cipher"` // Conn.out + halfConn.cipher + 8
+	AEADIfaceOff uint32 `json:"aead_iface_off"` // prefixNonceAEAD.aead + 8
+	H2HiOff      uint32 `json:"h2_hi_off"`      // GCM + off → high 64 bits of H×2
+	H2LoOff      uint32 `json:"h2_lo_off"`      // GCM + off → low 64 bits of H×2
 	Notes        string `json:"notes,omitempty"`
 
 	// Raw offsets for debugging (not used by BPF).


### PR DESCRIPTION
## Summary

- Add Go `crypto/tls` H extraction for the XOR-patch pipeline alongside OpenSSL/BoringSSL
- DWARF-based struct offset detection with Go buildinfo version fallback
- Per-TGID `go_tls_offset_config` BPF hash map — different Go versions can coexist
- `chain_type` field in `xor_pending` prevents OpenSSL H extraction from running on Go connections (was causing bad record MAC)
- H extraction chain: `Conn → halfConn.cipher (interface) → AEAD wrapper (interface) → GCM.productTable[224]`
- GF(2^128) halving recovers H from H×2 stored in productTable (~25 BPF instructions)
- Offset discovery tool: `tools/go-tls-offsets/`
- tc_pending ordering fix: H extraction before tc_pending creation (prevents ciphertext corruption on H failure)

## Test plan

- [x] Go struct offset detection works (DWARF + version fallback verified on Go 1.25.8 arm64)
- [x] Offsets pushed to BPF map (controller logs: `Pushed Go TLS offsets`)
- [x] Prescan finds kloak: prefixes in Go TLS writes (`xor_prescan_match` increments)
- [x] H extraction reads valid, consistent H values per connection
- [x] chain_type prevents OpenSSL H extraction on Go connections
- [x] TLS 1.3 nonce_len detection for Go connections (plaintext_len propagated through xor_pending → tc_pending)
- [x] GF(2^128) halving correctly recovers H from H×2 (mathematically verified)
- [x] `TestEBPFSecretRewrite/go` passes end-to-end (CI: PASS on AMD64, 15.19s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)