### PR TITLE
fix: harden webhook to prevent secret leakage when components are down

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ graph TD
 | Component | Description |
 |-----------|-------------|
 | **Controller** (DaemonSet) | Watches Secrets labeled `getkloak.io/enabled=true`, creates shadow secrets with length-matched `kloak:<UUID>` placeholders, syncs real values into eBPF maps, and attaches TLS uprobes to container processes via cgroup discovery. |
-| **Webhook** (Deployment) | Mutating admission webhook that intercepts Pod creation. Rewrites Secret volume mounts to point to shadow secrets. Evaluates enablement through pod annotations, namespace labels, and owner workload labels (following ReplicaSet to Deployment chains). |
+| **Webhook** (Deployment) | Mutating admission webhook that intercepts Pod creation. Rewrites Secret volume mounts to point to shadow secrets. Evaluates enablement through pod labels or namespace labels. Rejects pods if the shadow secret has not been created yet (fail-closed). Two webhook entries ensure only kloak-enabled namespaces and pods are affected; non-kloak workloads are never impacted, even when the webhook is down. |
 | **TLS Uprobes** | Attach to `SSL_write` / `SSL_write_ex` (OpenSSL/BoringSSL) and `crypto/tls.(*Conn).Write` (Go native). Intercept outbound TLS writes, scan for `kloak:` prefixes. Two rewrite paths: Phase 2 for plaintext rewrite (before encryption), and XOR path for ciphertext patching (after encryption). |
 | **XOR Path + TC Egress** | For Go native TLS: computes XOR diff in the uprobe, bridges through `tcp_sendmsg` kprobe to TC egress, which patches the encrypted packet in-flight and recomputes the GHASH authentication tag via a tail call to `tc_ghash_update`. |
 | **DNS Kprobe** | Kprobe/kretprobe on `udp_recvmsg` captures DNS responses system-wide. Parses A/AAAA records for watched hostnames and populates `dns_ip_map` (IP to hostname) with TTL tracking. |
@@ -211,8 +211,7 @@ kubectl get pods -n kloak-system
 
 | Key | Type | Scope | Description |
 |-----|------|-------|-------------|
-| `getkloak.io/enabled=true` | Label | Secret, Namespace, Workload | Enables Kloak for the target resource |
-| `getkloak.io/enabled=true` | Annotation | Pod | Enables Kloak for a specific pod |
+| `getkloak.io/enabled=true` | Label | Secret, Namespace, Pod | Enables Kloak for the target resource. On namespaces and pods, controls webhook scope. On secrets, triggers shadow secret creation. |
 | `getkloak.io/hosts=host1,host2` | Annotation | Secret | Restricts which destination hosts a secret can be sent to |
 | `getkloak.io/port=443` | Annotation | Secret | Restricts which destination port a secret can be sent to |
 | `getkloak.io/managed=true` | Label | Secret | Marks shadow secrets created by Kloak (do not set manually) |

--- a/charts/kloak/templates/mutatingwebhookconfiguration.yaml
+++ b/charts/kloak/templates/mutatingwebhookconfiguration.yaml
@@ -43,6 +43,33 @@ metadata:
     cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/kloak-webhook-cert
   {{- end }}
 webhooks:
+  - name: ns.pod.mutate.getkloak.io
+    admissionReviewVersions: ["v1"]
+    sideEffects: None
+    clientConfig:
+      service:
+        namespace: {{ .Release.Namespace }}
+        name: kloak-webhook
+        path: /mutate-pods
+      {{- if $caBundle }}
+      caBundle: {{ $caBundle }}
+      {{- end }}
+    rules:
+      - operations: ["CREATE"]
+        apiGroups: [""]
+        apiVersions: ["v1"]
+        resources: ["pods"]
+    namespaceSelector:
+      matchExpressions:
+        - key: getkloak.io/enabled
+          operator: In
+          values:
+            - "true"
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values:
+            - {{ .Release.Namespace }}
+    failurePolicy: Fail
   - name: pod.mutate.getkloak.io
     admissionReviewVersions: ["v1"]
     sideEffects: None
@@ -65,6 +92,7 @@ webhooks:
           operator: NotIn
           values:
             - {{ .Release.Namespace }}
