### PR TITLE
ci: replace k3d with k3s-direct for e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,10 +185,17 @@ jobs:
       - name: Install k3s
         run: |
           curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
+          # Wait for node to register before running kubectl wait
+          for i in $(seq 1 30); do
+            sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
+            echo "Waiting for k3s node to register ($i/30)..."
+            sleep 2
+          done
           sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
           mkdir -p ~/.kube
-          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
-          chmod 644 ~/.kube/config
+          sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-e2e.yaml
+          sudo chown "$(id -u):$(id -g)" ~/.kube/k3s-e2e.yaml
+          chmod 600 ~/.kube/k3s-e2e.yaml
 
       - name: Build and import images into k3s
         run: |
@@ -200,12 +207,10 @@ jobs:
           docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
           docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
           docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
-          for img in kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
-                     kloak-demo-js:latest kloak-demo-go-boring:latest \
-                     kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
-                     kloak-tls-echo:latest; do
-            docker save "$img" | sudo k3s ctr images import -
-          done
+          docker save kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
+            kloak-demo-js:latest kloak-demo-go-boring:latest \
+            kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
+            kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -213,12 +218,12 @@ jobs:
       - name: Run E2E tests (with eBPF)
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
-          KUBECONFIG: /home/runner/.kube/config
+          KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
 
       - name: Collect logs and BPF debug info on failure
         if: failure()
         env:
-          KUBECONFIG: /home/runner/.kube/config
+          KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
         run: |
           echo "=== Kloak Controller Logs ==="
           kubectl logs -n kloak-system -l app.kubernetes.io/component=controller --tail=200 2>/dev/null || true
@@ -247,5 +252,6 @@ jobs:
       - name: Stop k3s
         if: always()
         run: |
-          /usr/local/bin/k3s-killall.sh 2>/dev/null || true
+          sudo /usr/local/bin/k3s-killall.sh 2>/dev/null || true
           sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
+          rm -f ~/.kube/k3s-e2e.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,27 +173,26 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
           cache: true
 
-      - name: Install clang for eBPF generation
-        run: sudo apt-get update && sudo apt-get install -y clang llvm libbpf-dev
+      - name: Install clang and bpftool for eBPF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev
+          KVER="$(uname -r)" && sudo apt-get install -y linux-tools-common "linux-tools-${KVER}" 2>/dev/null || true
 
       - name: Generate eBPF bindings
         run: KLOAK_TARGET_ARCH=x86 go generate ./pkg/ebpf/
 
-      - name: Install k3d
-        run: curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-
-      - name: Create k3d cluster (with BPF mounts)
+      - name: Install k3s
         run: |
-          k3d cluster create kloak-e2e --wait --timeout 120s \
-            --volume /sys/kernel/btf:/sys/kernel/btf:ro@server:0 \
-            --volume /sys/fs/bpf:/sys/fs/bpf:rw@server:0 \
-            --volume /sys/kernel/tracing:/sys/kernel/tracing:ro@server:0
-          k3d kubeconfig get kloak-e2e > /tmp/kubeconfig-e2e.yaml
+          curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
+          sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
+          mkdir -p ~/.kube
+          cp /etc/rancher/k3s/k3s.yaml ~/.kube/config
+          chmod 644 ~/.kube/config
 
-      - name: Build and import images into k3d
+      - name: Build and import images into k3s
         run: |
           docker build --build-arg TARGETARCH=amd64 --build-arg COVER=1 -t kloak:e2e .
-          k3d image import kloak:e2e -c kloak-e2e
           docker build -t kloak-demo-go:latest ./examples/demo-go/
           docker build -t kloak-demo-python:latest ./examples/demo-python/
           docker build -t kloak-demo-js:latest ./examples/demo-js/
@@ -201,8 +200,12 @@ jobs:
           docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
           docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
           docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
-          k3d image import kloak-demo-go:latest kloak-demo-python:latest kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest -c kloak-e2e
-          k3d image import kloak-tls-echo:latest -c kloak-e2e
+          for img in kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
+                     kloak-demo-js:latest kloak-demo-go-boring:latest \
+                     kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
+                     kloak-tls-echo:latest; do
+            docker save "$img" | sudo k3s ctr images import -
+          done
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -210,37 +213,39 @@ jobs:
       - name: Run E2E tests (with eBPF)
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
-          KUBECONFIG: /tmp/kubeconfig-e2e.yaml
+          KUBECONFIG: /home/runner/.kube/config
 
-      # E2e coverage collection and merge disabled — unit coverage artifact
-      # upload was removed to save storage quota, so merge has nothing to work with.
-
-      - name: Collect logs on failure
+      - name: Collect logs and BPF debug info on failure
         if: failure()
         env:
