### PR TITLE
ci: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - dhiaayachi
+      - spinningfactory/core
     labels:
       - dependencies
     open-pull-requests-limit: 10
@@ -17,7 +17,7 @@ updates:
     schedule:
       interval: weekly
     reviewers:
-      - dhiaayachi
+      - spinningfactory/core
     labels:
       - dependencies
       - ci
@@ -28,6 +28,6 @@ updates:
     schedule:
       interval: monthly
     reviewers:
-      - dhiaayachi
+      - spinningfactory/core
     labels:
       - dependencies

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - dhiaayachi
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    reviewers:
+      - dhiaayachi
+    labels:
+      - dependencies
+      - ci
+
+  # Docker (Dockerfile base images)
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    reviewers:
+      - dhiaayachi
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary
Add Dependabot to automatically create PRs for dependency updates.

| Ecosystem | Schedule | Scope |
|-----------|----------|-------|
| Go modules | Weekly | All direct/indirect deps (cilium/ebpf, controller-runtime, etc.) |
| GitHub Actions | Weekly | Action versions in workflows |
| Docker | Monthly | Base images in Dockerfile (golang, alpine) |

## Test plan
- [ ] Merge and verify Dependabot opens PRs within 24 hours

🤖 Generated with [Claude Code](https://claude.com/claude-code)