-            - kube-system
-            - kube-public
+    objectSelector:
+      matchLabels:
+        getkloak.io/enabled: "true"
     failurePolicy: Fail

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -5,9 +5,9 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -17,7 +17,13 @@ import (
 )
 
 const (
-	// AnnotationEnabled is the annotation to enable Kloak on a pod.
+	// LabelEnabled is the label used to enable Kloak on a pod or namespace.
+	// Pod-level enablement uses a label (not annotation) so that Kubernetes
+	// objectSelector can match it, allowing the webhook to be scoped precisely.
+	LabelEnabled = "getkloak.io/enabled"
+
+	// AnnotationEnabled is the annotation injected by the webhook onto mutated pods.
+	// The controller (DaemonSet) reads this to determine if a pod is kloak-enabled.
 	AnnotationEnabled = "getkloak.io/enabled"
 )
 
@@ -66,7 +72,10 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 	mutatedPod.Annotations[AnnotationEnabled] = "true"
 
 	// Rewrite Secret volumes (swap with shadow secrets)
-	h.rewriteSecretVolumes(ctx, mutatedPod, req.Namespace)
+	if err := h.rewriteSecretVolumes(ctx, mutatedPod, req.Namespace); err != nil {
+		h.log.Error(err, "shadow secret not ready, rejecting pod")
+		return admission.Denied(fmt.Sprintf("kloak: %v", err))
+	}
 
 	// Create JSON patch
 	marshaledPod, err := json.Marshal(mutatedPod)
@@ -78,119 +87,74 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 }
 
 // isEnabled checks if Kloak should process this pod.
-// It checks for the explicit pod annotation first, then falls back to the namespace label.
+// Enablement is determined by pod label or namespace label only.
+// Workload-level inheritance (Deployment, DaemonSet, etc.) is not supported;
+// use pod template labels or namespace labels instead.
 func (h *Handler) isEnabled(ctx context.Context, pod *corev1.Pod, namespace string) (bool, error) {
-	// 1. Check explicit Pod annotation
-	if pod.Annotations != nil {
-		if val, ok := pod.Annotations[AnnotationEnabled]; ok {
+	// 1. Check pod label
+	if pod.Labels != nil {
+		if val, ok := pod.Labels[LabelEnabled]; ok {
 			return val == "true", nil
 		}
 	}
 
-	// 2. Check Namespace label (inheritance)
-	// We need to fetch the namespace object to check labels
+	// 2. Check namespace label
 	ns := &corev1.Namespace{}
 	if err := h.client.Get(ctx, client.ObjectKey{Name: namespace}, ns); err != nil {
 		h.log.Error(err, "failed to fetch namespace for label check", "namespace", namespace)
 		return false, err
 	}
 
-	if ns.Labels != nil && ns.Labels[AnnotationEnabled] == "true" {
+	if ns.Labels != nil && ns.Labels[LabelEnabled] == "true" {
 		return true, nil
-	}
-
-	// 3. Check OwnerReferences (Workload inheritance)
-	// Traverse up to find Deployment, DaemonSet, StatefulSet
-	for _, ref := range pod.OwnerReferences {
-		// Handle ReplicaSet (Deployment -> ReplicaSet -> Pod)
-		if ref.Kind == "ReplicaSet" {
-			rs := &appsv1.ReplicaSet{}
-			if err := h.client.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: namespace}, rs); err == nil {
-				// Check RS itself
-				if h.isObjectEnabled(rs.Labels, rs.Annotations) {
-					return true, nil
-				}
-
-				// Check RS owner (Deployment)
-				for _, rsRef := range rs.OwnerReferences {
-					if rsRef.Kind == "Deployment" {
-						deploy := &appsv1.Deployment{}
-						if err := h.client.Get(ctx, client.ObjectKey{Name: rsRef.Name, Namespace: namespace}, deploy); err == nil {
-							if h.isObjectEnabled(deploy.Labels, deploy.Annotations) {
-								return true, nil
-							}
-						}
-					}
-				}
-			}
-		}
-
-		// Handle DaemonSet
-		if ref.Kind == "DaemonSet" {
-			ds := &appsv1.DaemonSet{}
-			if err := h.client.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: namespace}, ds); err == nil {
-				if h.isObjectEnabled(ds.Labels, ds.Annotations) {
-					return true, nil
-				}
-			}
-		}
-
-		// Handle StatefulSet
-		if ref.Kind == "StatefulSet" {
-			sts := &appsv1.StatefulSet{}
-			if err := h.client.Get(ctx, client.ObjectKey{Name: ref.Name, Namespace: namespace}, sts); err == nil {
-				if h.isObjectEnabled(sts.Labels, sts.Annotations) {
-					return true, nil
-				}
-			}
-		}
 	}
 
 	return false, nil
 }
 