-          KUBECONFIG: /tmp/kubeconfig-e2e.yaml
+          KUBECONFIG: /home/runner/.kube/config
         run: |
           echo "=== Kloak Controller Logs ==="
           kubectl logs -n kloak-system -l app.kubernetes.io/component=controller --tail=200 2>/dev/null || true
           echo "=== Kloak Webhook Logs ==="
           kubectl logs -n kloak-system -l app.kubernetes.io/component=webhook --tail=100 2>/dev/null || true
-          echo "=== Demo Go Logs ==="
-          kubectl logs -n kloak-e2e -l app=demo-go --tail=50 2>/dev/null || true
-          echo "=== Demo Python Logs ==="
-          kubectl logs -n kloak-e2e -l app=demo-python --tail=50 2>/dev/null || true
-          echo "=== Demo JS Logs ==="
-          kubectl logs -n kloak-e2e -l app=demo-js --tail=50 2>/dev/null || true
-          echo "=== Demo Go BoringSSL Logs ==="
-          kubectl logs -n kloak-e2e -l app=demo-go-boring --tail=50 2>/dev/null || true
-          echo "=== Demo Python Raw TLS Logs ==="
-          kubectl logs -n kloak-e2e -l app=demo-python-raw-tls --tail=50 2>/dev/null || true
+          echo "=== Demo App Logs ==="
+          for app in demo-go demo-python demo-js demo-go-boring demo-python-raw-tls; do
+            echo "--- $app ---"
+            kubectl logs -n kloak-e2e -l app=$app --tail=50 2>/dev/null || true
+          done
           echo "=== All Pods ==="
           kubectl get pods -A 2>/dev/null || true
           echo "=== Events ==="
           kubectl get events -n kloak-e2e --sort-by='.lastTimestamp' 2>/dev/null || true
           echo "=== Describe Controller ==="
           kubectl describe daemonset -n kloak-system kloak-controller 2>/dev/null || true
+          echo "=== BPF Programs ==="
+          sudo bpftool prog list 2>/dev/null || true
+          echo "=== BPF Maps ==="
+          sudo bpftool map list 2>/dev/null || true
+          echo "=== Kernel dmesg (last 50 lines) ==="
+          sudo dmesg | tail -50 2>/dev/null || true
+          echo "=== BPF trace_pipe (buffered) ==="
+          sudo timeout 2 cat /sys/kernel/tracing/trace_pipe 2>/dev/null | head -100 || true
 
-      - name: Delete k3d cluster
+      - name: Stop k3s
         if: always()
-        run: k3d cluster delete kloak-e2e
+        run: |
+          /usr/local/bin/k3s-killall.sh 2>/dev/null || true
+          sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -166,11 +166,17 @@ e2e-k3s: e2e-k3s-setup e2e-k3s-run e2e-k3s-cleanup
 e2e-k3s-setup:
 	@echo "==> Installing k3s..."
 	@curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
-	@echo "==> Waiting for k3s node to be ready..."
+	@echo "==> Waiting for k3s node to register..."
+	@for i in $$(seq 1 30); do \
+		sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break; \
+		echo "  Waiting for k3s node ($$i/30)..."; \
+		sleep 2; \
+	done
 	@sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
 	@mkdir -p $(HOME)/.kube
-	@cp /etc/rancher/k3s/k3s.yaml $(HOME)/.kube/config
-	@chmod 644 $(HOME)/.kube/config
+	@sudo cp /etc/rancher/k3s/k3s.yaml $(HOME)/.kube/k3s-e2e.yaml
+	@sudo chown $$(id -u):$$(id -g) $(HOME)/.kube/k3s-e2e.yaml
+	@chmod 600 $(HOME)/.kube/k3s-e2e.yaml
 	@echo "==> Building images..."
 	@docker build --build-arg TARGETARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
 		--build-arg COVER=1 -t $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) .
@@ -182,23 +188,21 @@ e2e-k3s-setup:
 	@docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
 	@docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
 	@echo "==> Importing images into k3s containerd..."
-	@for img in $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest \
+	@docker save $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest \
 		kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest \
-		kloak-demo-python-raw-tls:latest kloak-tls-echo:latest; do \
-		echo "  Importing $$img..."; \
-		docker save $$img | sudo k3s ctr images import -; \
-	done
+		kloak-demo-python-raw-tls:latest kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
 	@echo "==> k3s e2e environment ready."
 
 # Run e2e tests against local k3s.
 e2e-k3s-run:
-	KUBECONFIG=$(HOME)/.kube/config \
+	KUBECONFIG=$(HOME)/.kube/k3s-e2e.yaml \
 	$(GOTEST) -v -timeout 900s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
 
 # Tear down k3s.
 e2e-k3s-cleanup:
-	@/usr/local/bin/k3s-killall.sh 2>/dev/null || true
+	@sudo /usr/local/bin/k3s-killall.sh 2>/dev/null || true
 	@sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
