### PR TITLE
ci: use self-hosted k3s-ebpf-large runners for E2E tests

### DIFF
--- a/.github/runners/Dockerfile
+++ b/.github/runners/Dockerfile
@@ -1,0 +1,45 @@
+# Custom GitHub Actions runner image for kloak E2E tests.
+# Pre-installs all dependencies so CI jobs only need to:
+#   1. Generate eBPF bindings
+#   2. Start k3s (background, no systemd)
+#   3. Build + import images
+#   4. Run tests
+#
+# Build & push:
+#   docker build -t ghcr.io/spinningfactory/kloak-runner:latest .github/runners/
+#   docker push ghcr.io/spinningfactory/kloak-runner:latest
+#
+# Then update the ARC values to use this image instead of
+# ghcr.io/actions/actions-runner:latest.
+
+FROM ghcr.io/actions/actions-runner:latest
+
+USER root
+
+# ── System packages: eBPF toolchain + Docker + Helm ──
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      clang llvm libbpf-dev \
+      ca-certificates curl gnupg lsb-release \
+      make gcc git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CE (daemon + CLI)
+RUN curl -fsSL https://get.docker.com | sh \
+    && rm -rf /var/lib/apt/lists/*
+
+# Helm
+RUN curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+# ── Go ──
+ARG GO_VERSION=1.25.3
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# ── k3s binary (installed, not started — started at job runtime) ──
+RUN curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_ENABLE=true sh -
+
+# Pre-warm Go module cache for faster builds
+COPY go.mod go.sum /tmp/kloak/
+RUN cd /tmp/kloak && go mod download && rm -rf /tmp/kloak
+
+USER runner

--- a/.github/runners/Dockerfile
+++ b/.github/runners/Dockerfile
@@ -38,8 +38,4 @@ ENV PATH="/usr/local/go/bin:${PATH}"
 # ── k3s binary (installed, not started — started at job runtime) ──
 RUN curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_SKIP_ENABLE=true sh -
 
-# Pre-warm Go module cache for faster builds
-COPY go.mod go.sum /tmp/kloak/
-RUN cd /tmp/kloak && go mod download && rm -rf /tmp/kloak
-
 USER runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
 
       - name: Start Docker
         run: |
-          sudo dockerd --host=unix:///var/run/docker.sock &
+          sudo dockerd --dns 8.8.8.8 --dns 8.8.4.4 --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
             sudo docker info >/dev/null 2>&1 && break
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,12 +168,13 @@ jobs:
       - name: Install Docker
         run: |
           curl -fsSL https://get.docker.com | sudo sh
-          sudo systemctl start docker 2>/dev/null || sudo dockerd &
-          # Wait for Docker to be ready
+          # No systemd in container — start dockerd directly
+          sudo dockerd --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
-            docker info >/dev/null 2>&1 && break
+            sudo docker info >/dev/null 2>&1 && break
             sleep 1
           done
+          sudo docker info >/dev/null 2>&1 || { echo "Docker failed to start"; exit 1; }
 
       - name: Install clang and bpftool for eBPF
         run: |
@@ -186,7 +187,10 @@ jobs:
 
       - name: Install k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik --docker" sh -
+          # No systemd in container — install k3s without starting the service,
+          # then run the server directly in the background.
+          curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik --docker" sh -
+          sudo k3s server --write-kubeconfig-mode 644 --disable=traefik --docker &
           for i in $(seq 1 30); do
             sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
             echo "Waiting for k3s node to register ($i/30)..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,13 @@ jobs:
 
       - name: Start Docker
         run: |
-          sudo dockerd --dns 8.8.8.8 --dns 8.8.4.4 --host=unix:///var/run/docker.sock &
+          # Configure Docker daemon with external DNS before starting.
+          # k3s overwrites /etc/resolv.conf with CoreDNS (10.43.0.10) which
+          # is unreachable from Docker's build network. daemon.json ensures
+          # both containers and BuildKit use external DNS.
+          sudo mkdir -p /etc/docker
+          echo '{"dns": ["8.8.8.8", "8.8.4.4"]}' | sudo tee /etc/docker/daemon.json
+          sudo dockerd --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
             sudo docker info >/dev/null 2>&1 && break
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,7 +190,8 @@ jobs:
 
       - name: Start k3s and import images
         run: |
-          sudo k3s server --write-kubeconfig-mode 644 --disable=traefik &
+          # Use native snapshotter — overlayfs doesn't work nested inside a container.
+          sudo k3s server --write-kubeconfig-mode 644 --disable=traefik --snapshotter=native &
           for i in $(seq 1 30); do
             sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
             echo "Waiting for k3s node to register ($i/30)..."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
 
   e2e:
     name: E2E Tests
-    runs-on: ubuntu-latest
+    runs-on: k3s-ebpf-large
     if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'e2e')
     steps:
       - name: Checkout code
@@ -164,6 +164,16 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache: true
+
+      - name: Install Docker
+        run: |
+          curl -fsSL https://get.docker.com | sudo sh
+          sudo systemctl start docker 2>/dev/null || sudo dockerd &
+          # Wait for Docker to be ready
+          for i in $(seq 1 30); do
+            docker info >/dev/null 2>&1 && break
+            sleep 1
+          done
 
       - name: Install clang and bpftool for eBPF
         run: |
@@ -176,8 +186,7 @@ jobs:
 
       - name: Install k3s
         run: |
-          curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
-          # Wait for node to register before running kubectl wait
+          curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik --docker" sh -
           for i in $(seq 1 30); do
             sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
             echo "Waiting for k3s node to register ($i/30)..."
@@ -199,10 +208,7 @@ jobs:
           docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
           docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
           docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
-          docker save kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
-            kloak-demo-js:latest kloak-demo-go-boring:latest \
-            kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
-            kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
+          # k3s with --docker uses Docker as runtime; images are already available.
 
       - name: Install Helm
         uses: azure/setup-helm@v5
@@ -240,10 +246,3 @@ jobs:
           sudo dmesg | tail -50 2>/dev/null || true
           echo "=== BPF trace_pipe (buffered) ==="
           sudo timeout 2 cat /sys/kernel/tracing/trace_pipe 2>/dev/null | head -100 || true
-
-      - name: Stop k3s
-        if: always()
-        run: |
-          sudo /usr/local/bin/k3s-killall.sh 2>/dev/null || true
-          sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
-          rm -f ~/.kube/k3s-e2e.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,9 @@ jobs:
 
       - name: Start Docker
         run: |
-          sudo dockerd --host=unix:///var/run/docker.sock &
+          # Use vfs storage driver — the runner pod is on overlayfs (Kubernetes),
+          # and nested overlayfs (Docker BuildKit on top) fails with EINVAL.
+          sudo dockerd --storage-driver=vfs --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
             sudo docker info >/dev/null 2>&1 && break
             sleep 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,12 +164,6 @@ jobs:
 
       - name: Start Docker
         run: |
-          # Configure Docker daemon with external DNS before starting.
-          # k3s overwrites /etc/resolv.conf with CoreDNS (10.43.0.10) which
-          # is unreachable from Docker's build network. daemon.json ensures
-          # both containers and BuildKit use external DNS.
-          sudo mkdir -p /etc/docker
-          echo '{"dns": ["8.8.8.8", "8.8.4.4"]}' | sudo tee /etc/docker/daemon.json
           sudo dockerd --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
             sudo docker info >/dev/null 2>&1 && break
@@ -180,9 +174,21 @@ jobs:
       - name: Generate eBPF bindings
         run: KLOAK_TARGET_ARCH=x86 go generate ./pkg/ebpf/
 
-      - name: Start k3s
+      - name: Build images
         run: |
-          sudo k3s server --write-kubeconfig-mode 644 --disable=traefik --docker &
+          # Build BEFORE starting k3s — k3s networking breaks Docker DNS.
+          docker build --build-arg TARGETARCH=amd64 --build-arg COVER=1 -t kloak:e2e .
+          docker build -t kloak-demo-go:latest ./examples/demo-go/
+          docker build -t kloak-demo-python:latest ./examples/demo-python/
+          docker build -t kloak-demo-js:latest ./examples/demo-js/
+          docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
+          docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
+          docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
+          docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
+
+      - name: Start k3s and import images
+        run: |
+          sudo k3s server --write-kubeconfig-mode 644 --disable=traefik &
           for i in $(seq 1 30); do
             sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
             echo "Waiting for k3s node to register ($i/30)..."
@@ -193,18 +199,10 @@ jobs:
           sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-e2e.yaml
           sudo chown "$(id -u):$(id -g)" ~/.kube/k3s-e2e.yaml
           chmod 600 ~/.kube/k3s-e2e.yaml
-
-      - name: Build and import images into k3s
-        run: |
-          docker build --build-arg TARGETARCH=amd64 --build-arg COVER=1 -t kloak:e2e .
-          docker build -t kloak-demo-go:latest ./examples/demo-go/
-          docker build -t kloak-demo-python:latest ./examples/demo-python/
-          docker build -t kloak-demo-js:latest ./examples/demo-js/
-          docker build -t kloak-demo-go-boring:latest ./examples/demo-go-boring/
-          docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
-          docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
-          docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
-          # k3s with --docker uses Docker as runtime; images are already available.
+          docker save kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
+            kloak-demo-js:latest kloak-demo-go-boring:latest \
+            kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
+            kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
 
       - name: Run E2E tests (with eBPF)
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,16 +159,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Set up Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
+      # Go, Docker, clang, Helm, k3s are pre-installed in the runner image
+      # (ghcr.io/spinningfactory/kloak-runner). See .github/runners/Dockerfile.
 
-      - name: Install Docker
+      - name: Start Docker
         run: |
-          curl -fsSL https://get.docker.com | sudo sh
-          # No systemd in container — start dockerd directly
           sudo dockerd --host=unix:///var/run/docker.sock &
           for i in $(seq 1 30); do
             sudo docker info >/dev/null 2>&1 && break
@@ -176,20 +171,11 @@ jobs:
           done
           sudo docker info >/dev/null 2>&1 || { echo "Docker failed to start"; exit 1; }
 
-      - name: Install clang and bpftool for eBPF
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang llvm libbpf-dev
-          KVER="$(uname -r)" && sudo apt-get install -y linux-tools-common "linux-tools-${KVER}" 2>/dev/null || true
-
       - name: Generate eBPF bindings
         run: KLOAK_TARGET_ARCH=x86 go generate ./pkg/ebpf/
 
-      - name: Install k3s
+      - name: Start k3s
         run: |
-          # No systemd in container — install k3s without starting the service,
-          # then run the server directly in the background.
-          curl -sfL https://get.k3s.io | INSTALL_K3S_SKIP_START=true INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik --docker" sh -
           sudo k3s server --write-kubeconfig-mode 644 --disable=traefik --docker &
           for i in $(seq 1 30); do
             sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
@@ -213,9 +199,6 @@ jobs:
           docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
           docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
           # k3s with --docker uses Docker as runtime; images are already available.
-
-      - name: Install Helm
-        uses: azure/setup-helm@v5
 
       - name: Run E2E tests (with eBPF)
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/


### PR DESCRIPTION
## Summary
- Switch E2E tests from GitHub-hosted `ubuntu-latest` to self-hosted `k3s-ebpf-large` ARC runners
- Privileged pods with BPF/NET_ADMIN/SYS_ADMIN capabilities, mounted kernel headers and debugfs
- Install Docker and k3s inside the runner at job start; k3s uses `--docker` so built images are directly visible to pods
- Runner pod is ephemeral — no teardown needed

## Test plan
- [ ] Verify the `k3s-ebpf-large` runner picks up the job
- [ ] Verify Docker installs and starts correctly inside the runner
- [ ] Verify k3s starts and becomes ready
- [ ] Verify E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)