### PR TITLE
fix: sync secrets to BPF maps before attaching uprobes

### DIFF
--- a/pkg/controller/reconciler.go
+++ b/pkg/controller/reconciler.go
@@ -124,11 +124,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	// attachUprobesToCgroup does blocking filesystem I/O and must not run
 	// while the lock is held to avoid blocking other reconcile goroutines.
 	var needsAttach []uint64
+	isNewPod := false
 
 	r.mu.Lock()
 	existingCgroups := r.trackedPods[string(pod.UID)]
 	if existingCgroups == nil {
 		existingCgroups = make(map[uint64]bool)
+		isNewPod = true
 	}
 
 	// Collect cgroups that need uprobe attachment:
@@ -157,6 +159,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	r.trackedPods[string(pod.UID)] = existingCgroups
 	r.podKeyToUID[req.String()] = string(pod.UID)
 	r.mu.Unlock()
+
+	// Force a secret sync before attaching uprobes to a newly discovered pod.
+	// On fresh deploy, the periodic sync may not have run yet, leaving
+	// secret_map entries with host_len=0 (wildcard). Without this, the first
+	// TLS write bypasses host filtering. Only sync for new pods — retries
+	// (libssl not loaded yet) don't need another sync.
+	if isNewPod && len(needsAttach) > 0 && r.UprobeManager != nil {
+		r.UprobeManager.SyncSecrets(ctx)
+	}
 
 	// Attach uprobes outside the lock — this involves filesystem I/O.
 	for _, cgroupID := range needsAttach {

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -95,6 +95,9 @@ type TLSUprobeManager struct {
 	tcAttached sync.Map // uint64 (netns inode) -> *tcAttachEntry
 	// cgroupToNetns maps cgroup ID → netns inode for cleanup on UntrackCgroup.
 	cgroupToNetns sync.Map // uint64 (cgroup ID) -> uint64 (netns inode)
+
+	// syncMu serializes BPF secret_map + watched_hosts sync operations.
+	syncMu sync.Mutex
 }
 
 // tcAttachEntry holds an open fd to a network namespace to prevent inode reuse.
@@ -802,7 +805,9 @@ func (m *TLSUprobeManager) PollEvents(ctx context.Context) error {
 	m.log.Infow("Starting eBPF TLS event poller and secret syncer")
 
 	// Trigger an initial sync
+	m.syncMu.Lock()
 	m.syncSecretsToBPF(ctx)
+	m.syncMu.Unlock()
 
 	// Periodic re-sync ticker. The initial sync may have found an empty store
 	// (secret reconciler hasn't run yet), so we must keep re-syncing.
@@ -814,7 +819,9 @@ func (m *TLSUprobeManager) PollEvents(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-syncTicker.C:
+			m.syncMu.Lock()
 			m.syncSecretsToBPF(ctx)
+			m.syncMu.Unlock()
 			m.DumpDebugCounters()
 		default:
 		}
@@ -891,10 +898,21 @@ func (m *TLSUprobeManager) PopulateTrustedDNSServers(ips []net.IP) error {
 
 // syncSecretsToBPF updates the eBPF map with the latest shadow secret values
 // and the watched_hosts map with hostnames from secret entries.
+// Must be called with syncMu held.
 func (m *TLSUprobeManager) syncSecretsToBPF(ctx context.Context) {
 	if err := syncSecrets(ctx, m.objs.SecretMap, m.objs.WatchedHosts, m.k8sReader, m.log); err != nil {
 		m.log.Errorw("failed to sync secrets to BPF map", "error", err)
 	}
+}
+
+// SyncSecrets forces an immediate sync of secrets to BPF maps.
+// Called by the reconciler before attaching uprobes to ensure secret_map
+// and watched_hosts are populated before the first TLS write.
+// Thread-safe: serialized with the periodic sync ticker.
+func (m *TLSUprobeManager) SyncSecrets(ctx context.Context) {
+	m.syncMu.Lock()
+	defer m.syncMu.Unlock()
+	m.syncSecretsToBPF(ctx)
 }
 
 // debugCounterNames maps index to human-readable name (must match C enum).


### PR DESCRIPTION
## Summary
On fresh deploy, the periodic secret sync (5s interval) may not have run by the time uprobes are attached to a new pod. The BPF `secret_map` entries lack host restrictions (`host_len=0`, treated as wildcard), so **all** secrets are rewritten regardless of `getkloak.io/hosts`. HTTP/2 HPACK then caches the rewritten header values, preventing correction on later syncs.

Fix: force a `SyncSecrets` call in the pod reconciler right before uprobe attachment. This ensures `secret_map` and `watched_hosts` are populated with correct host restrictions before the first TLS write.

## Root cause
1. Controller starts, runs initial sync → informer cache not ready → BPF maps empty or incomplete
2. Pod starts, controller attaches uprobes
3. App makes first HTTPS request → prescan finds `kloak:` → `secret_map` has entry but `host_len=0` → host filtering skipped → both secrets rewritten
4. HTTP/2 HPACK caches header values → subsequent requests use index references, not literal `kloak:` bytes → prescan never matches again
5. 5s later, periodic sync populates maps correctly → but too late, HPACK already cached

## Test plan
- [ ] Fresh `helm install` with demo enabled → blocked secret shows `kloak:` UUID (not real value)
- [ ] `helm upgrade` → no regression
- [ ] E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)