### PR TITLE
debug(bpf): print on the two silent H-extract returns

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1546,7 +1546,7 @@ int bpf_h_extract(void *ctx) {
   __builtin_memset(&new_conn, 0, sizeof(new_conn));
   if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0) {
 #ifdef KLOAK_DEBUG
-    bpf_printk("kloak [H-EXTRACT] H-fail: read failed ptr=%llx off=%u",
+    bpf_printk("kloak [H-EXTRACT] H-fail: H read failed ptr=%llx off=%u",
                ptr, offsets->algctx_to_h);
 #endif
     return 0;
@@ -2186,6 +2186,7 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
       bpf_printk("kloak [2-KPROBE] H-fail: H read failed ptr=%llx off=%u",
                  ptr, offsets->algctx_to_h);
 #endif
+      dbg_inc(DBG_KPROBE_BRIDGE_H_FAIL);
       return 0;
     }
 
@@ -2195,6 +2196,7 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
       bpf_printk("kloak [2-KPROBE] H-fail: H zero ptr=%llx off=%u",
                  ptr, offsets->algctx_to_h);
 #endif
+      dbg_inc(DBG_KPROBE_BRIDGE_H_FAIL);
       return 0;
     }
     h64[0] = __builtin_bswap64(h64[0]);

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1544,14 +1544,24 @@ int bpf_h_extract(void *ctx) {
   // The struct is 276 bytes but we only write 18 bytes — the rest is zero from stack init.
   struct tls_conn_state new_conn;
   __builtin_memset(&new_conn, 0, sizeof(new_conn));
-  if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0)
+  if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0) {
+#ifdef KLOAK_DEBUG
+    bpf_printk("kloak [H-EXTRACT] H-fail: read failed ptr=%llx off=%u",
+               ptr, offsets->algctx_to_h);
+#endif
     return 0;
+  }
 
   // OpenSSL stores H as two u64 in native (little-endian) byte order.
   // GHASH expects big-endian byte order. Byte-swap each 8-byte half.
   __u64 *h64 = (__u64 *)new_conn.ghash_h;
-  if (h64[0] == 0 && h64[1] == 0)
+  if (h64[0] == 0 && h64[1] == 0) {
+#ifdef KLOAK_DEBUG
+    bpf_printk("kloak [H-EXTRACT] H-fail: H zero ptr=%llx off=%u",
+               ptr, offsets->algctx_to_h);
+#endif
     return 0;
+  }
   h64[0] = __builtin_bswap64(h64[0]);
   h64[1] = __builtin_bswap64(h64[1]);
 
@@ -2171,12 +2181,22 @@ int bpf_kprobe_tcp_sendmsg(void *ctx) {
 #endif
       return 0;
     }
-    if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0)
+    if (bpf_probe_read_user(new_conn.ghash_h, 16, (void *)(ptr + offsets->algctx_to_h)) < 0) {
+#ifdef KLOAK_DEBUG
+      bpf_printk("kloak [2-KPROBE] H-fail: H read failed ptr=%llx off=%u",
+                 ptr, offsets->algctx_to_h);
+#endif
       return 0;
+    }
 
     __u64 *h64 = (__u64 *)new_conn.ghash_h;
-    if (h64[0] == 0 && h64[1] == 0)
+    if (h64[0] == 0 && h64[1] == 0) {
+#ifdef KLOAK_DEBUG
+      bpf_printk("kloak [2-KPROBE] H-fail: H zero ptr=%llx off=%u",
+                 ptr, offsets->algctx_to_h);
+#endif
       return 0;
+    }
     h64[0] = __builtin_bswap64(h64[0]);
     h64[1] = __builtin_bswap64(h64[1]);
 


### PR DESCRIPTION
## Summary
Add `bpf_printk` markers (under `#ifdef KLOAK_DEBUG`, same pattern as the existing H-fail prints) on the two `return 0` paths in `bpf_h_extract` and the OpenSSL branch of `bpf_kprobe_tcp_sendmsg` that come right after the SSL pointer-chain walk:

```c
if (bpf_probe_read_user(new_conn.ghash_h, 16, ptr + algctx_to_h) < 0)
    return 0;            // path 1: read failed (-EFAULT)
if (h64[0] == 0 && h64[1] == 0)
    return 0;            // path 2: H is all-zero
```

Tags emitted:
- `kloak [H-EXTRACT] H-fail: read failed ptr=… off=…`
- `kloak [H-EXTRACT] H-fail: H zero    ptr=… off=…`
- `kloak [2-KPROBE]  H-fail: H read failed ptr=… off=…`
- `kloak [2-KPROBE]  H-fail: H zero        ptr=… off=…`

## Why
[Run #24996884923](https://github.com/spinningfactory/kloak/actions/runs/24996884923) trace artifact shows:

| cgroup | binary | TC HIT | TC MISS |
|---|---|---|---|
| 2c46 | debian curl (3hop) | 7 | 3 |
| 3502 | go demo | 1 | 2 |
| **2b44** | **alpine curl (4hop)** | **0** | **88** |

For alpine curl: 832 `[2-KPROBE] FOUND xor_pending` events, **zero** curl-side H-fail messages, and zero successful tc_pending writes (`[2-KPROBE] sport=… cg=2b44` never appears). The bridge is silently dropping somewhere between successful pointer-chain walk and the tc_pending write — and the only two unlogged exits in that window are the H read and the H-zero check above.

Once these prints are in, the next 4hop failure will tell us:
- **"H read failed"** → `algctx_to_h` offset is wrong for the alpine OpenSSL 3.5.6 build; tighten/widen version detection.
- **"H zero"** → AEAD context not yet initialized when the kprobe fires; defer the bridge until we see a non-zero H once.

No production-behavior change — printks are inside `#ifdef KLOAK_DEBUG`, only included when the e2e Dockerfile sets `BPF_DEBUG=1` (PR #167).

## Test plan
- [ ] CI e2e on this PR runs (might still flake on 4hop — that's expected and is the data we want)
- [ ] When 4hop flakes, the `bpf-trace` artifact contains one of the two new tags for cg=2b44, telling us which path fired
- [ ] When 4hop passes, the new tags don't appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)