+	@rm -f $(HOME)/.kube/k3s-e2e.yaml
 
 clean:
 	$(GOCLEAN)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 .PHONY: all build build-linux test test-linux test-bpf-helpers e2e e2e-setup e2e-run e2e-cleanup \
+        e2e-k3s e2e-k3s-setup e2e-k3s-run e2e-k3s-cleanup \
         clean deps docker-build generate-ebpf generate-vmlinux run help \
         lima-start lima-stop lima-delete lima-shell lima-exec lima-check \
         lima-k3d-ensure lima-k3d-shell lima-k3d-e2e-setup lima-k3d-e2e-run lima-k3d-e2e lima-k3d-stop lima-k3d-delete
@@ -153,6 +154,51 @@ e2e-local-run:
 # Tear down e2e k3d cluster.
 e2e-cleanup:
 	@k3d cluster delete $(E2E_CLUSTER) 2>/dev/null || true
+
+# ============================================================================
+# k3s-native e2e targets (for CI / Linux workstations — no Docker nesting)
+# ============================================================================
+
+# Full k3s e2e: setup + run + cleanup.
+e2e-k3s: e2e-k3s-setup e2e-k3s-run e2e-k3s-cleanup
+
+# Install k3s, build all images, import into k3s containerd.
+e2e-k3s-setup:
+	@echo "==> Installing k3s..."
+	@curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
+	@echo "==> Waiting for k3s node to be ready..."
+	@sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
+	@mkdir -p $(HOME)/.kube
+	@cp /etc/rancher/k3s/k3s.yaml $(HOME)/.kube/config
+	@chmod 644 $(HOME)/.kube/config
+	@echo "==> Building images..."
+	@docker build --build-arg TARGETARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+		--build-arg COVER=1 -t $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) .
+	@docker build -t kloak-demo-go:$(E2E_IMAGE_TAG) -t kloak-demo-go:latest ./examples/demo-go/
+	@docker build -t kloak-demo-python:latest ./examples/demo-python/
+	@docker build -t kloak-demo-js:latest ./examples/demo-js/
+	@docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
+	@docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
+	@docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
+	@docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
+	@echo "==> Importing images into k3s containerd..."
+	@for img in $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest \
+		kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest \
+		kloak-demo-python-raw-tls:latest kloak-tls-echo:latest; do \
+		echo "  Importing $$img..."; \
+		docker save $$img | sudo k3s ctr images import -; \
+	done
+	@echo "==> k3s e2e environment ready."
+
+# Run e2e tests against local k3s.
+e2e-k3s-run:
+	KUBECONFIG=$(HOME)/.kube/config \
+	$(GOTEST) -v -timeout 900s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
+
+# Tear down k3s.
+e2e-k3s-cleanup:
+	@/usr/local/bin/k3s-killall.sh 2>/dev/null || true
+	@sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
 
 clean:
 	$(GOCLEAN)
@@ -309,6 +355,12 @@ help:
 	@echo "eBPF targets:"
 	@echo "  generate-ebpf   - Generate eBPF Go bindings (uses Lima on macOS)"
 	@echo "  generate-vmlinux - Generate vmlinux.h from kernel BTF"
+	@echo ""
+	@echo "k3s-native e2e targets (CI / Linux workstations):"
+	@echo "  e2e-k3s         - Full e2e: setup + run + cleanup (k3s-native)"
+	@echo "  e2e-k3s-setup   - Install k3s, build and import images"
+	@echo "  e2e-k3s-run     - Run e2e tests against local k3s"
+	@echo "  e2e-k3s-cleanup - Uninstall k3s"
 	@echo ""
 	@echo "Lima VM targets (for eBPF on macOS):"
 	@echo "  lima-start      - Start the Lima VM"


### PR DESCRIPTION
## Summary
- Replace k3d (k3s-in-Docker) with k3s installed directly on the GitHub Actions runner for e2e tests
- Import images via `docker save | k3s ctr images import` — no temp tar files, no k3d import
- Add BPF debugging on failure: `bpftool prog/map list`, `dmesg`, `trace_pipe`
- Add `e2e-k3s-setup/run/cleanup` Makefile targets for Linux workstations

## Why
k3d adds Docker-in-Docker complexity that makes BPF mount propagation fragile and debugging nearly impossible. With k3s-direct, the runner VM IS the k8s node — BPF filesystems, tracing, and kernel tools are all natively accessible. This is also more representative of production where kloak runs as a DaemonSet on real nodes.

## Test plan
- [ ] Add `e2e` label to trigger e2e CI job
- [ ] Verify k3s installs and node reaches Ready
- [ ] Verify all images import into k3s containerd
- [ ] Verify helm install with `pullPolicy: Never` works
- [ ] Verify existing e2e tests pass
- [ ] On failure: verify BPF debug output appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)