### PR TITLE
ci: strip generated eBPF bindings from unit coverage too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,21 +421,31 @@ jobs:
 
           # Build the combined profile. Each profile starts with a `mode:` line
           # plus per-line records. We pick whichever inputs exist.
-          # Drop the generated eBPF bindings — they have no source on the runner,
-          # so the coverage reporter can't resolve them.
+          # Drop the generated eBPF bindings (tlsuprobe_bpfel.go /
+          # tlsuprobe_bpfeb.go) from BOTH halves — they're only on disk on
+          # nodes that ran `go generate`, and downstream jobs that read the
+          # profile (Coverage Badge runs `go tool cover -func` against the
+          # whole file) will fail otherwise. Apply the filter to the unit
+          # half too, since pkg/ebpf is now in unit coverage.
           UNIT=/tmp/unit-coverage/coverage.out
           E2E=/tmp/e2e-coverage.out
           OUT=/tmp/combined-coverage.out
 
+          # head -1 keeps the `mode:` line; the filter trims subsequent lines.
+          strip_generated() { grep -v 'tlsuprobe_bpf'; }
+
           if [ -f "$UNIT" ] && [ -f "$E2E" ]; then
-            cp "$UNIT" "$OUT"
-            tail -n +2 "$E2E" | grep -v 'tlsuprobe_bpf' >> "$OUT"
+            head -1 "$UNIT" > "$OUT"
+            tail -n +2 "$UNIT" | strip_generated >> "$OUT"
+            tail -n +2 "$E2E"  | strip_generated >> "$OUT"
             echo "Combined unit + e2e coverage"
           elif [ -f "$UNIT" ]; then
-            cp "$UNIT" "$OUT"
+            head -1 "$UNIT" > "$OUT"
+            tail -n +2 "$UNIT" | strip_generated >> "$OUT"
             echo "Unit coverage only (no e2e data)"
           elif [ -f "$E2E" ]; then
-            grep -v 'tlsuprobe_bpf' "$E2E" > "$OUT"
+            head -1 "$E2E" > "$OUT"
+            tail -n +2 "$E2E" | strip_generated >> "$OUT"
             echo "E2E coverage only (no unit artifact — likely a single-job re-run after retention)"
           else
             echo "No coverage data available; producing empty profile"


### PR DESCRIPTION
## Summary
The Coverage Badge job on [main run #25000416952](https://github.com/spinningfactory/kloak/actions/runs/25000416952/job/73210556724) failed at `go tool cover -func combined-coverage.out` with:

```
cover: open .../pkg/ebpf/tlsuprobe_bpfel.go: no such file or directory
```

`tlsuprobe_bpfel.go` is bpf2go-generated and not committed; the Badge job runs on a clean checkout without a `go generate` step. The merge step already strips that file from the e2e half but copies the unit half verbatim. After PR #162 added `pkg/ebpf` to unit tests, the generated wrapper now appears in unit-coverage.out — and rides through unfiltered into combined-coverage.out, breaking downstream tooling.

## Fix
Apply the same `grep -v 'tlsuprobe_bpf'` filter to the unit half. All three branches of the merge (unit+e2e, unit-only, e2e-only) now use the same pattern: `head -1` for the `mode:` line, `tail -n +2 | strip_generated` for the records.

## Test plan
- [ ] CI on this PR runs through the merge step without failure
- [ ] Coverage Badge runs successfully on the next push to main and updates the badge
- [ ] Coverage Report (PR comment via fgrosse/go-coverage-report) still works — that one only reads lines for files changed in the PR, but a dirty profile shouldn't affect it either

🤖 Generated with [Claude Code](https://claude.com/claude-code)