### PR TITLE
ci(e2e): always log at trace level

### DIFF
--- a/test/e2e/values-e2e.yaml
+++ b/test/e2e/values-e2e.yaml
@@ -3,7 +3,12 @@ image:
   tag: e2e
   pullPolicy: Never
 log:
-  level: debug
+  # Trace-level so flake post-mortems on the e2e job can see the BPF debug
+  # counters (xor_conn_check, xor_secret_found, kprobe_bridge, tc_patched)
+  # and per-secret sync detail. Without this, info/debug hides the data-plane
+  # signals needed to distinguish "uprobe never fired" from "fallback miss"
+  # from "tag patch miss".
+  level: trace
   dev: true
 coverage:
   enabled: true


### PR DESCRIPTION
## Summary
Flip `test/e2e/values-e2e.yaml`'s log level from `debug` → `trace` so the e2e job's controller logs always include the BPF debug counters and per-secret sync detail.

## Why
The recent `TestCipherSuites/4hop`, `TestEBPFRawTLSHostFiltering`, and `TestEBPFSecretRewrite/{python,js}` flakes ([run 24973780575](https://github.com/spinningfactory/kloak/actions/runs/24973780575)) can't be diagnosed from the on-failure log dump because the most useful signals only print at trace level:

- `xor_conn_check`, `xor_secret_found`, `xor_delta_done` — distinguishes "uprobe never fired" from "uprobe fired but hit no secret" from "secret found but rewrite skipped"
- `kprobe_bridge`, `kprobe_bridge_no_entry`, `kprobe_bridge_h_fail` — distinguishes "tcp_sendmsg saw no xor_pending" from "saw it but H extraction failed"
- `tc_match`, `tc_patched` — distinguishes "tc_pending populated but skb didn't match" from "matched but patch logic skipped"

Without these, all we know is "the test timed out waiting for the rewrite," which is exactly what we already see.

## Cost
Trace adds ~5 lines per second per node during active sync. The e2e job already runs 10–15 minutes per run; the extra log volume is irrelevant. The on-failure dump uses `--tail=200` so it stays bounded.

## Test plan
- [ ] CI on this PR runs e2e green; controller log dump on failure (if it fails) now contains `xor_*` / `tc_*` / `kprobe_bridge*` lines
- [ ] No regression in test runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)