### PR TITLE
ci(e2e): flush kloak covcounters on shutdown so e2e contributes to coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,9 +387,13 @@ jobs:
           mkdir -p /tmp/e2e-covdata
           # Wait for the controller pod to fully terminate so the Go coverage
           # runtime can flush covcounters to the hostPath volume on clean exit.
-          # Helm uninstall from test teardown triggers the shutdown.
+          # The e2e teardown runs `helm uninstall --wait`, which already blocks
+          # until the pod is gone — the wait here is a belt-and-suspenders for
+          # rerun scenarios where teardown didn't run. 90s matches the helm
+          # timeout and covers the 60s pod terminationGracePeriodSeconds plus
+          # the time kloak's shutdown path takes (uprobe detach, BPF close).
           kubectl wait --for=delete pod -l app.kubernetes.io/component=controller \
-            -n kloak-system --timeout=30s 2>/dev/null || true
+            -n kloak-system --timeout=90s 2>/dev/null || true
           # k3s runs directly on the runner, so covdata lives at /tmp/kloak-coverage
           # on the host filesystem (values-e2e.yaml's coverage.hostPath).
           sudo cp -r /tmp/kloak-coverage/. /tmp/e2e-covdata/ 2>/dev/null || true

--- a/charts/kloak/templates/controller-daemonset.yaml
+++ b/charts/kloak/templates/controller-daemonset.yaml
@@ -19,6 +19,12 @@ spec:
     spec:
       serviceAccountName: kloak-controller
       hostPID: true
+      # 60s gives the controller-runtime manager time to finish its shutdown
+      # path (uprobe detach, BPF program close) on SIGTERM, so Go's coverage
+      # runtime can flush covcounters before kubelet SIGKILLs the pod. The
+      # default 30s was racing the cleanup and producing covmeta-only
+      # artifacts in CI.
+      terminationGracePeriodSeconds: 60
       initContainers:
         - name: mount-tracefs
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -135,8 +135,12 @@ func teardown() {
 	// Delete test namespace (cascade deletes all resources in it)
 	_ = clientset.CoreV1().Namespaces().Delete(context.Background(), testNamespace, metav1.DeleteOptions{})
 	// Remove kloak deployment unless we skipped install.
+	// --wait blocks until the controller pod is deleted, so the Go coverage
+	// runtime has time to flush covcounters to the hostPath volume on clean
+	// SIGTERM. Without it, helm returns immediately and the next CI step
+	// races kubelet's SIGKILL.
 	if os.Getenv("E2E_SKIP_INSTALL") == "" {
-		_, _ = helm("uninstall", "kloak", "-n", kloakNamespace)
+		_, _ = helm("uninstall", "kloak", "-n", kloakNamespace, "--wait", "--timeout", "90s")
 	}
 }
 


### PR DESCRIPTION
## Summary

The combined-coverage badge dropped to 33.3% on main after PR #162 broadened the unit-test scope to include `pkg/ebpf`. Diagnosis showed the **e2e half wasn't merging** — the merge step has been printing `Unit coverage only (no e2e data)` on every recent main run.

Root cause: `/tmp/kloak-coverage` had `covmeta.*` but no `covcounters.*`. Go's `-cover` runtime writes covmeta on startup but covcounters only on **clean** exit. The chain that delivers clean exit was racing kubelet's SIGKILL:

1. E2E teardown called `helm uninstall` (fire-and-forget) then `os.Exit(code)` immediately.
2. The next CI step waited up to 30s for the pod to disappear.
3. The DaemonSet's default `terminationGracePeriodSeconds` (30s) was barely enough for controller-runtime shutdown + uprobe detach, so the Go runtime often didn't reach the at-exit covcounters write before SIGKILL.

Fix end-to-end:

- `test/e2e/e2e_test.go` — `helm uninstall --wait --timeout 90s` so teardown blocks until the pod is gone.
- `charts/kloak/templates/controller-daemonset.yaml` — `terminationGracePeriodSeconds: 60` so the Go runtime's at-exit hook has time to flush.
- `.github/workflows/ci.yml` — bump `kubectl wait --for=delete` timeout 30s → 90s as a belt-and-suspenders for rerun scenarios.

Once this lands, `pkg/ebpf` runtime (uprobe.go, sync.go) will get real e2e coverage and the badge should jump past the previous 51.4% baseline.

## Per-package state today (unit only, what 33.3% is computed from)

| Package | Coverage |
|---|---|
| pkg/logging | 98.1% |
| pkg/webhook | 88.3% |
| pkg/cgroups | 66.7% |
| pkg/controller | 66.2% |
| pkg/ebpf | **24.2%** ← needs e2e to move |

## Test plan

- [ ] CI runs green on this PR.
- [ ] After merge to main, inspect the `Collect e2e coverage` step output: should see both `covmeta.*` and `covcounters.*` files.
- [ ] `Merge unit and e2e coverage` step prints `Combined unit + e2e coverage`, not `Unit coverage only`.
- [ ] Coverage badge jumps from 33.3% to a higher number (expect mid-50s+).

🤖 Generated with [Claude Code](https://claude.com/claude-code)