### PR TITLE
ci(e2e): compile bpf_printk markers and stream trace_pipe to disk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,14 +459,18 @@ jobs:
         env:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
         run: |
+          # At trace level the controller emits the per-5s debug counter dump
+          # plus per-secret sync details, which fills 200 lines in a few
+          # seconds. 5000 keeps roughly 10+ minutes of context — enough to
+          # span the test that actually flaked plus its setup.
           echo "=== Kloak Controller Logs ==="
-          kubectl logs -n kloak-system -l app.kubernetes.io/component=controller --tail=200 2>/dev/null || true
+          kubectl logs -n kloak-system -l app.kubernetes.io/component=controller --tail=5000 2>/dev/null || true
           echo "=== Kloak Webhook Logs ==="
-          kubectl logs -n kloak-system -l app.kubernetes.io/component=webhook --tail=100 2>/dev/null || true
+          kubectl logs -n kloak-system -l app.kubernetes.io/component=webhook --tail=500 2>/dev/null || true
           echo "=== Demo App Logs ==="
           for app in demo-go demo-python demo-js demo-go-boring demo-python-raw-tls; do
             echo "--- $app ---"
-            kubectl logs -n kloak-e2e -l app=$app --tail=50 2>/dev/null || true
+            kubectl logs -n kloak-e2e -l app=$app --tail=200 2>/dev/null || true
           done
           echo "=== All Pods ==="
           kubectl get pods -A 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,10 +292,14 @@ jobs:
           # instead of rebuilt. Cache is pushed on every build so it stays warm.
           CACHE=${{ env.CACHE_REPO }}
 
+          # BPF_DEBUG=1 compiles the bpf_printk markers in pkg/ebpf/bpf/tls_uprobe.c.
+          # Their output streams to /sys/kernel/tracing/trace_pipe and is captured
+          # by the "Start BPF trace capture" step below.
           docker buildx build --load \
             --cache-from type=registry,ref=${CACHE}:kloak \
             --cache-to type=registry,ref=${CACHE}:kloak,mode=max \
-            --build-arg TARGETARCH=amd64 --build-arg COVER=1 -t kloak:e2e .
+            --build-arg TARGETARCH=amd64 --build-arg COVER=1 --build-arg BPF_DEBUG=1 \
+            -t kloak:e2e .
 
           docker buildx build --load \
             --cache-from type=registry,ref=${CACHE}:demo-go \
@@ -340,10 +344,40 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v5
 
+      - name: Start BPF trace capture
+        # bpf_printk in pkg/ebpf/bpf/tls_uprobe.c (compiled with BPF_DEBUG=1
+        # above) streams to /sys/kernel/tracing/trace_pipe — a kernel ring
+        # buffer that drains as it's read. We start a backgrounded reader
+        # before the test so the full data-plane trace is available on
+        # failure (the buffer otherwise rolls over within seconds).
+        run: |
+          sudo touch /tmp/bpf-trace.log
+          sudo chmod 666 /tmp/bpf-trace.log
+          sudo nohup sh -c 'cat /sys/kernel/tracing/trace_pipe > /tmp/bpf-trace.log 2>&1' >/dev/null 2>&1 &
+          echo $! | sudo tee /tmp/bpf-trace.pid >/dev/null
+          # Give the reader a moment to attach to the pipe.
+          sleep 1
+          ls -la /tmp/bpf-trace.log
+
       - name: Run E2E tests (with eBPF)
         run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
+
+      - name: Stop BPF trace capture
+        if: always()
+        run: |
+          PID=$(cat /tmp/bpf-trace.pid 2>/dev/null) || true
+          if [ -n "$PID" ]; then
+            sudo kill "$PID" 2>/dev/null || true
+          fi
+          # The reader is a child of nohup'd sh; its `cat` may outlive the
+          # shell. Sweep up by name as a safety net.
+          sudo pkill -f "cat /sys/kernel/tracing/trace_pipe" 2>/dev/null || true
+          # Make readable for the failure-collection step.
+          sudo chmod 666 /tmp/bpf-trace.log 2>/dev/null || true
+          echo "BPF trace size:"
+          ls -la /tmp/bpf-trace.log 2>/dev/null || true
 
       - name: Collect e2e coverage
         if: always()
@@ -446,8 +480,24 @@ jobs:
           sudo bpftool map list 2>/dev/null || true
           echo "=== Kernel dmesg (last 50 lines) ==="
           sudo dmesg | tail -50 2>/dev/null || true
-          echo "=== BPF trace_pipe (buffered) ==="
-          sudo timeout 2 cat /sys/kernel/tracing/trace_pipe 2>/dev/null | head -100 || true
+          # Captured trace_pipe output for the whole run. Filter to kloak's
+          # bpf_printk lines and tail so the workflow log stays readable;
+          # the full file is uploaded as an artifact below.
+          echo "=== BPF trace (kloak-only, last 500 lines) ==="
+          if [ -s /tmp/bpf-trace.log ]; then
+            grep -F kloak /tmp/bpf-trace.log | tail -500 || true
+          else
+            echo "(no trace captured)"
+          fi
+
+      - name: Upload BPF trace
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: bpf-trace
+          path: /tmp/bpf-trace.log
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Stop k3s
         if: always()

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,12 @@ COPY . .
 # Generate eBPF Go wrappers (bpf2go runs on host arch, targets BPF bytecode).
 # Then overwrite .o files with direct clang (bpf2go's strip corrupts them).
 # Map TARGETARCH (amd64, arm64) to kernel arch defines.