-// isObjectEnabled checks if the given labels or annotations have the enabled flag.
-func (h *Handler) isObjectEnabled(labels, annotations map[string]string) bool {
-	if labels != nil && labels[AnnotationEnabled] == "true" {
-		return true
-	}
-	if annotations != nil && annotations[AnnotationEnabled] == "true" {
-		return true
-	}
-	return false
-}
-
 // rewriteSecretVolumes checks volume mounts and swaps enabled secrets with shadow secrets.
-func (h *Handler) rewriteSecretVolumes(ctx context.Context, pod *corev1.Pod, namespace string) {
+// Returns an error if a kloak-enabled secret's shadow does not exist (fail closed).
+func (h *Handler) rewriteSecretVolumes(ctx context.Context, pod *corev1.Pod, namespace string) error {
 	for i := range pod.Spec.Volumes {
 		vol := &pod.Spec.Volumes[i]
-		if vol.Secret != nil {
-			secretName := vol.Secret.SecretName
-
-			// Resolve namespace (pod namespace usually)
-			ns := namespace
-			if ns == "" {
-				ns = "default" // Fallback
-			}
-
-			// Check if secret is enabled
-			var secret corev1.Secret
-			err := h.client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: ns}, &secret)
-			if err != nil {
-				// If not found or error, just skip rewriting (safest default? or fail?)
-				// If we can't find it, we can't verify label.
-				// Pod admission will likely fail downstream if secret is missing anyway.
-				h.log.V(1).Info("failed to look up secret for volume rewriting", "name", secretName, "error", err)
-				continue
-			}
-
-			// Check annotation/label
-			enabled := secret.Labels[AnnotationEnabled] == "true" || secret.Annotations[AnnotationEnabled] == "true"
-			if enabled {
-				shadowName := secretName + "-kloak"
-				h.log.Info("Rewriting volume to use shadow secret", "original", secretName, "shadow", shadowName)
-				vol.Secret.SecretName = shadowName
-			}
+		if vol.Secret == nil {
+			continue
 		}
+
+		secretName := vol.Secret.SecretName
+
+		// Resolve namespace
+		ns := namespace
+		if ns == "" {
+			ns = "default"
+		}
+
+		// Check if secret is enabled
+		var secret corev1.Secret
+		if err := h.client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: ns}, &secret); err != nil {
+			// Secret not found or error -- skip rewriting. The secret may not be
+			// kloak-managed, and pod admission will fail downstream if it's truly missing.
+			h.log.V(1).Info("failed to look up secret for volume rewriting", "name", secretName, "error", err)
+			continue
+		}
+
+		enabled := secret.Labels[LabelEnabled] == "true" || secret.Annotations[LabelEnabled] == "true"
+		if !enabled {
+			continue
+		}
+
+		// Secret is kloak-enabled -- verify shadow exists before rewriting.
+		// If the shadow doesn't exist (controller hasn't reconciled yet), reject
+		// the pod to prevent mounting real secrets.
+		shadowName := secretName + "-kloak"
+		var shadowSecret corev1.Secret
+		if err := h.client.Get(ctx, client.ObjectKey{Name: shadowName, Namespace: ns}, &shadowSecret); err != nil {
+			return fmt.Errorf("shadow secret %s/%s not found for kloak-enabled secret %s (controller may not have reconciled yet)", ns, shadowName, secretName)
+		}
+
+		h.log.Info("Rewriting volume to use shadow secret", "original", secretName, "shadow", shadowName)
+		vol.Secret.SecretName = shadowName
 	}
+
+	return nil
 }

