### PR TITLE
Downgrade tc egress error to debug when process already exited

### DIFF
--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -566,7 +566,11 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 		// Attach tc egress to the container's eth0 for kernel-only ciphertext
 		// patching. Required for secret rewriting.
 		if err := m.attachTCEgress(pid); err != nil {
-			m.log.Errorw("Failed to attach tc egress to container — secrets will not be rewritten", "error", err, "pid", pid)
+			if errors.Is(err, os.ErrNotExist) {
+				m.log.Debugw("Process exited before tc egress could attach", "error", err, "pid", pid)
+			} else {
+				m.log.Errorw("Failed to attach tc egress to container — secrets will not be rewritten", "error", err, "pid", pid)
+			}
 		}
 
 		return nil


### PR DESCRIPTION
## Summary

- When a short-lived process (init container, crash-looping pod) exits before the controller can attach TC egress, the `/proc/<pid>/ns/net` path no longer exists
- Previously this logged as an error, which is noisy and expected for ephemeral processes
- Now checks for `os.ErrNotExist` and logs at debug level instead

## Test plan

- [ ] Deploy Kloak on a cluster with init containers and verify no error-level logs for exited processes
- [ ] Verify genuine TC egress failures (e.g., permission errors) still log at error level

🤖 Generated with [Claude Code](https://claude.com/claude-code)