### PR TITLE
fix: guard remaining bpf_printk calls with KLOAK_DEBUG

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -2365,7 +2365,9 @@ int tc_egress_patch(struct __sk_buff *skb) {
   __u8 tls_hdr[5];
   if (bpf_skb_load_bytes(skb, payload_off, tls_hdr, 5) < 0)
     return 0 /* TC_ACT_OK */;
+#ifdef KLOAK_DEBUG
   bpf_printk("kloak tc tls_hdr=%x ver=%x%x plen=%u", tls_hdr[0], tls_hdr[1], tls_hdr[2], payload_len);
+#endif
   // Validate TLS application_data record:
   //   byte 0: content type must be 0x17
   //   bytes 1-2: version must be 0x0301..0x0303 (TLS 1.0-1.3)
@@ -2550,9 +2552,11 @@ int tc_ghash_update(struct __sk_buff *skb) {
 
   bpf_skb_store_bytes(skb, tag_offset, w->new_tag, 16, 0);
 
+#ifdef KLOAK_DEBUG
   __u32 dsum = 0;
   for (__u32 di = 0; di < 16; di++) dsum += w->tag_delta[di];
   bpf_printk("kloak [5-GHASH] tag_off=%u dsum=%u", tag_offset, dsum);
+#endif
 
   return 0 /* TC_ACT_OK */;
 }


### PR DESCRIPTION
## Summary
- Guard 2 unguarded `bpf_printk` calls in the tc egress path with `#ifdef KLOAK_DEBUG`
- `tc_egress_patch`: TLS header debug log that ran on every packet
- `tc_ghash_update`: GHASH tag delta summary + `dsum` computation loop (dead code in production)

## Why
Each `bpf_printk` adds verifier validation overhead and writes to `trace_pipe` at runtime. The tc path is the hottest BPF code path (runs on every egress packet matching a TLS connection). These were the only 2 remaining unguarded calls.

Part of #93.

## Test plan
- [ ] CI lint + build passes (no functional change when `KLOAK_DEBUG` is not defined)
- [ ] E2E tests pass (secret rewriting unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)