### PR TITLE
feat: Add collision check when taking in new secrets

### DIFF
--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -169,7 +169,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Recalculate all mappings, then clear old ones and store the new ones.
 	// Delete-before-store removes stale keys (e.g. a key removed from the original secret)
-	// while UUIDs are reused where possible to keep shadow values stable.
+	// while ULIDs are reused where possible to keep shadow values stable.
 
 	// Fetch all existing shadows from storage once for collision detection
 	// This avoids O(N×M) complexity from calling List() for each key

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -310,7 +310,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // checkCollisions checks if a shadow value's 8-byte BPF prefix collides with any existing
 // shadow values in storage (excluding shadows from the current secret being reconciled).
 // Returns true if a collision is detected.
-func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow string, excludeSecretID string) (bool, error) {
+func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow, excludeSecretID string) (bool, error) {
 	if len(newShadow) < ShadowPrefixLen {
 		return false, fmt.Errorf("shadow secret too short")
 	}

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -154,7 +154,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 	}
 
-	// Fetch existing shadow secret to preserve UUIDs if possible
+	// Fetch existing shadow secret to preserve ULIDs if possible
 	var existingShadow corev1.Secret
 	shadowExists := false
 	if err := r.Get(ctx, shadowNamespacedName, &existingShadow); err == nil {

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -330,10 +330,6 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // shadow values in the provided prefix map (excluding shadows from the current secret being reconciled).
 // Returns true if a collision is detected.
 func checkCollisionsWithMap(newShadow, excludeSecretID string, existingPrefixMap map[string]map[string]struct{}) bool {
-	if len(newShadow) < ShadowPrefixLen {
-		return false
-	}
-
 	newPrefix := newShadow[:ShadowPrefixLen]
 
 	// Check if this prefix is used by other secrets

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -41,6 +41,10 @@ const (
 	// ValuePrefix is the prefix for generated UUID values.
 	// Must match what the eBPF program expects.
 	ValuePrefix = "kloak:"
+
+	// ShadowPrefixLen is the length of the prefix used for BPF map key collision detection.
+	// The BPF program uses the first 8 bytes as the lookup key.
+	ShadowPrefixLen = 8
 )
 
 type PortSpec struct {
@@ -135,6 +139,21 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// 4. Reconcile Shadow Secret
 	log.Info("Reconciling enabled secret")
 
+	// Validate secret length: eBPF requires at least ShadowPrefixLen bytes for the BPF key lookup
+	// Short secrets cannot be processed correctly by eBPF and are not supported
+	for key, originalBytes := range secret.Data {
+		originalLen := len(originalBytes)
+		if originalLen < ShadowPrefixLen {
+			log.Info("Skipping secret with value too short for eBPF (minimum ShadowPrefixLen bytes required)",
+				"secret", req.String(),
+				"key", key,
+				"length", originalLen,
+				"minimumRequired", ShadowPrefixLen)
+			// Return early without creating shadow secret
+			return ctrl.Result{}, nil
+		}
+	}
+
 	// Fetch existing shadow secret to preserve UUIDs if possible
 	var existingShadow corev1.Secret
 	shadowExists := false
@@ -152,7 +171,9 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Delete-before-store removes stale keys (e.g. a key removed from the original secret)
 	// while UUIDs are reused where possible to keep shadow values stable.
 
-	newMappings := make(map[string]string) // uuid -> original
+	// Track all shadows in this batch to detect intra-secret collisions
+	var shadowsInBatch []string
+	newMappings := make(map[string]string) // shadow -> original
 
 	for key, originalBytes := range secret.Data {
 		originalValue := string(originalBytes)
@@ -163,19 +184,35 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if shadowExists && len(existingShadow.Data[key]) > 0 {
 			existingVal := string(existingShadow.Data[key])
 			if strings.HasPrefix(existingVal, ValuePrefix) {
-				// Strip padding if necessary to compare/reuse the true UUID part
-				// For now, let's just use the exact existing padded string if lengths match
+				// Check if existing shadow collides with other secrets
 				if len(existingVal) == originalLen {
-					shadowValue = existingVal
+					hasCollision, err := r.checkCollisions(ctx, existingVal)
+					if err != nil {
+						log.Error(err, "failed to check existing shadow for collisions, regenerating",
+							"key", key)
+					} else if !hasCollision {
+						// Check it doesn't collide with other keys in this same secret
+						if prefix := existingVal[:ShadowPrefixLen]; !isPrefixUsed(shadowsInBatch, prefix) {
+							shadowValue = existingVal
+						}
+					}
 				}
 			}
 		}
 
-		// Generate new if needed or if length mismatch
+		// Generate new if needed or if length mismatch or collision detected
 		if shadowValue == "" {
-			shadowValue = generateShadowValue(originalLen, originalValue)
+			var err error
+			shadowValue, err = r.generateShadowValueWithCollisionCheck(
+				ctx, originalLen, originalValue, 3,
+			)
+			if err != nil {
+				return ctrl.Result{}, fmt.Errorf("failed to generate shadow value for key %s: %w", key, err)
+			}
 		}
 
+		// Track this shadow to detect collisions with other keys in same secret
+		shadowsInBatch = append(shadowsInBatch, shadowValue)
 		newData[key] = []byte(shadowValue)
 		newMappings[shadowValue] = originalValue
 	}
@@ -267,6 +304,76 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// checkCollisions checks if a shadow value's 8-byte BPF prefix collides with any existing
+// shadow values in storage. Returns true if a collision is detected.
+func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow string) (bool, error) {
+	if len(newShadow) < ShadowPrefixLen {
+		return false, fmt.Errorf("shadow secret too short")
+	}
+
+	newPrefix := newShadow[:ShadowPrefixLen]
+
+	allSecrets, err := r.Storage.List(ctx)
+	if err != nil {
+		return false, fmt.Errorf("list storage: %w", err)
+	}
+
+	for existingShadow := range allSecrets {
+		if len(existingShadow) < ShadowPrefixLen {
+			// Skip shadows shorter than 8 bytes (shouldn't happen post-fix, but handle defensively)
+			continue
+		}
+		existingPrefix := existingShadow[:ShadowPrefixLen]
+		if existingPrefix == newPrefix {
+			r.Log.V(2).Info("8-byte BPF key collision detected",
+				"newShadow", newShadow,
+				"existingShadow", existingShadow,
+				"collisionPrefix", newPrefix)
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// generateShadowValueWithCollisionCheck creates a shadow value and ensures no 8-byte prefix collision
+// with existing secrets. It retries generation up to maxRetries times if collisions are detected.
+func (r *SecretReconciler) generateShadowValueWithCollisionCheck(
+	ctx context.Context,
+	originalLen int,
+	realSecret string,
+	maxRetries int,
+) (string, error) {
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		shadow := generateShadowValue(originalLen, realSecret)
+
+		hasCollision, err := r.checkCollisions(ctx, shadow)
+		if err != nil {
+			return "", fmt.Errorf("collision check failed: %w", err)
+		}
+
+		if !hasCollision {
+			return shadow, nil
+		}
+
+		r.Log.V(2).Info("8-byte BPF key collision detected, regenerating",
+			"attempt", attempt+1, "maxRetries", maxRetries,
+			"prefix", shadow[:ShadowPrefixLen])
+	}
+
+	return "", fmt.Errorf("failed to generate unique shadow value after %d attempts", maxRetries)
+}
+
+// isPrefixUsed checks if a prefix is already used in the given shadows.
+func isPrefixUsed(shadows []string, prefix string) bool {
+	for _, shadow := range shadows {
+		if len(shadow) >= ShadowPrefixLen && shadow[:ShadowPrefixLen] == prefix {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -171,6 +171,29 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Delete-before-store removes stale keys (e.g. a key removed from the original secret)
 	// while UUIDs are reused where possible to keep shadow values stable.
 
+	// Fetch all existing shadows from storage once for collision detection
+	// This avoids O(N×M) complexity from calling List() for each key
+	allEntries, err := r.Storage.List(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to list storage: %w", err)
+	}
+
+	// Build a map of existing shadow prefixes to detect collisions with other secrets
+	// Key: 8-byte prefix, Value: set of ownerIDs that use this prefix
+	existingPrefixMap := make(map[string]map[string]struct{})
+	for shadow := range allEntries {
+		if len(shadow) >= ShadowPrefixLen {
+			prefix := shadow[:ShadowPrefixLen]
+			ownerID, found, _ := r.Storage.GetOwnerID(ctx, shadow)
+			if found {
+				if existingPrefixMap[prefix] == nil {
+					existingPrefixMap[prefix] = make(map[string]struct{})
+				}
+				existingPrefixMap[prefix][ownerID] = struct{}{}
+			}
+		}
+	}
+
 	// Track all shadows in this batch to detect intra-secret collisions
 	var shadowsInBatch []string
 	newMappings := make(map[string]string) // shadow -> original
@@ -187,11 +210,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 				// Check if existing shadow collides with other secrets
 				// Pass secretID to exclude shadows from the current secret
 				if len(existingVal) == originalLen {
-					hasCollision, err := r.checkCollisions(ctx, existingVal, secretID)
-					if err != nil {
-						log.Error(err, "failed to check existing shadow for collisions, regenerating",
-							"key", key)
-					} else if !hasCollision {
+					if !checkCollisionsWithMap(existingVal, secretID, existingPrefixMap) {
 						// Check it doesn't collide with other keys in this same secret
 						if prefix := existingVal[:ShadowPrefixLen]; !isPrefixUsed(shadowsInBatch, prefix) {
 							shadowValue = existingVal
@@ -205,7 +224,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if shadowValue == "" {
 			var err error
 			shadowValue, err = r.generateShadowValueWithCollisionCheck(
-				ctx, originalLen, originalValue, secretID, 3,
+				originalLen, originalValue, secretID, 3, existingPrefixMap,
 			)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to generate shadow value for key %s: %w", key, err)
@@ -307,71 +326,50 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, nil
 }
 
-// checkCollisions checks if a shadow value's 8-byte BPF prefix collides with any existing
-// shadow values in storage (excluding shadows from the current secret being reconciled).
+// checkCollisionsWithMap checks if a shadow value's 8-byte BPF prefix collides with any existing
+// shadow values in the provided prefix map (excluding shadows from the current secret being reconciled).
 // Returns true if a collision is detected.
-func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow, excludeSecretID string) (bool, error) {
+func checkCollisionsWithMap(newShadow, excludeSecretID string, existingPrefixMap map[string]map[string]struct{}) bool {
 	if len(newShadow) < ShadowPrefixLen {
-		return false, fmt.Errorf("shadow secret too short")
+		return false
 	}
 
 	newPrefix := newShadow[:ShadowPrefixLen]
 
-	allEntries, err := r.Storage.List(ctx)
-	if err != nil {
-		return false, fmt.Errorf("list storage: %w", err)
-	}
-
-	for existingShadow := range allEntries {
-		if len(existingShadow) < ShadowPrefixLen {
-			// Skip shadows shorter than 8 bytes (shouldn't happen post-fix, but handle defensively)
-			continue
-		}
-		// Check if this shadow belongs to the current secret being reconciled
-		if excludeSecretID != "" {
-			if ownerID, found, _ := r.Storage.GetOwnerID(ctx, existingShadow); found && ownerID == excludeSecretID {
-				// This shadow belongs to the current secret, exclude it from collision check
-				continue
+	// Check if this prefix is used by other secrets
+	if owners, exists := existingPrefixMap[newPrefix]; exists {
+		for ownerID := range owners {
+			if ownerID != excludeSecretID {
+				// Collision with a different secret
+				return true
 			}
 		}
-		existingPrefix := existingShadow[:ShadowPrefixLen]
-		if existingPrefix == newPrefix {
-			r.Log.V(2).Info("8-byte BPF key collision detected",
-				"newShadow", newShadow,
-				"existingShadow", existingShadow,
-				"collisionPrefix", newPrefix)
-			return true, nil
-		}
 	}
 
-	return false, nil
+	return false
 }
 
 // generateShadowValueWithCollisionCheck creates a shadow value and ensures no 8-byte prefix collision
 // with existing secrets (excluding shadows from the current secret being reconciled).
 // It retries generation up to maxRetries times if collisions are detected.
 func (r *SecretReconciler) generateShadowValueWithCollisionCheck(
-	ctx context.Context,
 	originalLen int,
 	realSecret string,
 	excludeSecretID string,
 	maxRetries int,
+	existingPrefixMap map[string]map[string]struct{},
 ) (string, error) {
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		shadow := generateShadowValue(originalLen, realSecret)
 
-		hasCollision, err := r.checkCollisions(ctx, shadow, excludeSecretID)
-		if err != nil {
-			return "", fmt.Errorf("collision check failed: %w", err)
+		if checkCollisionsWithMap(shadow, excludeSecretID, existingPrefixMap) {
+			r.Log.V(2).Info("8-byte BPF key collision detected, regenerating",
+				"attempt", attempt+1, "maxRetries", maxRetries,
+				"prefix", shadow[:ShadowPrefixLen])
+			continue
 		}
 
-		if !hasCollision {
-			return shadow, nil
-		}
-
-		r.Log.V(2).Info("8-byte BPF key collision detected, regenerating",
-			"attempt", attempt+1, "maxRetries", maxRetries,
-			"prefix", shadow[:ShadowPrefixLen])
+		return shadow, nil
 	}
 
 	return "", fmt.Errorf("failed to generate unique shadow value after %d attempts", maxRetries)

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -185,8 +185,9 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			existingVal := string(existingShadow.Data[key])
 			if strings.HasPrefix(existingVal, ValuePrefix) {
 				// Check if existing shadow collides with other secrets
+				// Pass secretID to exclude shadows from the current secret
 				if len(existingVal) == originalLen {
-					hasCollision, err := r.checkCollisions(ctx, existingVal)
+					hasCollision, err := r.checkCollisions(ctx, existingVal, secretID)
 					if err != nil {
 						log.Error(err, "failed to check existing shadow for collisions, regenerating",
 							"key", key)
@@ -204,7 +205,7 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if shadowValue == "" {
 			var err error
 			shadowValue, err = r.generateShadowValueWithCollisionCheck(
-				ctx, originalLen, originalValue, 3,
+				ctx, originalLen, originalValue, secretID, 3,
 			)
 			if err != nil {
 				return ctrl.Result{}, fmt.Errorf("failed to generate shadow value for key %s: %w", key, err)
@@ -307,23 +308,31 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 }
 
 // checkCollisions checks if a shadow value's 8-byte BPF prefix collides with any existing
-// shadow values in storage. Returns true if a collision is detected.
-func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow string) (bool, error) {
+// shadow values in storage (excluding shadows from the current secret being reconciled).
+// Returns true if a collision is detected.
+func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow string, excludeSecretID string) (bool, error) {
 	if len(newShadow) < ShadowPrefixLen {
 		return false, fmt.Errorf("shadow secret too short")
 	}
 
 	newPrefix := newShadow[:ShadowPrefixLen]
 
-	allSecrets, err := r.Storage.List(ctx)
+	allEntries, err := r.Storage.List(ctx)
 	if err != nil {
 		return false, fmt.Errorf("list storage: %w", err)
 	}
 
-	for existingShadow := range allSecrets {
+	for existingShadow := range allEntries {
 		if len(existingShadow) < ShadowPrefixLen {
 			// Skip shadows shorter than 8 bytes (shouldn't happen post-fix, but handle defensively)
 			continue
+		}
+		// Check if this shadow belongs to the current secret being reconciled
+		if excludeSecretID != "" {
+			if ownerID, found, _ := r.Storage.GetOwnerID(ctx, existingShadow); found && ownerID == excludeSecretID {
+				// This shadow belongs to the current secret, exclude it from collision check
+				continue
+			}
 		}
 		existingPrefix := existingShadow[:ShadowPrefixLen]
 		if existingPrefix == newPrefix {
@@ -339,17 +348,19 @@ func (r *SecretReconciler) checkCollisions(ctx context.Context, newShadow string
 }
 
 // generateShadowValueWithCollisionCheck creates a shadow value and ensures no 8-byte prefix collision
-// with existing secrets. It retries generation up to maxRetries times if collisions are detected.
+// with existing secrets (excluding shadows from the current secret being reconciled).
+// It retries generation up to maxRetries times if collisions are detected.
 func (r *SecretReconciler) generateShadowValueWithCollisionCheck(
 	ctx context.Context,
 	originalLen int,
 	realSecret string,
+	excludeSecretID string,
 	maxRetries int,
 ) (string, error) {
 	for attempt := 0; attempt < maxRetries; attempt++ {
 		shadow := generateShadowValue(originalLen, realSecret)
 
-		hasCollision, err := r.checkCollisions(ctx, shadow)
+		hasCollision, err := r.checkCollisions(ctx, shadow, excludeSecretID)
 		if err != nil {
 			return "", fmt.Errorf("collision check failed: %w", err)
 		}

--- a/pkg/controller/secret_reconciler_test.go
+++ b/pkg/controller/secret_reconciler_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -306,6 +307,8 @@ func TestSecretReconciler_MultipleKeys(t *testing.T) {
 }
 
 func TestSecretReconciler_ShortSecret(t *testing.T) {
+	// Test that secrets shorter than ShadowPrefixLen (8 bytes) are skipped
+	// and no shadow secret is created
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "short-secret",
@@ -313,24 +316,24 @@ func TestSecretReconciler_ShortSecret(t *testing.T) {
 			Labels:    map[string]string{AnnotationSecretEnabled: "true"},
 			UID:       "short-uid",
 		},
-		Data: map[string][]byte{"key": []byte("abc")}, // shorter than "kloak:" prefix
+		Data: map[string][]byte{"key": []byte("abc")}, // shorter than ShadowPrefixLen
 	}
 
 	r, c := newSecretReconciler(secret)
 	ctx := context.Background()
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "short-secret", Namespace: "default"}}
 
+	// Should not error, but should skip processing
 	if _, err := r.Reconcile(ctx, req); err != nil {
 		t.Fatal(err)
 	}
 
+	// Shadow secret should not be created
 	shadow := &corev1.Secret{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "short-secret-kloak", Namespace: "default"}, shadow); err != nil {
-		t.Fatal(err)
-	}
-
-	if len(shadow.Data["key"]) != 3 {
-		t.Errorf("shadow length %d != 3", len(shadow.Data["key"]))
+	if err := c.Get(ctx, types.NamespacedName{Name: "short-secret-kloak", Namespace: "default"}, shadow); err == nil {
+		t.Error("expected no shadow secret for short secret, but got one")
+	} else if !errors.IsNotFound(err) {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -11,37 +11,37 @@ type Memory struct {
 	mu sync.RWMutex
 	// hashToEntry maps hash → Entry
 	hashToEntry map[string]Entry
-	// podToHashes maps podID → set of hashes
-	podToHashes map[string]map[string]struct{}
-	// hashToPod maps hash → podID (for reverse lookup)
-	hashToPod map[string]string
+	// ownerToHashes maps ownerID → set of hashes
+	ownerToHashes map[string]map[string]struct{}
+	// hashToOwner maps hash → ownerID (for reverse lookup)
+	hashToOwner map[string]string
 }
 
 // NewMemory creates a new in-memory storage.
 func NewMemory() *Memory {
 	return &Memory{
-		hashToEntry: make(map[string]Entry),
-		podToHashes: make(map[string]map[string]struct{}),
-		hashToPod:   make(map[string]string),
+		hashToEntry:   make(map[string]Entry),
+		ownerToHashes: make(map[string]map[string]struct{}),
+		hashToOwner:   make(map[string]string),
 	}
 }
 
-// Store saves a hash→Entry mapping for a pod.
-func (m *Memory) Store(ctx context.Context, podID, hash string, entry Entry) error {
+// Store saves a hash→Entry mapping for an owner.
+func (m *Memory) Store(ctx context.Context, ownerID, hash string, entry Entry) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	// Store hash → Entry
 	m.hashToEntry[hash] = entry
 
-	// Track hash → pod relationship
-	m.hashToPod[hash] = podID
+	// Track hash → owner relationship
+	m.hashToOwner[hash] = ownerID
 
-	// Track pod → hashes relationship
-	if m.podToHashes[podID] == nil {
-		m.podToHashes[podID] = make(map[string]struct{})
+	// Track owner → hashes relationship
+	if m.ownerToHashes[ownerID] == nil {
+		m.ownerToHashes[ownerID] = make(map[string]struct{})
 	}
-	m.podToHashes[podID][hash] = struct{}{}
+	m.ownerToHashes[ownerID][hash] = struct{}{}
 
 	return nil
 }
@@ -55,13 +55,13 @@ func (m *Memory) Lookup(ctx context.Context, hash string) (Entry, bool, error) {
 	return entry, found, nil
 }
 
-// Delete removes all mappings for a pod.
-func (m *Memory) Delete(ctx context.Context, podID string) error {
+// Delete removes all mappings for an owner.
+func (m *Memory) Delete(ctx context.Context, ownerID string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	// Get all hashes for this pod
-	hashes, exists := m.podToHashes[podID]
+	// Get all hashes for this owner
+	hashes, exists := m.ownerToHashes[ownerID]
 	if !exists {
 		return nil
 	}
@@ -69,11 +69,11 @@ func (m *Memory) Delete(ctx context.Context, podID string) error {
 	// Remove each hash
 	for hash := range hashes {
 		delete(m.hashToEntry, hash)
-		delete(m.hashToPod, hash)
+		delete(m.hashToOwner, hash)
 	}
 
-	// Remove pod tracking
-	delete(m.podToHashes, podID)
+	// Remove owner tracking
+	delete(m.ownerToHashes, ownerID)
 
 	return nil
 }
@@ -89,6 +89,15 @@ func (m *Memory) List(ctx context.Context) (map[string]Entry, error) {
 		result[k] = v
 	}
 	return result, nil
+}
+
+// GetOwnerID returns the ownerID associated with a hash.
+func (m *Memory) GetOwnerID(ctx context.Context, hash string) (string, bool, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	ownerID, found := m.hashToOwner[hash]
+	return ownerID, found, nil
 }
 
 // Compile-time check that Memory implements Storage

--- a/pkg/storage/memory.go
+++ b/pkg/storage/memory.go
@@ -92,11 +92,11 @@ func (m *Memory) List(ctx context.Context) (map[string]Entry, error) {
 }
 
 // GetOwnerID returns the ownerID associated with a hash.
-func (m *Memory) GetOwnerID(ctx context.Context, hash string) (string, bool, error) {
+func (m *Memory) GetOwnerID(ctx context.Context, hash string) (ownerID string, found bool, err error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
-	ownerID, found := m.hashToOwner[hash]
+	ownerID, found = m.hashToOwner[hash]
 	return ownerID, found, nil
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -17,18 +17,21 @@ type Entry struct {
 // Storage defines the interface for hash-to-value storage.
 // Implementations can be in-memory, etcd, Redis, Vault, etc.
 type Storage interface {
-	// Store saves a hash→Entry mapping for a pod.
-	// If the hash already exists, it updates the entry.
-	Store(ctx context.Context, podID, hash string, entry Entry) error
+	// Store saves a hash→Entry mapping. The ownerID identifies what owns this shadow
+	// (e.g., a secret namespace/name). If the hash already exists, it updates the entry.
+	Store(ctx context.Context, ownerID, hash string, entry Entry) error
 
 	// Lookup retrieves the original entry for a hash.
 	// Returns the entry, whether it was found, and any error.
 	Lookup(ctx context.Context, hash string) (Entry, bool, error)
 
-	// Delete removes all mappings for a pod.
-	Delete(ctx context.Context, podID string) error
+	// Delete removes all mappings for an owner.
+	Delete(ctx context.Context, ownerID string) error
 
 	// List returns all hash→Entry mappings.
 	// Used for syncing to eBPF maps.
 	List(ctx context.Context) (map[string]Entry, error)
+
+	// GetOwnerID returns the ownerID associated with a hash, if any.
+	GetOwnerID(ctx context.Context, hash string) (string, bool, error)
 }

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -29,12 +29,29 @@ func TestShadowSecretMultipleKeys(t *testing.T) {
 
 func TestShadowSecretLengthMatching(t *testing.T) {
 	data := map[string][]byte{
-		"short":  []byte("abcde"),
+		"short":  []byte("abcdefgh"),
 		"medium": []byte("this-is-a-medium-length-secret-value-here!x"),
 		"long":   []byte(strings.Repeat("x", 200)),
 	}
 	createEnabledSecret(t, "test-shadow-lengths", data, nil)
 	assertShadowSecret(t, "test-shadow-lengths", data)
+}
+
+func TestShadowSecretLengthTooShort(t *testing.T) {
+	data := map[string][]byte{
+		"short": []byte("abcdefg"),
+	}
+	createEnabledSecret(t, "test-shadow-lengths", data, nil)
+
+	// Poll briefly and verify no shadow is created.
+	// Use a short timeout — if the shadow doesn't appear in 10s, it won't.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	err := waitForSecret(ctx, testNamespace, "test-no-shadow-kloak")
+	if err == nil {
+		t.Fatal("shadow secret should NOT exist for non-enabled secret")
+	}
+	// Expected: timeout (no shadow created) — that's the passing case
 }
 
 func TestShadowSecretUpdate(t *testing.T) {


### PR DESCRIPTION
This PR adds a collision check when syncing secrets. Because the key in eBPF is the first 8 bytes of the prefix, and the first 6 are fixed, the risk of collision is very high at the moment. It gives only 2 unique bytes to differentiate secrets, that need to be printable characters. That leaves around 16k unique possibilities. When the amount of secrets managed by Kloak grows, the chance of a collision grows as well.

With this PR, we detect collisions and attempt to create a new shadow secret to solve the collision. In any case, we do not allow a new shadow secret to be reconciled when it creates a collision, as it would break existing secrets already in use.