--- a/pkg/webhook/handler.go
+++ b/pkg/webhook/handler.go
@@ -132,9 +132,12 @@ func (h *Handler) rewriteSecretVolumes(ctx context.Context, pod *corev1.Pod, nam
 		// Check if secret is enabled
 		var secret corev1.Secret
 		if err := h.client.Get(ctx, client.ObjectKey{Name: secretName, Namespace: ns}, &secret); err != nil {
-			// Secret not found or error -- skip rewriting. The secret may not be
-			// kloak-managed, and pod admission will fail downstream if it's truly missing.
-			h.log.V(1).Info("failed to look up secret for volume rewriting", "name", secretName, "error", err)
+			if client.IgnoreNotFound(err) != nil {
+				// API error (permissions, transient failure) -- deny to maintain fail-closed posture
+				return fmt.Errorf("failed to look up secret %s/%s: %w", ns, secretName, err)
+			}
+			// Secret not found -- skip rewriting. Pod admission will fail downstream if it's truly missing.
+			h.log.V(1).Info("secret not found for volume rewriting", "name", secretName)
 			continue
 		}
 
@@ -150,6 +153,9 @@ func (h *Handler) rewriteSecretVolumes(ctx context.Context, pod *corev1.Pod, nam
 		var shadowSecret corev1.Secret
 		if err := h.client.Get(ctx, client.ObjectKey{Name: shadowName, Namespace: ns}, &shadowSecret); err != nil {
 			return fmt.Errorf("shadow secret %s/%s not found for kloak-enabled secret %s (controller may not have reconciled yet)", ns, shadowName, secretName)
+		}
+		if shadowSecret.Labels["getkloak.io/managed"] != "true" {
+			return fmt.Errorf("secret %s/%s exists but is not a kloak-managed shadow secret", ns, shadowName)
 		}
 
 		h.log.Info("Rewriting volume to use shadow secret", "original", secretName, "shadow", shadowName)

--- a/pkg/webhook/handler_test.go
+++ b/pkg/webhook/handler_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -22,7 +22,6 @@ import (
 func newTestHandler(objs ...client.Object) *Handler {
 	scheme := k8sruntime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
 	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
 	return &Handler{
 		client:  c,
@@ -48,36 +47,11 @@ func TestIsEnabled(t *testing.T) {
 	nsEnabled := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "enabled-ns",
-			Labels: map[string]string{AnnotationEnabled: "true"},
-		},
-	}
-	deployment := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "enabled-deploy", Namespace: "default",
-			Labels: map[string]string{AnnotationEnabled: "true"},
-		},
-	}
-	rs := &appsv1.ReplicaSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "enabled-deploy-rs", Namespace: "default",
-			OwnerReferences: []metav1.OwnerReference{{Kind: "Deployment", Name: "enabled-deploy"}},
-		},
-	}
-	ds := &appsv1.DaemonSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "enabled-ds", Namespace: "default",
-			Annotations: map[string]string{AnnotationEnabled: "true"},
+			Labels: map[string]string{LabelEnabled: "true"},
 		},
 	}
 
-	sts := &appsv1.StatefulSet{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "enabled-sts", Namespace: "default",
-			Labels: map[string]string{AnnotationEnabled: "true"},
-		},
-	}
-
-	h := newTestHandler(nsDefault, nsEnabled, deployment, rs, ds, sts)
+	h := newTestHandler(nsDefault, nsEnabled)
 
 	tests := []struct {
 		name      string
@@ -86,30 +60,26 @@ func TestIsEnabled(t *testing.T) {
 		expected  bool
 	}{
 		{
-			name:      "no annotations, default ns",
+			name:      "no labels, default ns",
 			pod:       &corev1.Pod{},
 			namespace: "default",
 			expected:  false,
 		},
 		{
-			name: "explicit enabled=true",
+			name: "explicit label enabled=true",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationEnabled: "true",
-					},
+					Labels: map[string]string{LabelEnabled: "true"},
 				},
 			},
 			namespace: "default",
 			expected:  true,
 		},
 		{
-			name: "explicit enabled=false",
+			name: "explicit label enabled=false",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationEnabled: "false",
-					},
+					Labels: map[string]string{LabelEnabled: "false"},
 				},
 			},
 			namespace: "default",
@@ -125,58 +95,11 @@ func TestIsEnabled(t *testing.T) {
 			name: "disabled pod in enabled namespace",
 			pod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						AnnotationEnabled: "false",
-					},
+					Labels: map[string]string{LabelEnabled: "false"},
 				},
 			},
 			namespace: "enabled-ns",
 			expected:  false,
