### PR TITLE
feat: detect OpenSSL version from statically linked binaries (e.g., Node.js)

### DIFF
--- a/pkg/ebpf/openssl_offsets.go
+++ b/pkg/ebpf/openssl_offsets.go
@@ -68,7 +68,12 @@ var opensslOffsetTable = map[string]TLSOffsets{
 // The library is accessed via /proc/<pid>/root/<libPath> to reach into
 // the container's overlay filesystem.
 func DetectOpenSSLVersion(pid int, libPath string) (version string, offsets TLSOffsets, err error) {
-	hostPath := fmt.Sprintf("/proc/%d/root%s", pid, libPath)
+	// If libPath is already an absolute host path (e.g., /proc/PID/exe),
+	// use it directly. Otherwise, prefix with /proc/PID/root for container paths.
+	hostPath := libPath
+	if !strings.HasPrefix(libPath, "/proc/") {
+		hostPath = fmt.Sprintf("/proc/%d/root%s", pid, libPath)
+	}
 
 	f, err := elf.Open(hostPath)
 	if err != nil {

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -587,7 +587,9 @@ func (m *TLSUprobeManager) pushTLSOffsets(pid int, containerLibs []string) {
 	// Try shared libraries first, then the main executable.
 	// Statically linked OpenSSL (e.g., Node.js) won't have shared libs
 	// but the main exe contains the version string and uses the same offsets.
-	paths := append(containerLibs, fmt.Sprintf("/proc/%d/exe", pid))
+	paths := make([]string, len(containerLibs)+1)
+	copy(paths, containerLibs)
+	paths[len(containerLibs)] = fmt.Sprintf("/proc/%d/exe", pid)
 
 	for _, libPath := range paths {
 		version, offsets, err := DetectOpenSSLVersion(pid, libPath)

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -579,11 +579,17 @@ func (m *TLSUprobeManager) AttachTLS(pid int) error {
 	return fmt.Errorf("could not find compatible TLS symbols for PID %d", pid)
 }
 
-// pushTLSOffsets detects the OpenSSL version in the container's TLS libraries
-// and pushes struct offsets to the tls_offset_config BPF map. This enables the
-// XOR-patch path for TLS 1.3 AES-GCM connections.
+// pushTLSOffsets detects the OpenSSL version from the container's TLS libraries
+// or the main executable (for statically linked OpenSSL) and pushes struct
+// offsets to the tls_offset_config BPF map. This enables the XOR-patch path
+// for AES-GCM connections.
 func (m *TLSUprobeManager) pushTLSOffsets(pid int, containerLibs []string) {
-	for _, libPath := range containerLibs {
+	// Try shared libraries first, then the main executable.
+	// Statically linked OpenSSL (e.g., Node.js) won't have shared libs
+	// but the main exe contains the version string and uses the same offsets.
+	paths := append(containerLibs, fmt.Sprintf("/proc/%d/exe", pid))
+
+	for _, libPath := range paths {
 		version, offsets, err := DetectOpenSSLVersion(pid, libPath)
 		if err != nil {
 			m.log.Debugw("OpenSSL version detection skipped", "lib", libPath, "reason", err)


### PR DESCRIPTION
## Problem

Node.js statically links OpenSSL 3.5 into the main binary. Kloak attaches `SSL_write` uprobes successfully, but `pushTLSOffsets` only scans shared libraries from `/proc/pid/maps`. With no shared `libssl.so`, version detection fails, the XOR-patch path never activates, and secrets are never rewritten.

## Root cause

`pushTLSOffsets` iterated only `containerLibs` (shared TLS libraries). For statically linked OpenSSL, `containerLibs` is empty, so the loop body never executes.

## Fix

Always append `/proc/<pid>/exe` (the main executable) to the list of paths to scan for the OpenSSL version string. Shared libraries are tried first; the main exe is the fallback. First successful detection wins.

Also update `DetectOpenSSLVersion` to handle absolute host paths (like `/proc/pid/exe`) directly, instead of always prepending `/proc/pid/root`.

## Verified

The Node.js 24 binary from `openclaw` contains `OpenSSL 3.5.5` in its `.rodata` section:
```
$ strings /usr/local/bin/node | grep 'OpenSSL [0-9]'
OpenSSL 3.5.5 27 Jan 2026
```

OpenSSL 3.5 offsets are already in the offset table.

## Test plan
- [ ] Deploy to EKS cluster with openclaw Node.js app
- [ ] Verify controller logs: "Pushed TLS offsets for XOR-patch path" with version=3.5.5
- [ ] Verify secrets are rewritten (BPF counters: tc_patched > 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)