### PR TITLE
feat: add optional demo app deployment to Helm chart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,16 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push demo-go image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./examples/demo-go
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}-demo-go:latest
+            ghcr.io/${{ github.repository }}-demo-go:sha-${{ github.sha }}
+
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest

--- a/charts/kloak/templates/demo-deployment.yaml
+++ b/charts/kloak/templates/demo-deployment.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: demo
-          image: "{{ .Values.demo.image.repository }}:{{ .Values.demo.image.tag }}"
+          image: "{{ .Values.demo.image.repository }}:{{ .Values.demo.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.demo.image.pullPolicy }}
           env:
             - name: SECRET_ALLOWED_FILE
@@ -41,12 +41,7 @@ spec:
               mountPath: "/etc/secrets/blocked"
               readOnly: true
           resources:
-            requests:
-              cpu: 10m
-              memory: 32Mi
-            limits:
-              cpu: 100m
-              memory: 64Mi
+            {{- toYaml .Values.demo.resources | nindent 12 }}
       volumes:
         - name: secret-allowed
           secret:

--- a/charts/kloak/templates/demo-deployment.yaml
+++ b/charts/kloak/templates/demo-deployment.yaml
@@ -26,14 +26,19 @@ spec:
           imagePullPolicy: {{ .Values.demo.image.pullPolicy }}
           env:
             - name: SECRET_ALLOWED_FILE
-              value: "/etc/secrets/api-key"
+              value: "/etc/secrets/allowed/api-key"
+            - name: SECRET_BLOCKED_FILE
+              value: "/etc/secrets/blocked/api-key"
             - name: TARGET_URL
               value: {{ .Values.demo.targetURL | quote }}
             - name: REQUEST_INTERVAL
               value: {{ .Values.demo.requestInterval | quote }}
           volumeMounts:
-            - name: secret-vol
-              mountPath: "/etc/secrets"
+            - name: secret-allowed
+              mountPath: "/etc/secrets/allowed"
+              readOnly: true
+            - name: secret-blocked
+              mountPath: "/etc/secrets/blocked"
               readOnly: true
           resources:
             requests:
@@ -43,7 +48,10 @@ spec:
               cpu: 100m
               memory: 64Mi
       volumes:
-        - name: secret-vol
+        - name: secret-allowed
           secret:
-            secretName: {{ include "kloak.fullname" . }}-demo-secret
+            secretName: {{ include "kloak.fullname" . }}-demo-allowed
+        - name: secret-blocked
+          secret:
+            secretName: {{ include "kloak.fullname" . }}-demo-blocked
 {{- end }}

--- a/charts/kloak/templates/demo-deployment.yaml
+++ b/charts/kloak/templates/demo-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kloak.fullname" . }}-demo
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.demo.namespace }}
   labels:
     {{- include "kloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo

--- a/charts/kloak/templates/demo-deployment.yaml
+++ b/charts/kloak/templates/demo-deployment.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.demo.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "kloak.fullname" . }}-demo
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "kloak.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: demo
+  template:
+    metadata:
+      labels:
+        {{- include "kloak.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: demo
+        getkloak.io/enabled: "true"
+    spec:
+      containers:
+        - name: demo
+          image: "{{ .Values.demo.image.repository }}:{{ .Values.demo.image.tag }}"
+          imagePullPolicy: {{ .Values.demo.image.pullPolicy }}
+          env:
+            - name: SECRET_ALLOWED_FILE
+              value: "/etc/secrets/api-key"
+            - name: TARGET_URL
+              value: {{ .Values.demo.targetURL | quote }}
+            - name: REQUEST_INTERVAL
+              value: {{ .Values.demo.requestInterval | quote }}
+          volumeMounts:
+            - name: secret-vol
+              mountPath: "/etc/secrets"
+              readOnly: true
+          resources:
+            requests:
+              cpu: 10m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 64Mi
+      volumes:
+        - name: secret-vol
+          secret:
+            secretName: {{ include "kloak.fullname" . }}-demo-secret
+{{- end }}

--- a/charts/kloak/templates/demo-namespace.yaml
+++ b/charts/kloak/templates/demo-namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.demo.enabled }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.demo.namespace }}
+  labels:
+    {{- include "kloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo
+    getkloak.io/enabled: "true"
+{{- end }}

--- a/charts/kloak/templates/demo-secret.yaml
+++ b/charts/kloak/templates/demo-secret.yaml
@@ -2,17 +2,30 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "kloak.fullname" . }}-demo-secret
+  name: {{ include "kloak.fullname" . }}-demo-allowed
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo
     getkloak.io/enabled: "true"
-  {{- if .Values.demo.secret.allowedHost }}
   annotations:
-    getkloak.io/hosts: {{ .Values.demo.secret.allowedHost | quote }}
-  {{- end }}
+    getkloak.io/hosts: {{ .Values.demo.secretAllowed.allowedHost | quote }}
 type: Opaque
 data:
-  api-key: {{ .Values.demo.secret.value | b64enc | quote }}
+  api-key: {{ .Values.demo.secretAllowed.value | b64enc | quote }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kloak.fullname" . }}-demo-blocked
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo
+    getkloak.io/enabled: "true"
+  annotations:
+    getkloak.io/hosts: {{ .Values.demo.secretBlocked.allowedHost | quote }}
+type: Opaque
+data:
+  api-key: {{ .Values.demo.secretBlocked.value | b64enc | quote }}
 {{- end }}

--- a/charts/kloak/templates/demo-secret.yaml
+++ b/charts/kloak/templates/demo-secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.demo.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "kloak.fullname" . }}-demo-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kloak.labels" . | nindent 4 }}
+    app.kubernetes.io/component: demo
+    getkloak.io/enabled: "true"
+  {{- if .Values.demo.secret.allowedHost }}
+  annotations:
+    getkloak.io/hosts: {{ .Values.demo.secret.allowedHost | quote }}
+  {{- end }}
+type: Opaque
+data:
+  api-key: {{ .Values.demo.secret.value | b64enc | quote }}
+{{- end }}

