### PR TITLE
feat: Add IP-based filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,9 +192,9 @@ sequenceDiagram
 
 ## How It Works
 
-### 1. Label Your Secrets
+### 1. Label and Annotate Your Secrets
 
-Add `getkloak.io/enabled=true` to any Kubernetes Secret. Kloak generates a shadow secret with `kloak:<UUID>` placeholders that are length-matched to the original values.
+Add `getkloak.io/enabled=true` as a label to enable Kloak. Use annotations for host and port filtering. Kloak generates a shadow secret with `kloak:<UUID>` placeholders that are length-matched to the original values.
 
 ```yaml
 apiVersion: v1

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Kloak transparently intercepts outbound TLS traffic in Kubernetes using eBPF upr
 - **Secret isolation** -- Applications only see hashed shadow values (`kloak:<UUID>`). Real secrets exist solely in eBPF maps and are injected in-kernel at TLS write time.
 - **Zero overhead** -- eBPF uprobes operate in kernel space with negligible latency impact. No userspace proxy or sidecar in the data path.
 - **Kubernetes native** -- Works with standard Kubernetes Secrets. Enable with a single label.
-- **DNS-verified host filtering** -- Secrets annotated with `getkloak.io/hosts` are only sent to destinations verified through the DNS resolution chain, preventing exfiltration to unauthorized servers.
+- **Host and IP filtering** -- Secrets annotated with `getkloak.io/hosts` are only sent to specific destination hostnames or IP addresses, preventing exfiltration to unauthorized servers.
 - **Port-based filtering** -- Secrets annotated with `getkloak.io/port` are restricted to connections on a specific destination port.
 - **Broad runtime support** -- Hooks into OpenSSL, BoringSSL, and Go's native `crypto/tls`. Works with Python, Node.js, Go, Rust, Ruby, PHP, curl, and any OpenSSL-linked runtime.
 
@@ -57,7 +57,7 @@ kubectl get pods -n kloak-system
 | Key | Type | Scope | Description |
 |-----|------|-------|-------------|
 | `getkloak.io/enabled=true` | Label | Secret, Namespace, Pod | Enables Kloak for the target resource. On namespaces and pods, controls webhook scope. On secrets, triggers shadow secret creation. |
-| `getkloak.io/hosts=host1,host2` | Annotation | Secret | Restricts which destination hosts a secret can be sent to |
+| `getkloak.io/hosts=host` | Annotation | Secret | Restricts which destination host or IP address a secret can be sent to (single value only) |
 | `getkloak.io/port=443` | Annotation | Secret | Restricts which destination port a secret can be sent to |
 | `getkloak.io/managed=true` | Label | Secret | Marks shadow secrets created by Kloak (do not set manually) |
 

--- a/examples/setup-demo.sh
+++ b/examples/setup-demo.sh
@@ -211,7 +211,8 @@ deploy_demo() {
     kubectl create secret generic secret-allowed \
         --from-literal=api-key="REAL-ALLOWED-KEY-12345" \
         -n "$DEMO_NAMESPACE" --dry-run=client -o yaml | \
-        kubectl label -f - getkloak.io/enabled="true" getkloak.io/hosts="httpbin.org" --local -o yaml | \
+        kubectl label -f - getkloak.io/enabled="true" --local -o yaml | \
+        kubectl annotate -f - getkloak.io/hosts="httpbin.org" --local -o yaml | \
         kubectl apply -f -
     
     # Create SECRET for raw TLS demo: Allowed for tls.kloak-demo (short FQDN fits MAX_HOST_LEN=32)
@@ -219,7 +220,8 @@ deploy_demo() {
     kubectl create secret generic secret-rawtls-allowed \
         --from-literal=api-key="REAL-ALLOWED-KEY-12345" \
         -n "$DEMO_NAMESPACE" --dry-run=client -o yaml | \
-        kubectl label -f - getkloak.io/enabled="true" getkloak.io/hosts="tls.kloak-demo.svc.cluster.local" --local -o yaml | \
+        kubectl label -f - getkloak.io/enabled="true" --local -o yaml | \
+        kubectl annotate -f - getkloak.io/hosts="tls.kloak-demo.svc.cluster.local" --local -o yaml | \
         kubectl apply -f -
 
     # Create SECRET for raw TLS demo: Blocked (only allowed for example.com)
@@ -227,7 +229,8 @@ deploy_demo() {
     kubectl create secret generic secret-rawtls-blocked \
         --from-literal=api-key="REAL-BLOCKED-KEY-67890" \
         -n "$DEMO_NAMESPACE" --dry-run=client -o yaml | \
-        kubectl label -f - getkloak.io/enabled="true" getkloak.io/hosts="example.com" --local -o yaml | \
+        kubectl label -f - getkloak.io/enabled="true" --local -o yaml | \
+        kubectl annotate -f - getkloak.io/hosts="example.com" --local -o yaml | \
         kubectl apply -f -
 
     # Create SECRET 2: Blocked for httpbin.org (only allowed for example.com)
@@ -235,7 +238,8 @@ deploy_demo() {
     kubectl create secret generic secret-blocked \
         --from-literal=api-key="REAL-BLOCKED-KEY-67890" \
         -n "$DEMO_NAMESPACE" --dry-run=client -o yaml | \
-        kubectl label -f - getkloak.io/enabled="true" getkloak.io/hosts="example.com" --local -o yaml | \
+        kubectl label -f - getkloak.io/enabled="true" --local -o yaml | \
+        kubectl annotate -f - getkloak.io/hosts="example.com" --local -o yaml | \
         kubectl apply -f -
     
     # Wait a moment for cleanup

--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -24,10 +24,10 @@ const (
 	// AnnotationSecretEnabled is the label/annotation to enable Kloak secret replication.
 	AnnotationSecretEnabled = "getkloak.io/enabled"
 
-	// AnnotationPort is the label/annotation to specify an allowed port for a secret.
+	// AnnotationPort is the annotation to specify an allowed port for a secret.
 	AnnotationPort = "getkloak.io/port"
 
-	// AnnotationHosts is the label/annotation to specify allowed hosts for a secret.
+	// AnnotationHosts is the annotation to specify allowed hosts for a secret.
 	AnnotationHosts = "getkloak.io/hosts"
 
 	// ShadowSecretSuffix is the suffix appended to the name of the shadow secret.

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -67,6 +67,8 @@ struct secret_value {
   char real_secret[SECRET_MAX_LEN];
   __u32 host_len;                      // 0 = wildcard (allow all hosts)
   char allowed_host[MAX_HOST_LEN];     // e.g. "httpbin.org"
+  __u32 ip_len;                        // 0 = no IP filter, 16 = IPv4-mapped-IPv6
+  char allowed_ip[16];                 // IPv4-mapped-IPv6 address
   __u16 port;                          // 0 = wildcard, otherwise port number (host byte order)
   __u8 protocol;                       // IPPROTO_TCP (6) = TCP, IPPROTO_UDP (17) = UDP
   __u32 prefix_len;                    // actual prefix length (8..42)
@@ -97,12 +99,14 @@ struct scratch_buf {
   __u32 xor_match_count;   // total matches found by pre-scan
   __u32 xor_current_match; // index of the next match to process
   struct {
-    __u32 pos;                    // byte offset of kloak: prefix in data[]
-    struct secret_key key;        // 8-byte key prefix
-  } xor_matches[XOR_MAX_MATCHES];
-  char host_value[MAX_HOST_LEN]; // host from DNS chain
-  __u16 dest_port;      // destination port in host byte order
-  char data[MAX_DATA_SIZE];
+     __u32 pos;                    // byte offset of kloak: prefix in data[]
+     struct secret_key key;        // 8-byte key prefix
+   } xor_matches[XOR_MAX_MATCHES];
+   char host_value[MAX_HOST_LEN]; // host from DNS chain
+   __u16 dest_port;      // destination port in host byte order
+   char ip_value[16];    // destination IP (IPv4-mapped-IPv6)
+   __u32 ip_len;         // 0 = no IP, 16 = IPv4-mapped-IPv6
+   char data[MAX_DATA_SIZE];
 };
 
 struct {
@@ -1293,6 +1297,8 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
   scratch_data->xor_fd = 0;
   __builtin_memset(scratch_data->host_value, 0, MAX_HOST_LEN);
   scratch_data->dest_port = 0;
+  __builtin_memset(scratch_data->ip_value, 0, 16);
+  scratch_data->ip_len = 0;
 
   __u64 pid_tgid = bpf_get_current_pid_tgid();
   __u32 tgid = (__u32)(pid_tgid >> 32);
@@ -1360,6 +1366,9 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
     if (!civ) { dbg_inc(DBG_RESOLVE_NO_CONN); return; }
     // Store destination port (network byte order from connect)
     scratch_data->dest_port = __bpf_ntohs(civ->port);
+    // Store destination IP for filtering
+    __builtin_memcpy(scratch_data->ip_value, civ->ip, 16);
+    scratch_data->ip_len = 16;
     struct dns_ip_key dik;
     __builtin_memset(&dik, 0, sizeof(dik));
     __builtin_memcpy(dik.ip, civ->ip, 16);
@@ -1381,13 +1390,14 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
     struct conn_ip_val *civ = bpf_map_lookup_elem(&conn_ip_map, &cik);
     if (!civ)
       continue;
-    // Store destination port (network byte order from connect)
-    scratch_data->dest_port = __bpf_ntohs(civ->port);
     struct dns_ip_key dik;
     __builtin_memset(&dik, 0, sizeof(dik));
     __builtin_memcpy(dik.ip, civ->ip, 16);
     struct dns_ip_val *div = bpf_map_lookup_elem(&dns_ip_map, &dik);
     if (div && !dns_entry_expired(div) && div->host_len > 0 && div->host_len <= MAX_HOST_LEN) {
+      scratch_data->dest_port = __bpf_ntohs(civ->port);
+      __builtin_memcpy(scratch_data->ip_value, civ->ip, 16);
+      scratch_data->ip_len = 16;
       __builtin_memcpy(scratch_data->host_value, div->hostname, MAX_HOST_LEN);
       scratch_data->host_value_len = div->host_len;
       scratch_data->xor_fd = try_fd;
@@ -1396,6 +1406,10 @@ static __always_inline void resolve_host(struct scratch_buf *scratch_data,
       return;
     }
   }
+  // Reset stale IP/port from the last loop iteration — no verified host was found.
+  scratch_data->dest_port = 0;
+  scratch_data->ip_len = 0;
+  __builtin_memset(scratch_data->ip_value, 0, 16);
   dbg_inc(DBG_RESOLVE_NO_FD);
 }
 
@@ -1605,20 +1619,29 @@ int bpf_xor_path(void *ctx) {
   if (!val || val->len == 0 || val->len > SECRET_MAX_LEN)
     goto next; // Skip this match.
 
-  // Host filtering: val is fresh, re-lookup sd for host_value.
   __u32 val_len = val->len;
   __u32 val_host_len = val->host_len;
+  __u32 val_ip_len = val->ip_len;
   __u16 val_port = val->port;
-  if (val_host_len > 0 || val_port > 0) {
-    // Single lookup for both host and port filtering.
-    sd = bpf_map_lookup_elem(&scratch, &zero);
-    if (!sd) return 0;
+  // Save allowed_host before any map lookup that could invalidate val.
+  const char *val_allowed_host = val->allowed_host;
+
+  if (val_host_len > 0 || val_ip_len == 16 || val_port > 0) {
+    __u32 sd_ip_len = sd->ip_len;
 
     // Host filtering
     if (val_host_len > 0 && val_host_len < MAX_HOST_LEN) {
       if (sd_host_len == 0)
         goto next;
-      if (!hosts_match(sd->host_value, val->allowed_host))
+      if (!hosts_match(sd->host_value, val_allowed_host))
+        goto next;
+    }
+
+    // IP filtering - val_ip_len == 0 means no IP filter, otherwise check exact match
+    if (val_ip_len == 16) {
+      if (sd_ip_len != 16)
+        goto next;
+      if (__builtin_memcmp(sd->ip_value, val->allowed_ip, 16) != 0)
         goto next;
     }
 

--- a/pkg/ebpf/sync.go
+++ b/pkg/ebpf/sync.go
@@ -3,6 +3,7 @@ package ebpf
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"strings"
 
@@ -60,9 +61,16 @@ func syncSecrets(ctx context.Context, secretMap, watchedHostsMap *ebpf.Map, read
 		// rejects comma-separated lists — multi-host is not yet supported by
 		// the BPF data plane. "*" means "no filter", same as an empty value.
 		var allowedHost string
+		var allowedIP net.IP
 		if hostsLabel, ok := secret.Labels["getkloak.io/hosts"]; ok {
 			if trimmed := strings.TrimSpace(hostsLabel); trimmed != "" && trimmed != "*" {
 				allowedHost = trimmed
+
+				ip := net.ParseIP(trimmed)
+				if ip != nil {
+					allowedIP = ip
+					allowedHost = ""
+				}
 			}
 		}
 
@@ -131,18 +139,24 @@ func syncSecrets(ctx context.Context, secretMap, watchedHostsMap *ebpf.Map, read
 			val.PrefixLen = uint32(prefixLen)
 			copy(val.FullPrefix[:], []byte(shadowPrefix)[:prefixLen])
 
-			// Set allowed host for host-based filtering.
-			// allowedHost is guaranteed < MAX_HOST_LEN (validated above).
-			if allowedHost != "" {
+			// Set allowed host/IP for filtering
+			switch {
+			case allowedHost != "":
 				val.HostLen = uint32(len(allowedHost))
 				copy(val.AllowedHost[:], allowedHost)
+				val.IpLen = 0 // Host-based filtering
 
 				// Track this hostname for the watched_hosts map
 				var whk watchedHostKey
 				copy(whk.Host[:], allowedHost)
 				newHosts[whk] = struct{}{}
+			case allowedIP != nil:
+				copy(val.AllowedIp[:], allowedIP.To16())
+				val.IpLen = 16 // Mark as IP-based filtering with valid IP
+			default:
+				// HostLen == 0 and IpLen == 0 means wildcard (allow all hosts/IPs)
+				val.IpLen = 0
 			}
-			// HostLen == 0 means wildcard (allow all hosts)
 
 			// Set allowed port for port-based filtering
 			// Port == 0 means wildcard (allow all ports)
@@ -189,6 +203,8 @@ func syncSecrets(ctx context.Context, secretMap, watchedHostsMap *ebpf.Map, read
 					copy(huffVal.RealSecret[:], huffReal[:huffLen])
 					huffVal.HostLen = val.HostLen
 					huffVal.AllowedHost = val.AllowedHost
+					huffVal.IpLen = val.IpLen
+					copy(huffVal.AllowedIp[:], val.AllowedIp[:])
 					huffVal.Port = val.Port
 					huffVal.Protocol = val.Protocol
 					huffPrefixLen := len(huffShadow)

--- a/pkg/ebpf/sync.go
+++ b/pkg/ebpf/sync.go
@@ -56,14 +56,15 @@ func syncSecrets(ctx context.Context, secretMap, watchedHostsMap *ebpf.Map, read
 			continue
 		}
 
-		// Parse the allowed host from the secret's label. The admission webhook
-		// (pkg/webhook/secret_validator.go) enforces one host per secret and
-		// rejects comma-separated lists — multi-host is not yet supported by
-		// the BPF data plane. "*" means "no filter", same as an empty value.
+		// Parse the allowed host from the secret's annotation. The admission
+		// webhook (pkg/webhook/secret_validator.go) enforces one host per
+		// secret and rejects comma-separated lists — multi-host is not yet
+		// supported by the BPF data plane. "*" means "no filter", same as an
+		// empty value.
 		var allowedHost string
 		var allowedIP net.IP
-		if hostsLabel, ok := secret.Labels["getkloak.io/hosts"]; ok {
-			if trimmed := strings.TrimSpace(hostsLabel); trimmed != "" && trimmed != "*" {
+		if hostsAnnotation, ok := secret.Annotations["getkloak.io/hosts"]; ok {
+			if trimmed := strings.TrimSpace(hostsAnnotation); trimmed != "" && trimmed != "*" {
 				allowedHost = trimmed
 
 				ip := net.ParseIP(trimmed)
@@ -86,11 +87,11 @@ func syncSecrets(ctx context.Context, secretMap, watchedHostsMap *ebpf.Map, read
 			continue
 		}
 
-		// Parse port spec from the secret's labels
+		// Parse port spec from the secret's annotation
 		var port uint16
 		var protocol uint8
-		if portLabel, ok := secret.Labels["getkloak.io/port"]; ok && portLabel != "" {
-			ps, err := parseSyncPortSpec(portLabel)
+		if portAnnotation, ok := secret.Annotations["getkloak.io/port"]; ok && portAnnotation != "" {
+			ps, err := parseSyncPortSpec(portAnnotation)
 			if err != nil {
 				log.Errorw("Invalid port specification, treating as wildcard", "error", err, "secret", secret.Name)
 			} else {

--- a/pkg/ebpf/sync_test.go
+++ b/pkg/ebpf/sync_test.go
@@ -59,16 +59,21 @@ func newFakeClient(objs ...client.Object) client.Client {
 }
 
 // enabledSecret creates an enabled secret with the given data keys/values.
-func enabledSecret(name, ns string, data map[string][]byte, labels map[string]string) *corev1.Secret {
+func enabledSecret(name, ns string, data map[string][]byte, labels map[string]string, annotations map[string]string) *corev1.Secret {
 	l := map[string]string{"getkloak.io/enabled": "true"}
 	for k, v := range labels {
 		l[k] = v
 	}
+	a := map[string]string{}
+	for k, v := range annotations {
+		a[k] = v
+	}
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: ns,
-			Labels:    l,
+			Name:        name,
+			Namespace:   ns,
+			Labels:      l,
+			Annotations: a,
 		},
 		Data: data,
 	}
@@ -93,7 +98,7 @@ func TestSyncSecrets_BasicSync(t *testing.T) {
 	m := createTestSecretMap(t)
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte("my-real-secret-value!")}, nil),
+			map[string][]byte{"api-key": []byte("my-real-secret-value!")}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -124,7 +129,7 @@ func TestSyncSecrets_MinLength(t *testing.T) {
 	// Shadow value "kloak:" is 6 bytes, below 8-byte minimum
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte("short")}, nil),
+			map[string][]byte{"api-key": []byte("short")}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:")}),
 	)
@@ -148,7 +153,7 @@ func TestSyncSecrets_Truncation(t *testing.T) {
 	longShadow := "kloak:abcd1234-5678-9abc-def0-123456789abc" + strings.Repeat(" ", 158)
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte(longValue)}, nil),
+			map[string][]byte{"api-key": []byte(longValue)}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte(longShadow)}),
 	)
@@ -174,7 +179,7 @@ func TestSyncSecrets_HostFilter(t *testing.T) {
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
+			nil, map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -204,7 +209,7 @@ func TestSyncSecrets_WildcardHost(t *testing.T) {
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "*"}),
+			nil, map[string]string{"getkloak.io/hosts": "*"}),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -231,7 +236,7 @@ func TestSyncSecrets_StaleEntryPruning(t *testing.T) {
 	// First sync: add a secret
 	reader1 := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte("my-real-secret-value!")}, nil),
+			map[string][]byte{"api-key": []byte("my-real-secret-value!")}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -265,7 +270,7 @@ func TestSyncSecrets_Update(t *testing.T) {
 	// Initial value
 	reader1 := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte("old-secret-value-here")}, nil),
+			map[string][]byte{"api-key": []byte("old-secret-value-here")}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -276,7 +281,7 @@ func TestSyncSecrets_Update(t *testing.T) {
 	// Update value (same shadow, different real value)
 	reader2 := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte("new-secret-value-here")}, nil),
+			map[string][]byte{"api-key": []byte("new-secret-value-here")}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -302,7 +307,7 @@ func TestSyncSecrets_FullPrefix(t *testing.T) {
 	shadow := "kloak:abcd1234-5678-9abc-def0-123456789abc"
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
-			map[string][]byte{"api-key": []byte(shadow)}, nil),
+			map[string][]byte{"api-key": []byte(shadow)}, nil, nil),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte(shadow)}),
 	)
@@ -333,12 +338,12 @@ func TestSyncSecrets_WatchedHostsSync(t *testing.T) {
 	reader := newFakeClient(
 		enabledSecret("secret1", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
+			nil, map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
 		shadowSecret("secret1-kloak", "default", "secret1",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 		enabledSecret("secret2", "default",
 			map[string][]byte{"api-key": []byte("another-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "api.github.com"}),
+			nil, map[string]string{"getkloak.io/hosts": "api.github.com"}),
 		shadowSecret("secret2-kloak", "default", "secret2",
 			map[string][]byte{"api-key": []byte("kloak:efgh5678-1234-5678")}),
 	)
@@ -370,7 +375,7 @@ func TestSyncSecrets_WatchedHostsPruning(t *testing.T) {
 	reader1 := newFakeClient(
 		enabledSecret("my-secret", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
+			nil, map[string]string{"getkloak.io/hosts": "api.stripe.com"}),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -403,7 +408,7 @@ func TestSyncSecrets_IPFilter(t *testing.T) {
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "192.168.1.1"}),
+			nil, map[string]string{"getkloak.io/hosts": "192.168.1.1"}),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)
@@ -446,7 +451,7 @@ func TestSyncSecrets_IPv6Filter(t *testing.T) {
 	reader := newFakeClient(
 		enabledSecret("my-secret", "default",
 			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
-			map[string]string{"getkloak.io/hosts": "2001:db8::1"}),
+			nil, map[string]string{"getkloak.io/hosts": "2001:db8::1"}),
 		shadowSecret("my-secret-kloak", "default", "my-secret",
 			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
 	)

--- a/pkg/ebpf/sync_test.go
+++ b/pkg/ebpf/sync_test.go
@@ -22,7 +22,7 @@ func createTestSecretMap(t *testing.T) *ciliumebpf.Map {
 	m, err := ciliumebpf.NewMap(&ciliumebpf.MapSpec{
 		Type:       ciliumebpf.Hash,
 		KeySize:    8,   // SECRET_KEY_LEN
-		ValueSize:  216, // sizeof(secret_value) with padding
+		ValueSize:  272, // sizeof(secret_value) with padding (including IP filtering fields)
 		MaxEntries: 64,
 	})
 	if err != nil {
@@ -395,6 +395,89 @@ func TestSyncSecrets_WatchedHostsPruning(t *testing.T) {
 	// Host should be pruned
 	if err := wh.Lookup(&key, &val); err == nil {
 		t.Error("stale host should have been pruned from watched_hosts map")
+	}
+}
+
+func TestSyncSecrets_IPFilter(t *testing.T) {
+	m := createTestSecretMap(t)
+	reader := newFakeClient(
+		enabledSecret("my-secret", "default",
+			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
+			map[string]string{"getkloak.io/hosts": "192.168.1.1"}),
+		shadowSecret("my-secret-kloak", "default", "my-secret",
+			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
+	)
+
+	if err := syncSecrets(context.Background(), m, nil, reader, testLog()); err != nil {
+		t.Fatalf("syncSecrets failed: %v", err)
+	}
+
+	var key secretKey
+	copy(key.Prefix[:], []byte("kloak:ab"))
+	var val secretValue
+	if err := m.Lookup(&key, &val); err != nil {
+		t.Fatalf("secret not found in map: %v", err)
+	}
+
+	// IP filtering should be active (IpLen == 16)
+	if val.IpLen != 16 {
+		t.Errorf("expected ipLen=16 for IP filter, got %d", val.IpLen)
+	}
+
+	// HostLen should be 0 since we're using IP filter
+	if val.HostLen != 0 {
+		t.Errorf("expected hostLen=0 for IP filter, got %d", val.HostLen)
+	}
+
+	// Verify the IP is stored correctly (IPv4-mapped-IPv6: ::ffff:192.168.1.1)
+	// 192.168.1.1 in big-endian: 0xC0A80101
+	// IPv4-mapped-IPv6: ::ffff:0:C0A80101
+	expectedIP := []byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0xc0, 0xa8, 0x01, 0x01}
+	gotIP := val.AllowedIp[:16]
+	for i := 0; i < 16; i++ {
+		if gotIP[i] != expectedIP[i] {
+			t.Errorf("expected IP byte %d to be 0x%02x, got 0x%02x", i, expectedIP[i], gotIP[i])
+		}
+	}
+}
+
+func TestSyncSecrets_IPv6Filter(t *testing.T) {
+	m := createTestSecretMap(t)
+	reader := newFakeClient(
+		enabledSecret("my-secret", "default",
+			map[string][]byte{"api-key": []byte("my-real-secret-value!")},
+			map[string]string{"getkloak.io/hosts": "2001:db8::1"}),
+		shadowSecret("my-secret-kloak", "default", "my-secret",
+			map[string][]byte{"api-key": []byte("kloak:abcd1234-5678-9abc")}),
+	)
+
+	if err := syncSecrets(context.Background(), m, nil, reader, testLog()); err != nil {
+		t.Fatalf("syncSecrets failed: %v", err)
+	}
+
+	var key secretKey
+	copy(key.Prefix[:], []byte("kloak:ab"))
+	var val secretValue
+	if err := m.Lookup(&key, &val); err != nil {
+		t.Fatalf("secret not found in map: %v", err)
+	}
+
+	if val.IpLen != 16 {
+		t.Errorf("expected ipLen=16 for IP filter, got %d", val.IpLen)
+	}
+
+	if val.HostLen != 0 {
+		t.Errorf("expected hostLen=0 for IP filter, got %d", val.HostLen)
+	}
+
+	// Verify the IPv6 is stored correctly
+	// 2001:db8::1 -> 2001 0db8 0000 0000 0000 0000 0000 0001
+	expectedIP := []byte{0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0x01}
+	gotIP := val.AllowedIp[:16]
+	for i := 0; i < 16; i++ {
+		if gotIP[i] != expectedIP[i] {
+			t.Errorf("expected IP byte %d to be 0x%02x, got 0x%02x", i, expectedIP[i], gotIP[i])
+		}
 	}
 }
 

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -55,9 +55,11 @@ type secretValue struct {
 	RealSecret  [128]byte
 	HostLen     uint32
 	AllowedHost [64]byte
-	Port        uint16  // 0 = wildcard, otherwise port number (host byte order)
-	Protocol    uint8   // IPPROTO_TCP (6) = TCP, IPPROTO_UDP (17) = UDP
-	_           [1]byte // padding to align PrefixLen (uint32)
+	IpLen       uint32
+	AllowedIp   [16]byte // IPv4-mapped-IPv6
+	Port        uint16   // 0 = wildcard, otherwise port number (host byte order)
+	Protocol    uint8    // IPPROTO_TCP (6) = TCP, IPPROTO_UDP (17) = UDP
+	_           [1]byte  // padding to align PrefixLen (uint32)
 	PrefixLen   uint32
 	FullPrefix  [42]byte // SECRET_PREFIX_MAX
 	_           [2]byte  // trailing padding to match C struct alignment

--- a/pkg/webhook/secret_validator.go
+++ b/pkg/webhook/secret_validator.go
@@ -3,6 +3,7 @@ package webhook
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -125,7 +126,7 @@ func validateSecretData(data map[string][]byte, stringData map[string]string) er
 	return nil
 }
 
-// validateHostsLabel validates the single hostname in the getkloak.io/hosts
+// validateHostsLabel validates the single host or IP in the getkloak.io/hosts
 // label. Today only one host per secret is supported by the BPF data plane;
 // multi-host support was present in an earlier version but broke during a
 // rewrite and has not been restored. When it comes back, the CSV rejection
@@ -135,6 +136,7 @@ func validateSecretData(data map[string][]byte, stringData map[string]string) er
 //   - "" — no host filter (allow any destination)
 //   - "*" — explicit wildcard (same as empty)
 //   - a single RFC 1123 DNS subdomain, ≤ maxHostLen bytes
+//   - an IPv4 or IPv6 address
 //
 // Note: k8s label values already restrict chars to [A-Za-z0-9._-] and length
 // to 63, so a comma would normally be rejected at the API layer before this
@@ -146,7 +148,7 @@ func validateHostsLabel(hosts string) error {
 		return nil
 	}
 	if strings.Contains(hosts, ",") {
-		return fmt.Errorf("multiple hosts are not supported yet — specify a single hostname (or '*' for any)")
+		return fmt.Errorf("multiple hosts are not supported yet — specify a single hostname, IP, or '*' for any")
 	}
 	h := strings.TrimSpace(hosts)
 	if h == "" {
@@ -157,6 +159,9 @@ func validateHostsLabel(hosts string) error {
 	}
 	if len(h) > maxHostLen {
 		return fmt.Errorf("host %q exceeds max length %d bytes", h, maxHostLen)
+	}
+	if net.ParseIP(h) != nil {
+		return nil
 	}
 	if errs := validation.IsDNS1123Subdomain(h); len(errs) != 0 {
 		return fmt.Errorf("host %q is not a valid DNS name: %s", h, strings.Join(errs, "; "))

--- a/pkg/webhook/secret_validator.go
+++ b/pkg/webhook/secret_validator.go
@@ -16,10 +16,10 @@ import (
 )
 
 const (
-	// LabelHosts is the CSV list of hostnames a secret may be sent to.
-	LabelHosts = "getkloak.io/hosts"
-	// LabelPort restricts a secret to a specific port (or port/proto).
-	LabelPort = "getkloak.io/port"
+	// AnnotationHosts is the hostname/IP a secret may be sent to.
+	AnnotationHosts = "getkloak.io/hosts"
+	// AnnotationPort restricts a secret to a specific port (or port/proto).
+	AnnotationPort = "getkloak.io/port"
 
 	// maxHostLen mirrors MAX_HOST_LEN in pkg/ebpf/bpf/tls_uprobe.c.
 	// The BPF filter compares with `host_len < MAX_HOST_LEN`, so a host
@@ -69,16 +69,16 @@ func (v *SecretValidator) Handle(ctx context.Context, req admission.Request) adm
 		return admission.Allowed("not kloak-enabled")
 	}
 
-	if err := validateHostsLabel(secret.Labels[LabelHosts]); err != nil {
-		v.log.Warnw("rejecting secret: invalid hosts label",
+	if err := validateHostsLabel(secret.Annotations[AnnotationHosts]); err != nil {
+		v.log.Warnw("rejecting secret: invalid hosts annotation",
 			"namespace", secret.Namespace, "name", secret.Name, "error", err)
-		return admission.Denied(fmt.Sprintf("kloak: invalid %s label: %v", LabelHosts, err))
+		return admission.Denied(fmt.Sprintf("kloak: invalid %s annotation: %v", AnnotationHosts, err))
 	}
 
-	if err := validatePortLabel(secret.Labels[LabelPort]); err != nil {
-		v.log.Warnw("rejecting secret: invalid port label",
+	if err := validatePortLabel(secret.Annotations[AnnotationPort]); err != nil {
+		v.log.Warnw("rejecting secret: invalid port annotation",
 			"namespace", secret.Namespace, "name", secret.Name, "error", err)
-		return admission.Denied(fmt.Sprintf("kloak: invalid %s label: %v", LabelPort, err))
+		return admission.Denied(fmt.Sprintf("kloak: invalid %s annotation: %v", AnnotationPort, err))
 	}
 
 	if err := validateSecretData(secret.Data, secret.StringData); err != nil {
@@ -127,9 +127,9 @@ func validateSecretData(data map[string][]byte, stringData map[string]string) er
 }
 
 // validateHostsLabel validates the single host or IP in the getkloak.io/hosts
-// label. Today only one host per secret is supported by the BPF data plane;
-// multi-host support was present in an earlier version but broke during a
-// rewrite and has not been restored. When it comes back, the CSV rejection
+// annotation. Today only one host per secret is supported by the BPF data
+// plane; multi-host support was present in an earlier version but broke during
+// a rewrite and has not been restored. When it comes back, the CSV rejection
 // below should be relaxed.
 //
 // Accepted forms:
@@ -137,12 +137,6 @@ func validateSecretData(data map[string][]byte, stringData map[string]string) er
 //   - "*" — explicit wildcard (same as empty)
 //   - a single RFC 1123 DNS subdomain, ≤ maxHostLen bytes
 //   - an IPv4 or IPv6 address
-//
-// Note: k8s label values already restrict chars to [A-Za-z0-9._-] and length
-// to 63, so a comma would normally be rejected at the API layer before this
-// validator runs. We still check here to give a clear error message if the
-// label source ever changes (e.g. annotation-based config) and to document
-// intent to the next reader.
 func validateHostsLabel(hosts string) error {
 	if hosts == "" {
 		return nil

--- a/pkg/webhook/secret_validator_test.go
+++ b/pkg/webhook/secret_validator_test.go
@@ -31,6 +31,11 @@ func TestValidateHostsLabel(t *testing.T) {
 		{"trailing comma rejected", "a.com,", "multiple hosts are not supported"},
 		{"invalid DNS chars", "bad_host.com", "not a valid DNS name"},
 		{"invalid leading dash", "-bad.com", "not a valid DNS name"},
+		{"ipv4 address", "192.168.1.1", ""},
+		{"ipv4 private range", "10.0.0.1", ""},
+		{"ipv6 address", "2001:db8::1", ""},
+		{"ipv6 loopback", "::1", ""},
+		{"ipv4 loopback", "127.0.0.1", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -164,6 +169,18 @@ func TestSecretValidator_Handle(t *testing.T) {
 		{
 			name:      "enabled with valid labels and data",
 			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "api.example.com", LabelPort: "443/tcp"},
+			data:      validData,
+			wantAllow: true,
+		},
+		{
+			name:      "enabled with ipv4 host accepted",
+			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "192.168.1.1", LabelPort: "443/tcp"},
+			data:      validData,
+			wantAllow: true,
+		},
+		{
+			name:      "enabled with ipv6 host accepted",
+			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "2001:db8::1", LabelPort: "443/tcp"},
 			data:      validData,
 			wantAllow: true,
 		},

--- a/pkg/webhook/secret_validator_test.go
+++ b/pkg/webhook/secret_validator_test.go
@@ -130,13 +130,14 @@ func TestSecretValidator_Handle(t *testing.T) {
 	logger := zap.NewNop().Sugar()
 	v := NewSecretValidator(logger)
 
-	build := func(labels map[string]string, data map[string][]byte) admission.Request {
+	build := func(labels map[string]string, annotations map[string]string, data map[string][]byte) admission.Request {
 		s := &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "s",
-				Namespace: "default",
-				Labels:    labels,
+				Name:        "s",
+				Namespace:   "default",
+				Labels:      labels,
+				Annotations: annotations,
 			},
 			Data: data,
 		}
@@ -154,76 +155,86 @@ func TestSecretValidator_Handle(t *testing.T) {
 	validData := map[string][]byte{"api-key": []byte("super-secret-token")}
 
 	cases := []struct {
-		name       string
-		labels     map[string]string
-		data       map[string][]byte
-		wantAllow  bool
-		wantReason string
+		name        string
+		labels      map[string]string
+		annotations map[string]string
+		data        map[string][]byte
+		wantAllow   bool
+		wantReason  string
 	}{
 		{
-			name:      "not kloak-enabled is allowed regardless of other fields",
-			labels:    map[string]string{LabelHosts: strings.Repeat("a", 70)},
-			data:      nil,
-			wantAllow: true,
+			name:        "not kloak-enabled is allowed regardless of other fields",
+			labels:      nil,
+			annotations: map[string]string{AnnotationHosts: strings.Repeat("a", 70)},
+			data:        nil,
+			wantAllow:   true,
 		},
 		{
-			name:      "enabled with valid labels and data",
-			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "api.example.com", LabelPort: "443/tcp"},
-			data:      validData,
-			wantAllow: true,
+			name:        "enabled with valid annotations and data",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: map[string]string{AnnotationHosts: "api.example.com", AnnotationPort: "443/tcp"},
+			data:        validData,
+			wantAllow:   true,
 		},
 		{
-			name:      "enabled with ipv4 host accepted",
-			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "192.168.1.1", LabelPort: "443/tcp"},
-			data:      validData,
-			wantAllow: true,
+			name:        "enabled with ipv4 host accepted",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: map[string]string{AnnotationHosts: "192.168.1.1", AnnotationPort: "443/tcp"},
+			data:        validData,
+			wantAllow:   true,
 		},
 		{
-			name:      "enabled with ipv6 host accepted",
-			labels:    map[string]string{LabelEnabled: "true", LabelHosts: "2001:db8::1", LabelPort: "443/tcp"},
-			data:      validData,
-			wantAllow: true,
+			name:        "enabled with ipv6 host accepted",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: map[string]string{AnnotationHosts: "2001:db8::1", AnnotationPort: "443/tcp"},
+			data:        validData,
+			wantAllow:   true,
 		},
 		{
-			name:       "enabled with too-long host denied",
-			labels:     map[string]string{LabelEnabled: "true", LabelHosts: strings.Repeat("a", 64)},
-			data:       validData,
-			wantAllow:  false,
-			wantReason: "exceeds max length",
+			name:        "enabled with too-long host denied",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: map[string]string{AnnotationHosts: strings.Repeat("a", 64)},
+			data:        validData,
+			wantAllow:   false,
+			wantReason:  "exceeds max length",
 		},
 		{
-			name:       "enabled with bad port denied",
-			labels:     map[string]string{LabelEnabled: "true", LabelPort: "abc"},
-			data:       validData,
-			wantAllow:  false,
-			wantReason: "invalid port",
+			name:        "enabled with bad port denied",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: map[string]string{AnnotationPort: "abc"},
+			data:        validData,
+			wantAllow:   false,
+			wantReason:  "invalid port",
 		},
 		{
-			name:       "enabled with empty data denied",
-			labels:     map[string]string{LabelEnabled: "true"},
-			data:       nil,
-			wantAllow:  false,
-			wantReason: "no data entries",
+			name:        "enabled with empty data denied",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: nil,
+			data:        nil,
+			wantAllow:   false,
+			wantReason:  "no data entries",
 		},
 		{
-			name:       "enabled with short data denied",
-			labels:     map[string]string{LabelEnabled: "true"},
-			data:       map[string][]byte{"k": []byte("short")},
-			wantAllow:  false,
-			wantReason: "minimum 8",
+			name:        "enabled with short data denied",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: nil,
+			data:        map[string][]byte{"k": []byte("short")},
+			wantAllow:   false,
+			wantReason:  "minimum 8",
 		},
 		{
-			name:       "enabled with oversize data denied",
-			labels:     map[string]string{LabelEnabled: "true"},
-			data:       map[string][]byte{"k": make([]byte, 200)},
-			wantAllow:  false,
-			wantReason: "maximum 128",
+			name:        "enabled with oversize data denied",
+			labels:      map[string]string{LabelEnabled: "true"},
+			annotations: nil,
+			data:        map[string][]byte{"k": make([]byte, 200)},
+			wantAllow:   false,
+			wantReason:  "maximum 128",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			resp := v.Handle(context.Background(), build(tc.labels, tc.data))
+			resp := v.Handle(context.Background(), build(tc.labels, tc.annotations, tc.data))
 			if resp.Allowed != tc.wantAllow {
 				t.Fatalf("allowed=%v want=%v (msg=%q)", resp.Allowed, tc.wantAllow, resp.Result.Message)
 			}

--- a/test/e2e/cipher_test.go
+++ b/test/e2e/cipher_test.go
@@ -44,7 +44,7 @@ func TestCipherSuites(t *testing.T) {
 	// Create kloak-enabled secret targeting the echo server's FQDN.
 	createEnabledSecret(t, secretName, map[string][]byte{
 		"api-key": []byte(secretValue),
-	}, map[string]string{
+	}, nil, map[string]string{
 		"getkloak.io/hosts": echoSvcHost,
 	})
 	assertShadowSecret(t, secretName, map[string][]byte{

--- a/test/e2e/cleanup_test.go
+++ b/test/e2e/cleanup_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestSecretDeletionCascade(t *testing.T) {
 	data := map[string][]byte{"key": []byte("cascade-delete-test-val")}
-	createEnabledSecret(t, "test-cascade", data, nil)
+	createEnabledSecret(t, "test-cascade", data, nil, nil)
 	assertShadowSecret(t, "test-cascade", data)
 
 	// Delete the original secret
@@ -29,7 +29,7 @@ func TestSecretDeletionCascade(t *testing.T) {
 
 func TestPodDeletion(t *testing.T) {
 	data := map[string][]byte{"key": []byte("pod-delete-test-value!")}
-	createEnabledSecret(t, "test-pod-del", data, nil)
+	createEnabledSecret(t, "test-pod-del", data, nil, nil)
 	assertShadowSecret(t, "test-pod-del", data)
 
 	createPodWithSecretVolume(t, "test-pod-del-pod", "test-pod-del")

--- a/test/e2e/dns_whitelist_test.go
+++ b/test/e2e/dns_whitelist_test.go
@@ -40,7 +40,7 @@ func TestDNSWhitelist(t *testing.T) {
 	// Create kloak-enabled secret with host filter targeting the echo server.
 	createEnabledSecret(t, secretName, map[string][]byte{
 		"api-key": []byte(secretValue),
-	}, map[string]string{
+	}, nil, map[string]string{
 		"getkloak.io/hosts": echoSvcHost,
 	})
 	assertShadowSecret(t, secretName, map[string][]byte{

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -117,10 +117,10 @@ func TestEBPFRawTLSHostFiltering(t *testing.T) {
 	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-KEY-12345")}
 	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-KEY-67890")}
 
-	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
 		"getkloak.io/hosts": echoHostFQDN,
 	})
-	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
 		"getkloak.io/hosts": "example.com",
 	})
 
@@ -176,10 +176,10 @@ func TestEBPFSecretRewrite(t *testing.T) {
 	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-KEY-12345")}
 	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-KEY-67890")}
 
-	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
 		"getkloak.io/hosts": "httpbin.org",
 	})
-	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
 		"getkloak.io/hosts": "example.com",
 	})
 
@@ -275,10 +275,10 @@ func TestEBPFSecretLengths(t *testing.T) {
 			allowedData := map[string][]byte{"api-key": []byte(tc.allowed)}
 			blockedData := map[string][]byte{"api-key": []byte(tc.blocked)}
 
-			createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+			createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
 				"getkloak.io/hosts": echoHostFQDN,
 			})
-			createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+			createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
 				"getkloak.io/hosts": "example.com",
 			})
 

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -154,9 +154,9 @@ func waitForDaemonSetReady(ctx context.Context, namespace, name string) error {
 }
 
 // createEnabledSecret creates a secret with getkloak.io/enabled=true and registers cleanup.
-func createEnabledSecret(t *testing.T, name string, data map[string][]byte, extraLabels map[string]string) {
+func createEnabledSecret(t *testing.T, name string, data map[string][]byte, extraLabels map[string]string, extraAnnotations map[string]string) {
 	t.Helper()
-	if err := tryCreateEnabledSecret(t, name, data, extraLabels); err != nil {
+	if err := tryCreateEnabledSecret(t, name, data, extraLabels, extraAnnotations); err != nil {
 		t.Fatalf("failed to create secret %s: %v", name, err)
 	}
 }
@@ -165,17 +165,22 @@ func createEnabledSecret(t *testing.T, name string, data map[string][]byte, extr
 // the API error (if any) instead of calling t.Fatalf. Use this to assert that
 // the validating webhook rejects an invalid configuration. Cleanup is
 // registered regardless of outcome so transient creations still get removed.
-func tryCreateEnabledSecret(t *testing.T, name string, data map[string][]byte, extraLabels map[string]string) error {
+func tryCreateEnabledSecret(t *testing.T, name string, data map[string][]byte, extraLabels map[string]string, extraAnnotations map[string]string) error {
 	t.Helper()
 	labels := map[string]string{"getkloak.io/enabled": "true"}
 	for k, v := range extraLabels {
 		labels[k] = v
 	}
+	annotations := map[string]string{}
+	for k, v := range extraAnnotations {
+		annotations[k] = v
+	}
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: testNamespace,
-			Labels:    labels,
+			Name:        name,
+			Namespace:   testNamespace,
+			Labels:      labels,
+			Annotations: annotations,
 		},
 		Data: data,
 	}

--- a/test/e2e/ip_filtering_test.go
+++ b/test/e2e/ip_filtering_test.go
@@ -1,0 +1,204 @@
+//go:build e2e_ebpf
+
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// TestEBPFIPIpFiltering tests that IP-based filtering works correctly.
+// A single TLS echo server is deployed, and two secrets are created:
+// - secret-ip-allowed: getkloak.io/hosts set to the echo server's ClusterIP
+// - secret-ip-blocked: getkloak.io/hosts set to a fake IP (1.2.3.4)
+// When the client connects to the echo server's IP, only the allowed secret
+// should be rewritten; the blocked secret's placeholder should pass through.
+func TestEBPFIPFiltering(t *testing.T) {
+	// Wait for stale secrets from previous tests to be cleaned up.
+	gcCtx, gcCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer gcCancel()
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-allowed")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-blocked")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-allowed-kloak")
+	_ = waitForSecretAbsent(gcCtx, testNamespace, "secret-blocked-kloak")
+
+	// Deploy TLS echo server and get its ClusterIP
+	echoClusterIP := deployIPFilterEchoServer(t)
+	t.Logf("Echo server ClusterIP: %s", echoClusterIP)
+
+	// The client will connect to the echo server's IP directly
+	// (not via hostname, so DNS resolution doesn't happen)
+
+	allowedData := map[string][]byte{"api-key": []byte("REAL-IP-ALLOWED-KEY-12345")}
+	blockedData := map[string][]byte{"api-key": []byte("REAL-IP-BLOCKED-KEY-67890")}
+
+	// Secret allowed: hosts matches echo server's ClusterIP
+	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+		"getkloak.io/hosts": echoClusterIP,
+	})
+
+	// Secret blocked: hosts is a fake IP that will never match
+	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+		"getkloak.io/hosts": "1.2.3.4",
+	})
+
+	assertShadowSecret(t, "secret-allowed", allowedData)
+	assertShadowSecret(t, "secret-blocked", blockedData)
+
+	// Use the existing raw TLS demo deployment
+	demoManifest := filepath.Join(repoRoot, "examples", "demo-python-raw-tls", "deployment.yaml")
+	if err := applyManifest(t, demoManifest); err != nil {
+		t.Fatalf("failed to deploy demo-python-raw-tls: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = kubectl("delete", "-f", demoManifest, "-n", testNamespace, "--ignore-not-found")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	if err := waitForDeploymentReady(ctx, testNamespace, "demo-python-raw-tls"); err != nil {
+		t.Fatalf("demo-python-raw-tls not ready: %v", err)
+	}
+
+	// The client pod connects to TARGET_HOST (set to "tls" service name by default)
+	// For IP-based filtering test, we need to change it to use the ClusterIP directly
+	// instead of the service name (which would cause DNS resolution).
+	
+	// Use kubectl to patch the deployment's TARGET_HOST environment variable
+	patchData := fmt.Sprintf(`{"spec":{"template":{"spec":{"containers":[{"name":"demo-app","env":[{"name":"TARGET_HOST","value":"%s"}]}]}}}}`, echoClusterIP)
+	_, err := kubectl("patch", "deployment", "demo-python-raw-tls", "-n", testNamespace, "-p", patchData)
+	if err != nil {
+		t.Fatalf("failed to patch deployment to use IP: %v", err)
+	}
+	t.Logf("Patched demo-python-raw-tls to connect to IP: %s", echoClusterIP)
+
+	// Restart the deployment to pick up the new environment variable
+	_, _ = kubectl("rollout", "restart", "deployment", "demo-python-raw-tls", "-n", testNamespace)
+	ctxRestart, cancelRestart := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancelRestart()
+	if err := waitForDeploymentReady(ctxRestart, testNamespace, "demo-python-raw-tls"); err != nil {
+		t.Fatalf("demo-python-raw-tls restart failed: %v", err)
+	}
+
+	// Poll app logs for the allowed secret and verify blocked secret placeholder
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer pollCancel()
+	var out string
+	for {
+		select {
+		case <-pollCtx.Done():
+			t.Logf("=== demo-python-raw-tls final logs ===\n%s", out)
+			t.Logf("=== Controller logs ===\n%s", controllerLogs())
+			t.Fatalf("timed out waiting for allowed secret in raw TLS demo logs")
+		default:
+		}
+		out, _ = kubectl("logs", "-n", testNamespace, "-l", "app=demo-python-raw-tls", "--tail=200")
+		if strings.Contains(out, "REAL-IP-ALLOWED-KEY-12345") {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+	t.Logf("=== demo-python-raw-tls logs ===\n%s", out)
+
+	// Verify the blocked secret's placeholder appears (not rewritten)
+	if strings.Contains(out, "REAL-IP-BLOCKED-KEY-67890") {
+		t.Errorf("blocked secret should NOT be rewritten (IP mismatch)")
+	}
+
+	// Verify blocked secret's placeholder appears in output
+	// If not rewritten by eBPF, the kloak: placeholder value is sent as-is
+	if !strings.Contains(out, "kloak:") {
+		t.Logf("output: %s", out)
+		t.Errorf("blocked secret placeholder should appear unmodified in echo output")
+	}
+}
+
+// deployIPFilterEchoServer creates a dedicated TLS echo server for IP filtering tests.
+// Returns the ClusterIP of the service.
+func deployIPFilterEchoServer(t *testing.T) string {
+	t.Helper()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ip-filter-echo",
+			Namespace: testNamespace,
+			Labels: map[string]string{
+				"app":                 "ip-filter-echo",
+				"getkloak.io/enabled": "false",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:            "echo",
+				Image:           e2eImage("kloak-tls-echo", "latest"),
+				ImagePullPolicy: e2ePullPolicy(),
+				Ports:           []corev1.ContainerPort{{ContainerPort: 8443}},
+				ReadinessProbe: &corev1.Probe{
+					ProbeHandler: corev1.ProbeHandler{
+						HTTPGet: &corev1.HTTPGetAction{
+							Path:   "/health",
+							Port:   intstr.FromInt32(8443),
+							Scheme: corev1.URISchemeHTTPS,
+						},
+					},
+					InitialDelaySeconds: 2,
+					PeriodSeconds:       2,
+				},
+			}},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(testNamespace).Create(
+		context.Background(), pod, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create echo server pod: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clientset.CoreV1().Pods(testNamespace).Delete(
+			context.Background(), "ip-filter-echo", metav1.DeleteOptions{})
+	})
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ip-filter-echo",
+			Namespace: testNamespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{"app": "ip-filter-echo"},
+			Ports: []corev1.ServicePort{{
+				Port:       8443,
+				TargetPort: intstr.FromInt32(8443),
+			}},
+		},
+	}
+	_, err = clientset.CoreV1().Services(testNamespace).Create(
+		context.Background(), svc, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatalf("failed to create echo server service: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clientset.CoreV1().Services(testNamespace).Delete(
+			context.Background(), "ip-filter-echo", metav1.DeleteOptions{})
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	if err := waitForPodReady(ctx, testNamespace, "ip-filter-echo"); err != nil {
+		t.Fatalf("echo server not ready: %v", err)
+	}
+
+	// Fetch the assigned ClusterIP
+	created, err := clientset.CoreV1().Services(testNamespace).Get(
+		context.Background(), "ip-filter-echo", metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get echo server service: %v", err)
+	}
+	return created.Spec.ClusterIP
+}

--- a/test/e2e/ip_filtering_test.go
+++ b/test/e2e/ip_filtering_test.go
@@ -41,12 +41,12 @@ func TestEBPFIPFiltering(t *testing.T) {
 	blockedData := map[string][]byte{"api-key": []byte("REAL-IP-BLOCKED-KEY-67890")}
 
 	// Secret allowed: hosts matches echo server's ClusterIP
-	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
 		"getkloak.io/hosts": echoClusterIP,
 	})
 
 	// Secret blocked: hosts is a fake IP that will never match
-	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
 		"getkloak.io/hosts": "1.2.3.4",
 	})
 

--- a/test/e2e/port_filtering_test.go
+++ b/test/e2e/port_filtering_test.go
@@ -33,11 +33,11 @@ func TestEBPFRawTLSPortFiltering(t *testing.T) {
 
 	// Secret names must match the deployment manifest volume references
 	// (secret-allowed, secret-blocked) — not custom names.
-	createEnabledSecret(t, "secret-allowed", allowedData, map[string]string{
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
 		"getkloak.io/hosts": echoHostFQDN,
 		"getkloak.io/port":  echoPort,
 	})
-	createEnabledSecret(t, "secret-blocked", blockedData, map[string]string{
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
 		"getkloak.io/hosts": echoHostFQDN,
 		"getkloak.io/port":  wrongPort,
 	})

--- a/test/e2e/secret_test.go
+++ b/test/e2e/secret_test.go
@@ -13,7 +13,7 @@ func TestShadowSecretCreation(t *testing.T) {
 	data := map[string][]byte{
 		"api-key": []byte("MY-SECRET-VALUE-12345"),
 	}
-	createEnabledSecret(t, "test-shadow-create", data, nil)
+	createEnabledSecret(t, "test-shadow-create", data, nil, nil)
 	assertShadowSecret(t, "test-shadow-create", data)
 }
 
@@ -23,7 +23,7 @@ func TestShadowSecretMultipleKeys(t *testing.T) {
 		"password": []byte("super-secret-password-123"),
 		"token":    []byte("tok_live_abcdefghijklmnop"),
 	}
-	createEnabledSecret(t, "test-shadow-multi", data, nil)
+	createEnabledSecret(t, "test-shadow-multi", data, nil, nil)
 	assertShadowSecret(t, "test-shadow-multi", data)
 }
 
@@ -36,7 +36,7 @@ func TestShadowSecretLengthMatching(t *testing.T) {
 		"medium": []byte("this-is-a-medium-length-secret-value-here!x"),
 		"long":   []byte(strings.Repeat("x", 128)),
 	}
-	createEnabledSecret(t, "test-shadow-lengths", data, nil)
+	createEnabledSecret(t, "test-shadow-lengths", data, nil, nil)
 	assertShadowSecret(t, "test-shadow-lengths", data)
 }
 
@@ -44,7 +44,7 @@ func TestShadowSecretUpdate(t *testing.T) {
 	data := map[string][]byte{
 		"key": []byte("original-value-here!"),
 	}
-	createEnabledSecret(t, "test-shadow-update", data, nil)
+	createEnabledSecret(t, "test-shadow-update", data, nil, nil)
 	assertShadowSecret(t, "test-shadow-update", data)
 
 	// Update the secret
@@ -69,7 +69,7 @@ func TestShadowSecretDisable(t *testing.T) {
 	data := map[string][]byte{
 		"key": []byte("will-be-disabled-soon"),
 	}
-	createEnabledSecret(t, "test-shadow-disable", data, nil)
+	createEnabledSecret(t, "test-shadow-disable", data, nil, nil)
 	assertShadowSecret(t, "test-shadow-disable", data)
 
 	// Remove the enabled label

--- a/test/e2e/secret_validation_test.go
+++ b/test/e2e/secret_validation_test.go
@@ -36,46 +36,41 @@ func assertAdmissionRejected(t *testing.T, err error, wantReason string) {
 func TestSecretValidation_RejectsShortData(t *testing.T) {
 	err := tryCreateEnabledSecret(t, "test-val-short", map[string][]byte{
 		"flag": []byte("short"), // 5 bytes, below the 8-byte BPF key minimum
-	}, nil)
+	}, nil, nil)
 	assertAdmissionRejected(t, err, "minimum 8")
 }
 
 func TestSecretValidation_RejectsLongData(t *testing.T) {
 	err := tryCreateEnabledSecret(t, "test-val-long", map[string][]byte{
 		"big": make([]byte, 129), // one byte over the 128-byte BPF rewrite cap
-	}, nil)
+	}, nil, nil)
 	assertAdmissionRejected(t, err, "maximum 128")
 }
 
 func TestSecretValidation_RejectsEmptyData(t *testing.T) {
-	err := tryCreateEnabledSecret(t, "test-val-empty", map[string][]byte{}, nil)
+	err := tryCreateEnabledSecret(t, "test-val-empty", map[string][]byte{}, nil, nil)
 	assertAdmissionRejected(t, err, "no data entries")
 }
 
 func TestSecretValidation_RejectsInvalidHostLabel(t *testing.T) {
-	// underscores pass the k8s label regex but are invalid in RFC 1123 DNS.
-	// This reaches the validator and exercises the DNS check.
+	// underscores are invalid in RFC 1123 DNS names.
 	err := tryCreateEnabledSecret(t, "test-val-bad-host",
 		map[string][]byte{"api-key": []byte("valid-8byte-or-more")},
-		map[string]string{"getkloak.io/hosts": "bad_host.example.com"})
+		nil, map[string]string{"getkloak.io/hosts": "bad_host.example.com"})
 	assertAdmissionRejected(t, err, "not a valid DNS name")
 }
 
 func TestSecretValidation_RejectsBadPortLabel(t *testing.T) {
 	err := tryCreateEnabledSecret(t, "test-val-bad-port",
 		map[string][]byte{"api-key": []byte("valid-8byte-or-more")},
-		map[string]string{"getkloak.io/port": "not-a-port"})
+		nil, map[string]string{"getkloak.io/port": "not-a-port"})
 	assertAdmissionRejected(t, err, "invalid port")
 }
 
 func TestSecretValidation_AcceptsValidSecret(t *testing.T) {
-	// k8s label values cannot contain commas or slashes, so multi-host
-	// (a,b) and port-with-proto (443/tcp) can't be expressed via labels.
-	// Multi-host rejection is covered in the unit suite where we call
-	// validateHostsLabel directly.
 	err := tryCreateEnabledSecret(t, "test-val-happy",
 		map[string][]byte{"api-key": []byte(strings.Repeat("a", 32))},
-		map[string]string{
+		nil, map[string]string{
 			"getkloak.io/hosts": "api.example.com",
 			"getkloak.io/port":  "443",
 		})
@@ -90,7 +85,7 @@ func TestSecretValidation_AcceptsBoundaryLengths(t *testing.T) {
 		map[string][]byte{
 			"min": make([]byte, 8),
 			"max": make([]byte, 128),
-		}, nil)
+		}, nil, nil)
 	if err != nil {
 		t.Fatalf("expected boundary-length secret to be admitted, got: %v", err)
 	}
@@ -122,7 +117,7 @@ func TestSecretValidation_AllowsNonEnabledSecret(t *testing.T) {
 func TestSecretValidation_RejectsOnUpdate(t *testing.T) {
 	name := "test-val-update"
 	if err := tryCreateEnabledSecret(t, name,
-		map[string][]byte{"api-key": []byte("valid-initial-value")}, nil); err != nil {
+		map[string][]byte{"api-key": []byte("valid-initial-value")}, nil, nil); err != nil {
 		t.Fatalf("create should have succeeded: %v", err)
 	}
 

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestWebhookVolumeRewrite(t *testing.T) {
 	secretData := map[string][]byte{"api-key": []byte("webhook-test-secret-val")}
-	createEnabledSecret(t, "test-wh-rewrite", secretData, nil)
+	createEnabledSecret(t, "test-wh-rewrite", secretData, nil, nil)
 	assertShadowSecret(t, "test-wh-rewrite", secretData)
 
 	createPodWithSecretVolume(t, "test-wh-rewrite-pod", "test-wh-rewrite")
@@ -45,7 +45,7 @@ func TestWebhookVolumeRewrite(t *testing.T) {
 
 func TestWebhookAnnotationInjection(t *testing.T) {
 	secretData := map[string][]byte{"key": []byte("annotation-inject-val!")}
-	createEnabledSecret(t, "test-wh-annot", secretData, nil)
+	createEnabledSecret(t, "test-wh-annot", secretData, nil, nil)
 	assertShadowSecret(t, "test-wh-annot", secretData)
 
 	// Create pod WITHOUT the label — namespace label should trigger webhook
@@ -81,7 +81,7 @@ func TestWebhookNonEnabledSecretUntouched(t *testing.T) {
 	enabledData := map[string][]byte{"key": []byte("enabled-secret-value!")}
 	plainData := map[string][]byte{"key": []byte("plain-secret-value!!")}
 
-	createEnabledSecret(t, "test-wh-enabled", enabledData, nil)
+	createEnabledSecret(t, "test-wh-enabled", enabledData, nil, nil)
 	createPlainSecret(t, "test-wh-plain", plainData)
 	assertShadowSecret(t, "test-wh-enabled", enabledData)
 
@@ -123,7 +123,7 @@ func TestWebhookNonEnabledSecretUntouched(t *testing.T) {
 
 func TestWebhookMountedContent(t *testing.T) {
 	secretData := map[string][]byte{"api-key": []byte("REAL-SECRET-DO-NOT-LEAK")}
-	createEnabledSecret(t, "test-wh-content", secretData, nil)
+	createEnabledSecret(t, "test-wh-content", secretData, nil, nil)
 	assertShadowSecret(t, "test-wh-content", secretData)
 
 	// Create a pod that cats the mounted secret and exits


### PR DESCRIPTION
This PR adds support for filtering secrets by destination IP address in addition to hostname. Users can now specify `getkloak.io/hosts: "192.168.1.1"` (or any IP address) instead of just hostnames. Fixes #104 

Changes:
- **Breaking**: Kloak now use Annotations instead of Labels for hosts and port filtering, following it's documentation
- BPF code (pkg/ebpf/bpf/tls_uprobe.c): Added ip_len and allowed_ip[16] fields to secret filtering struct
- Userspace sync (pkg/ebpf/sync.go, uprobe.go): Parse IPs from labels, convert to IPv4-mapped-IPv6 format, sync to BPF map
- Host filtering logic: Uses memcmp() for exact 16-byte IP matching
- Tests: Added unit tests (pkg/ebpf/sync_test.go) and e2e test (test/e2e/ip_filtering_test.go)

Behavior:
- getkloak.io/hosts: <hostname> → hostname-based filtering (existing)
- getkloak.io/hosts: <ip> → IP-based filtering (new)
- Both formats are mutually exclusive (single entry)
- IP addresses stored as 16-byte IPv4-mapped-IPv6 (consistent with existing code)
Backward compatibility:
- Existing hostname-based filtering unchanged
- IP filtering only activates when valid IP is specified