### PR TITLE
fix: helm chart index pointing to deleted tgz files

### DIFF
--- a/.github/workflows/helm-publish.yml
+++ b/.github/workflows/helm-publish.yml
@@ -26,23 +26,8 @@ jobs:
       - name: Package chart
         run: helm package charts/kloak -d .helm-pkg
 
-      - name: Download existing index
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          AWS_ENDPOINT_URL: https://${{ secrets.R2_ACCOUNT_ID }}.r2.cloudflarestorage.com
-          AWS_REGION: auto
-        run: |
-          aws s3 cp s3://kloak-chart/index.yaml .helm-pkg/existing-index.yaml 2>/dev/null || true
-
       - name: Build repo index
-        run: |
-          if [ -f .helm-pkg/existing-index.yaml ]; then
-            helm repo index .helm-pkg --url https://chart.getkloak.io --merge .helm-pkg/existing-index.yaml
-          else
-            helm repo index .helm-pkg --url https://chart.getkloak.io
-          fi
-          rm -f .helm-pkg/existing-index.yaml
+        run: helm repo index .helm-pkg --url https://chart.getkloak.io
 
       - name: Upload to R2
         env:


### PR DESCRIPTION
## Summary
- Remove the download/merge of existing `index.yaml` from R2
- Build a fresh index each publish — only the latest nightly chart is referenced

## Why
The workflow merged old index entries (`--merge`) then deleted old `.tgz` files (`--delete`), leaving `index.yaml` with URLs pointing to non-existent packages. Since these are nightly dev builds (`0.0.1-nightly-<sha>`), there's no need to keep old versions.

## Test plan
- [ ] Merge to main triggers helm-publish workflow
- [ ] `helm repo add kloak https://chart.getkloak.io && helm search repo kloak` returns the latest chart
- [ ] The `.tgz` URL in `index.yaml` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)