+# When BPF_DEBUG=1, define KLOAK_DEBUG so the in-kernel bpf_printk markers in
+# tls_uprobe.c are compiled in. Their output streams to
+# /sys/kernel/tracing/trace_pipe and is captured by the e2e job.
 ARG TARGETARCH
 ARG TARGETOS
+ARG BPF_DEBUG=0
 RUN if [ "$TARGETARCH" = "amd64" ]; then \
       ARCH_DEFINE=__TARGET_ARCH_x86; \
       export KLOAK_TARGET_ARCH=x86; \
@@ -26,10 +30,15 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       ARCH_DEFINE=__TARGET_ARCH_${TARGETARCH}; \
       export KLOAK_TARGET_ARCH=${TARGETARCH}; \
     fi && \
+    if [ "$BPF_DEBUG" = "1" ]; then \
+      DEBUG_DEFINE=-DKLOAK_DEBUG; \
+    else \
+      DEBUG_DEFINE=; \
+    fi && \
     cd pkg/ebpf && go generate && \
-    clang -O2 -g -Wall -Werror -D${ARCH_DEFINE} \
+    clang -O2 -g -Wall -Werror -D${ARCH_DEFINE} ${DEBUG_DEFINE} \
       -target bpfel -c bpf/tls_uprobe.c -o tlsuprobe_bpfel.o && \
-    clang -O2 -g -Wall -Werror -D${ARCH_DEFINE} \
+    clang -O2 -g -Wall -Werror -D${ARCH_DEFINE} ${DEBUG_DEFINE} \
       -target bpfeb -c bpf/tls_uprobe.c -o tlsuprobe_bpfeb.o
 
 # Cross-compile Go binary for the target platform (no CGO, pure Go).


### PR DESCRIPTION
## Summary
Two changes that let us actually capture the in-kernel BPF trail on e2e failures, complementing PR #166's userspace trace logging.

- **Dockerfile**: new `BPF_DEBUG=1` build-arg. When set, clang gets `-DKLOAK_DEBUG`, compiling the `bpf_printk` lines already present in `pkg/ebpf/bpf/tls_uprobe.c` (guarded behind `#ifdef KLOAK_DEBUG`). Default off — production images stay quiet.
- **ci.yml e2e job**:
  - Passes `--build-arg BPF_DEBUG=1` for the `kloak:e2e` image.
  - Adds **Start BPF trace capture** — backgrounds a `sudo cat /sys/kernel/tracing/trace_pipe > /tmp/bpf-trace.log`. `trace_pipe` is a draining ring buffer; without a long-lived reader, most of the data-plane trail rolls off within seconds. The pre-existing on-failure dump (`sudo timeout 2 cat trace_pipe`) only caught the last fragment.
  - Adds **Stop BPF trace capture** (`if: always()`) — kills the reader, plus a `pkill` safety net for the orphaned `cat` if its nohup shell exits first.
  - On-failure dump now `grep -F kloak /tmp/bpf-trace.log | tail -500`, and the full file is uploaded as a `bpf-trace` artifact (retention 7 days) so it survives single-job re-runs.

## Why
The recent `TestCipherSuites/4hop`, `TestEBPFRawTLSHostFiltering`, and `TestEBPFSecretRewrite/{python,js}` flakes can't be diagnosed without distinguishing "uprobe never fired" from "fallback miss" from "tag patch miss." `bpf_printk` has the answers, but the `#ifdef KLOAK_DEBUG` guard means the relevant calls aren't compiled in for production builds. Turning it on for the e2e image (only) and capturing the stream throughout the run gives us the data without changing any runtime behavior.

## Sequence on the runner
```
Start BPF trace capture            (cat trace_pipe & → /tmp/bpf-trace.log)
Run E2E tests (with eBPF)
Stop BPF trace capture              (kill reader, even if tests passed)
... coverage steps ...
Collect logs and BPF debug info on failure   (greps the captured file)
Upload BPF trace                    (artifact, always)
Stop k3s
```

## Test plan
- [ ] CI on this PR runs e2e green; the **BPF trace size** echo at the end of "Stop BPF trace capture" shows non-empty file
- [ ] If e2e fails, the on-failure dump's "BPF trace (kloak-only, last 500 lines)" section contains lines like `kloak [2-KPROBE-GO] H-fail: ...`, `kloak [3-TC] HIT/MISS ...`, etc.
- [ ] `bpf-trace` artifact is downloadable from the run page

🤖 Generated with [Claude Code](https://claude.com/claude-code)