-		},
-		{
-			name: "inheritance from deployment (via RS)",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind: "ReplicaSet",
-							Name: "enabled-deploy-rs",
-						},
-					},
-				},
-			},
-			namespace: "default",
-			expected:  true,
-		},
-		{
-			name: "inheritance from daemonset",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind: "DaemonSet",
-							Name: "enabled-ds",
-						},
-					},
-				},
-			},
-			namespace: "default",
-			expected:  true,
-		},
-		{
-			name: "inheritance from statefulset",
-			pod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							Kind: "StatefulSet",
-							Name: "enabled-sts",
-						},
-					},
-				},
-			},
-			namespace: "default",
-			expected:  true,
 		},
 	}
 
@@ -197,7 +120,13 @@ func TestRewriteSecretVolumes(t *testing.T) {
 	enabledSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-secret", Namespace: "default",
-			Labels: map[string]string{AnnotationEnabled: "true"},
+			Labels: map[string]string{LabelEnabled: "true"},
+		},
+	}
+	shadowSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-secret-kloak", Namespace: "default",
+			Labels: map[string]string{"getkloak.io/managed": "true"},
 		},
 	}
 	disabledSecret := &corev1.Secret{
@@ -206,7 +135,7 @@ func TestRewriteSecretVolumes(t *testing.T) {
 		},
 	}
 
-	h := newTestHandler(enabledSecret, disabledSecret)
+	h := newTestHandler(enabledSecret, shadowSecret, disabledSecret)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -242,7 +171,10 @@ func TestRewriteSecretVolumes(t *testing.T) {
 		},
 	}
 
-	h.rewriteSecretVolumes(context.Background(), pod, "default")
+	err := h.rewriteSecretVolumes(context.Background(), pod, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Verify "my-secret" rewrote to "my-secret-kloak"
 	if pod.Spec.Volumes[0].Secret.SecretName != "my-secret-kloak" {
@@ -252,6 +184,39 @@ func TestRewriteSecretVolumes(t *testing.T) {
 	// Verify "other-secret" stayed same
 	if pod.Spec.Volumes[1].Secret.SecretName != "other-secret" {
 		t.Errorf("Expected other-secret, got %s", pod.Spec.Volumes[1].Secret.SecretName)
+	}
+}
+
+func TestRewriteSecretVolumes_MissingShadowRejects(t *testing.T) {
+	enabledSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-secret", Namespace: "default",
+			Labels: map[string]string{LabelEnabled: "true"},
+		},
+	}
+	// No shadow secret created
+
+	h := newTestHandler(enabledSecret)
+
+	pod := &corev1.Pod{
+		Spec: corev1.PodSpec{
+			Volumes: []corev1.Volume{
+				{
+					Name: "vol",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{SecretName: "my-secret"},
+					},
+				},
+			},
+		},
+	}
+
+	err := h.rewriteSecretVolumes(context.Background(), pod, "default")
+	if err == nil {
+		t.Fatal("expected error when shadow secret is missing, got nil")
+	}
+	if !strings.Contains(err.Error(), "shadow secret") {
+		t.Errorf("expected error about shadow secret, got: %v", err)
 	}
 }
 
@@ -277,16 +242,22 @@ func TestHandle_EnabledPodWithSecretVolume(t *testing.T) {
 	enabledSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "my-secret", Namespace: "default",
-			Labels: map[string]string{AnnotationEnabled: "true"},
+			Labels: map[string]string{LabelEnabled: "true"},
 		},
 	}
-	h := newTestHandler(ns, enabledSecret)
+	shadowSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-secret-kloak", Namespace: "default",
+			Labels: map[string]string{"getkloak.io/managed": "true"},
+		},
+	}
+	h := newTestHandler(ns, enabledSecret, shadowSecret)
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        "test-pod",
-			Namespace:   "default",
-			Annotations: map[string]string{AnnotationEnabled: "true"},
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{LabelEnabled: "true"},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
@@ -321,6 +292,49 @@ func TestHandle_EnabledPodWithSecretVolume(t *testing.T) {
 	if !foundVolumeRewrite {
 		patchJSON, _ := json.Marshal(resp.Patches)
 		t.Errorf("expected patch to rewrite volume to my-secret-kloak, got patches: %s", patchJSON)
+	}
+}
+
+func TestHandle_MissingShadowDenied(t *testing.T) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "default"},
+	}
+	enabledSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "my-secret", Namespace: "default",
+			Labels: map[string]string{LabelEnabled: "true"},
+		},
+	}
+	// No shadow secret
+	h := newTestHandler(ns, enabledSecret)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "default",
+			Labels:    map[string]string{LabelEnabled: "true"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "busybox"}},
+			Volumes: []corev1.Volume{
+				{
+					Name: "secret-vol",
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{SecretName: "my-secret"},
+					},
+				},
+			},
+		},
+	}
+
+	req := makeAdmissionRequest(pod, "default")
+	resp := h.Handle(context.Background(), req)
+
+	if resp.Allowed {
+		t.Fatal("expected denied when shadow secret is missing")
+	}
+	if resp.Result == nil || !strings.Contains(resp.Result.Message, "shadow secret") {
+		t.Errorf("expected denial message about shadow secret, got: %v", resp.Result)
 	}
 }
 
