### PR TITLE
chore: migrate Docker image from Docker Hub to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,12 +139,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v4
-        with:
-          username: ${{ secrets.DOCKER_PAT_USER }}
-          password: ${{ secrets.DOCKER_PAT_PASS }}
-
       - name: Build and push multi-arch image
         uses: docker/build-push-action@v7
         with:
@@ -152,10 +146,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:dev
             ghcr.io/${{ github.repository }}:sha-${{ github.sha }}
-            ${{ secrets.DOCKER_PAT_USER }}/kloak:dev
-            ${{ secrets.DOCKER_PAT_USER }}/kloak:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -1,5 +1,5 @@
 image:
-  repository: dhiaayachi/kloak
+  repository: ghcr.io/spinningfactory/kloak
   tag: dev
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## Summary
- Remove Docker Hub login and image tags from CI workflow
- Push only to `ghcr.io/spinningfactory/kloak` with `dev` and `sha-<commit>` tags on main
- Update Helm chart default image repository to `ghcr.io/spinningfactory/kloak`

## Notes
- `DOCKER_PAT_USER` and `DOCKER_PAT_PASS` secrets can be removed from repo settings

## Test plan
- [ ] Merge and verify CI pushes image to GHCR with `dev` tag
- [ ] Verify Helm chart deploys using the new image reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)