### PR TITLE
fix: support non-FIPS Go binaries for TLS H extraction

### DIFF
--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -232,6 +232,22 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 		}
 	}
 
+	// Go 1.25+ non-FIPS, hardware AES: crypto/aes.gcmAsm.productTable
+	if !foundPD {
+		if pt, ok := getField(structFields, "crypto/aes.gcmAsm", "productTable"); ok {
+			pdBase = pt + 224
+			foundPD = true
+		}
+	}
+
+	// Go 1.25+ non-FIPS, software AES: crypto/cipher.gcm.productTable
+	if !foundPD {
+		if pt, ok := getField(structFields, "crypto/cipher.gcm", "productTable"); ok {
+			pdBase = pt + 224
+			foundPD = true
+		}
+	}
+
 	if foundPD {
 		// Determine target architecture from the ELF binary.
 		goarch := ""
@@ -277,6 +293,8 @@ func isGoTLSTargetStruct(name string) bool {
 		"crypto/tls.prefixNonceAEAD",
 		"crypto/tls.xorNonceAEAD",
 		"crypto/cipher.gcmAES",
+		"crypto/aes.gcmAsm",
+		"crypto/cipher.gcm",
 		"crypto/internal/fips140/aes/gcm.GCM",
 		"crypto/internal/fips140/aes/gcm.gcmPlatformData",
 	}

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -81,15 +81,20 @@ func goTLSOffsetsForArch(entry goTLSOffsetEntry, goarch string) GoTLSOffsets {
 
 // DetectGoTLSOffsets reads a Go binary and returns the struct offsets needed
 // for H extraction. Tries DWARF first, then falls back to version-based lookup.
-func DetectGoTLSOffsets(exePath string) (version string, offsets GoTLSOffsets, err error) {
+// The source return indicates how offsets were obtained ("dwarf" or "version-table").
+func DetectGoTLSOffsets(exePath string) (version string, offsets GoTLSOffsets, source string, err error) {
 	// Try DWARF-based detection first.
 	version, offsets, err = detectGoTLSFromDWARF(exePath)
 	if err == nil {
-		return version, offsets, nil
+		return version, offsets, "dwarf", nil
 	}
 
 	// Fall back to buildinfo version lookup.
-	return detectGoTLSByVersion(exePath)
+	version, offsets, err = detectGoTLSByVersion(exePath)
+	if err != nil {
+		return "", GoTLSOffsets{}, "", err
+	}
+	return version, offsets, "version-table", nil
 }
 
 func detectGoTLSByVersion(exePath string) (string, GoTLSOffsets, error) {
@@ -216,18 +221,21 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 	// The two 64-bit words are in different order on AMD64 vs ARM64.
 	pdBase, foundPD := uint32(0), false
 
+	// H×2 is stored at entry 14 within productTable (each entry is 16 bytes).
+	const h2ProductTableOffset = 224
+
 	// Go 1.24+: GCM.gcmPlatformData → gcmPlatformData.productTable
 	gcmPD, okPD := getField(structFields, "crypto/internal/fips140/aes/gcm.GCM", "gcmPlatformData")
 	pdPT, okPT := getField(structFields, "crypto/internal/fips140/aes/gcm.gcmPlatformData", "productTable")
 	if okPD && okPT {
-		pdBase = gcmPD + pdPT + 224 // H×2 at entry 14 (offset 224 within productTable)
+		pdBase = gcmPD + pdPT + h2ProductTableOffset
 		foundPD = true
 	}
 
 	// Go <1.24: crypto/cipher.gcmAES.productTable
 	if !foundPD {
 		if pt, ok := getField(structFields, "crypto/cipher.gcmAES", "productTable"); ok {
-			pdBase = pt + 224
+			pdBase = pt + h2ProductTableOffset
 			foundPD = true
 		}
 	}
@@ -235,7 +243,7 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 	// Go 1.25+ non-FIPS, hardware AES: crypto/aes.gcmAsm.productTable
 	if !foundPD {
 		if pt, ok := getField(structFields, "crypto/aes.gcmAsm", "productTable"); ok {
-			pdBase = pt + 224
+			pdBase = pt + h2ProductTableOffset
 			foundPD = true
 		}
 	}
@@ -243,7 +251,7 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 	// Go 1.25+ non-FIPS, software AES: crypto/cipher.gcm.productTable
 	if !foundPD {
 		if pt, ok := getField(structFields, "crypto/cipher.gcm", "productTable"); ok {
-			pdBase = pt + 224
+			pdBase = pt + h2ProductTableOffset
 			foundPD = true
 		}
 	}

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -617,19 +617,13 @@ func (m *TLSUprobeManager) pushGoTLSOffsets(pid int) {
 	exePath := fmt.Sprintf("/proc/%d/exe", pid)
 
 	// DetectGoTLSOffsets tries DWARF first, then falls back to version-based lookup.
-	version, offsets, err := DetectGoTLSOffsets(exePath)
+	version, offsets, source, err := DetectGoTLSOffsets(exePath)
 	if err != nil {
 		m.log.Errorw("Go TLS offset detection failed — Go secrets will NOT be rewritten", "error", err, "pid", pid)
 		return
 	}
 
-	// Detect if DWARF was available by trying it separately. If DWARF fails,
-	// we're using the version-based fallback which only has FIPS offsets.
-	// Non-FIPS binaries with stripped DWARF will get wrong offsets silently.
-	_, _, dwarfErr := detectGoTLSFromDWARF(exePath)
-	source := "DWARF"
-	if dwarfErr != nil {
-		source = "version-table"
+	if source == "version-table" {
 		m.log.Warnw("Go TLS offsets from version table (DWARF unavailable) — assumes FIPS build; non-FIPS binaries may fail",
 			"pid", pid, "goVersion", version)
 	}

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -623,8 +623,19 @@ func (m *TLSUprobeManager) pushGoTLSOffsets(pid int) {
 		return
 	}
 
-	m.log.Debugw("Detected Go TLS offsets",
-		"pid", pid, "goVersion", version,
+	// Detect if DWARF was available by trying it separately. If DWARF fails,
+	// we're using the version-based fallback which only has FIPS offsets.
+	// Non-FIPS binaries with stripped DWARF will get wrong offsets silently.
+	_, _, dwarfErr := detectGoTLSFromDWARF(exePath)
+	source := "DWARF"
+	if dwarfErr != nil {
+		source = "version-table"
+		m.log.Warnw("Go TLS offsets from version table (DWARF unavailable) — assumes FIPS build; non-FIPS binaries may fail",
+			"pid", pid, "goVersion", version)
+	}
+
+	m.log.Debugw("detected Go TLS offsets",
+		"pid", pid, "goVersion", version, "source", source,
 		"connToCipher", offsets.ConnToCipher,
 		"aeadIfaceOff", offsets.AEADIfaceOff,
 		"h2HiOff", offsets.H2HiOff,


### PR DESCRIPTION
## Problem

Go 1.25+ non-FIPS binaries use different internal structs for AES-GCM than FIPS builds. The DWARF offset detection only searches for FIPS module structs, causing H extraction to fail silently. Result: "bad record MAC" on every rewritten TLS record (issue #136, Scenario A).

## Root cause

DWARF detection searched for:
1. `crypto/internal/fips140/aes/gcm.GCM` → FIPS module (Go 1.24+)
2. `crypto/cipher.gcmAES` → Go <1.24

Non-FIPS Go 1.25 uses neither — it uses `crypto/aes.gcmAsm` (hardware AES) or `crypto/cipher.gcm` (software). H extraction returned wrong offsets → garbage GHASH tag.

## Fix

Add two additional DWARF search paths with detection priority:
1. FIPS: `crypto/internal/fips140/aes/gcm.GCM` → `gcmPlatformData.productTable`
2. Pre-1.24: `crypto/cipher.gcmAES` → `productTable`
3. **Non-FIPS HW: `crypto/aes.gcmAsm` → `productTable`** (new)
4. **Non-FIPS SW: `crypto/cipher.gcm` → `productTable`** (new)

Also adds a warning when the version-based fallback is used (stripped DWARF), since it only has FIPS offsets.

## Test plan
- [ ] Go 1.25 non-FIPS binary against TLS server — no "bad record MAC"
- [ ] Go 1.25 FIPS binary — existing path still works
- [ ] Stripped Go binary — warning logged, FIPS offsets used

Fixes #136 (Scenario A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)