--- a/charts/kloak/templates/demo-secret.yaml
+++ b/charts/kloak/templates/demo-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kloak.fullname" . }}-demo-allowed
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.demo.namespace }}
   labels:
     {{- include "kloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo
@@ -18,7 +18,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ include "kloak.fullname" . }}-demo-blocked
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.demo.namespace }}
   labels:
     {{- include "kloak.labels" . | nindent 4 }}
     app.kubernetes.io/component: demo

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -70,7 +70,8 @@ demo:
   namespace: kloak-demo
   image:
     repository: ghcr.io/spinningfactory/kloak-demo-go
-    tag: latest
+    # Empty tag defaults to chart appVersion.
+    tag: ""
     pullPolicy: IfNotPresent
   # Target URL that the demo app sends requests to (must be HTTPS).
   targetURL: "https://httpbin.org/headers"
@@ -84,3 +85,10 @@ demo:
   secretBlocked:
     value: "real-api-key-blocked-67890"
     allowedHost: "example.com"
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+    limits:
+      cpu: 100m
+      memory: 64Mi

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -62,6 +62,9 @@ coverage:
 #   - "blocked" secret (hosts: example.com) → shadow UUID in response
 demo:
   enabled: false
+  # Namespace for the demo app. Created automatically with the
+  # getkloak.io/enabled label so the webhook intercepts pods in it.
+  namespace: kloak-demo
   image:
     repository: ghcr.io/spinningfactory/kloak-demo-go
     tag: latest

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -54,6 +54,12 @@ coverage:
 
 # Optional demo app deployment for validating kloak is working.
 # Enable with: helm install kloak charts/kloak --set demo.enabled=true
+#
+# Deploys a Go app that sends two secrets to httpbin.org as headers.
+# DNS host filtering (via kube-dns, auto-discovered) verifies that
+# secrets are only rewritten for their allowed hosts:
+#   - "allowed" secret (hosts: httpbin.org) → real value in response
+#   - "blocked" secret (hosts: example.com) → shadow UUID in response
 demo:
   enabled: false
   image:
@@ -64,10 +70,11 @@ demo:
   targetURL: "https://httpbin.org/headers"
   # Interval in seconds between requests.
   requestInterval: "5"
-  # The secret value to use. This secret will be labeled with
-  # getkloak.io/enabled=true and sent as X-Api-Key header.
-  secret:
-    value: "my-super-secret-api-key-12345"
-    # Host restriction: only allow this secret to be sent to this host.
-    # Set to "" for wildcard (allow all hosts).
+  # Allowed secret: host matches targetURL → kloak rewrites with real value.
+  secretAllowed:
+    value: "real-api-key-allowed-12345"
     allowedHost: "httpbin.org"
+  # Blocked secret: host does NOT match targetURL → shadow UUID passes through.
+  secretBlocked:
+    value: "real-api-key-blocked-67890"
+    allowedHost: "example.com"

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -1,3 +1,6 @@
+# Install: helm install kloak oci://ghcr.io/spinningfactory/kloak/kloak -n kloak-system --create-namespace
+# With demo: helm install kloak oci://ghcr.io/spinningfactory/kloak/kloak -n kloak-system --create-namespace --set demo.enabled=true
+
 image:
   repository: ghcr.io/spinningfactory/kloak
   tag: dev

--- a/charts/kloak/values.yaml
+++ b/charts/kloak/values.yaml
@@ -51,3 +51,23 @@ certificates:
 coverage:
   enabled: false
   hostPath: /tmp/kloak-coverage
+
+# Optional demo app deployment for validating kloak is working.
+# Enable with: helm install kloak charts/kloak --set demo.enabled=true
+demo:
+  enabled: false
+  image:
+    repository: ghcr.io/spinningfactory/kloak-demo-go
+    tag: latest
+    pullPolicy: IfNotPresent
+  # Target URL that the demo app sends requests to (must be HTTPS).
+  targetURL: "https://httpbin.org/headers"
+  # Interval in seconds between requests.
+  requestInterval: "5"
+  # The secret value to use. This secret will be labeled with
+  # getkloak.io/enabled=true and sent as X-Api-Key header.
+  secret:
+    value: "my-super-secret-api-key-12345"
+    # Host restriction: only allow this secret to be sent to this host.
+    # Set to "" for wildcard (allow all hosts).
+    allowedHost: "httpbin.org"


### PR DESCRIPTION
## Summary
- Add `--set demo.enabled=true` to deploy a demo Go app alongside kloak
- Demo app reads a kloak-managed secret and sends it to httpbin.org
- When kloak is working, httpbin echoes back the real secret value
- Configurable: image, target URL, request interval, secret value, host restriction
- Also publishes `ghcr.io/spinningfactory/kloak-demo-go` image on main pushes

## Usage
```bash
helm install kloak charts/kloak -n kloak-system --create-namespace \
  --set demo.enabled=true
```

Then check the demo pod logs:
```bash
kubectl logs -n kloak-system -l app.kubernetes.io/component=demo
```

## Test plan
- [ ] `helm lint charts/kloak --set demo.enabled=true` passes
- [ ] `helm template` renders correct Secret + Deployment
- [ ] Demo disabled by default (no demo resources when flag not set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)