@@ -390,8 +404,10 @@ func TestRewriteSecretVolumes_NonSecretVolumes(t *testing.T) {
 		},
 	}
 
-	// Should not panic or error on non-secret volumes
-	h.rewriteSecretVolumes(context.Background(), pod, "default")
+	err := h.rewriteSecretVolumes(context.Background(), pod, "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if pod.Spec.Volumes[0].ConfigMap.Name != "my-config" {
 		t.Error("non-secret volume should be unchanged")
@@ -402,10 +418,16 @@ func TestRewriteSecretVolumes_EmptyNamespace(t *testing.T) {
 	enabledSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "ns-secret", Namespace: "default",
-			Labels: map[string]string{AnnotationEnabled: "true"},
+			Labels: map[string]string{LabelEnabled: "true"},
 		},
 	}
-	h := newTestHandler(enabledSecret)
+	shadowSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ns-secret-kloak", Namespace: "default",
+			Labels: map[string]string{"getkloak.io/managed": "true"},
+		},
+	}
+	h := newTestHandler(enabledSecret, shadowSecret)
 
 	pod := &corev1.Pod{
 		Spec: corev1.PodSpec{
@@ -421,7 +443,10 @@ func TestRewriteSecretVolumes_EmptyNamespace(t *testing.T) {
 	}
 
 	// Empty namespace should fall back to "default"
-	h.rewriteSecretVolumes(context.Background(), pod, "")
+	err := h.rewriteSecretVolumes(context.Background(), pod, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if pod.Spec.Volumes[0].Secret.SecretName != "ns-secret-kloak" {
 		t.Errorf("expected ns-secret-kloak, got %s", pod.Spec.Volumes[0].Secret.SecretName)
@@ -432,12 +457,12 @@ func TestHandle_NamespaceInheritance(t *testing.T) {
 	nsEnabled := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "enabled-ns",
-			Labels: map[string]string{AnnotationEnabled: "true"},
+			Labels: map[string]string{LabelEnabled: "true"},
 		},
 	}
 	h := newTestHandler(nsEnabled)
 
-	// Pod without annotation in enabled namespace
+	// Pod without label in enabled namespace
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "inherit-pod", Namespace: "enabled-ns"},
 		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app", Image: "busybox"}}},


### PR DESCRIPTION
## Summary
- Simplify enablement to **pod label** or **namespace label** only -- removes workload inheritance (Deployment, DaemonSet, StatefulSet)
- Split MutatingWebhookConfiguration into two entries:
  - **Namespace-scoped**: matches namespaces with `getkloak.io/enabled=true`
  - **Pod-scoped**: matches pods with `getkloak.io/enabled=true` label via `objectSelector`
- Non-kloak workloads are never sent to the webhook, so they are unaffected when kloak is down
- Webhook now **rejects** pods when the shadow secret doesn't exist (fail-closed), preventing real secrets from being mounted if the controller hasn't reconciled yet
- Both entries use `failurePolicy: Fail`

## Breaking changes
- Pod enablement now requires a **label** (not annotation). Update pod templates from `annotations:` to `labels:` for `getkloak.io/enabled`
- Workload-level inheritance (Deployment/DaemonSet/StatefulSet labels) is no longer supported. Use pod template labels or namespace labels instead.

## Test plan
- [x] `go test -v ./pkg/webhook/` -- all 20 tests pass
- [x] `helm template` renders both webhook entries correctly
- [ ] Deploy to test cluster and verify:
  - Non-kloak namespace pods start normally when webhook is down
  - Kloak-enabled pods are rejected when shadow secret is missing
  - Kloak-enabled pods succeed after controller creates shadow secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)