### PR TITLE
ci: explicitly flush coverage counters on kloak shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,14 @@ jobs:
         #   - test/e2e — separate job
         #   - cmd/      — entrypoint wiring; coverage merges via the e2e binary
         #   - tools/    — CLI utilities, coverage isn't meaningful
-        run: go test -v -race -coverprofile=coverage.out $(go list ./... | grep -v -E '/test/e2e|/cmd/|/tools/')
+        # Then strip the bpf2go-generated tlsuprobe_bpf{el,eb}.go from the
+        # profile so it doesn't inflate denominators or break downstream
+        # `go tool cover -func` on jobs that don't run `go generate`.
+        run: |
+          go test -v -race -coverprofile=coverage.raw $(go list ./... | grep -v -E '/test/e2e|/cmd/|/tools/')
+          head -1 coverage.raw > coverage.out
+          tail -n +2 coverage.raw | grep -v 'tlsuprobe_bpf' >> coverage.out
+          rm -f coverage.raw
 
       - name: Upload unit coverage
         uses: actions/upload-artifact@v5

--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -170,6 +170,14 @@ func runController(cmd *cobra.Command, args []string) {
 			setupLog.Errorw("failed to close uprobe manager", "error", err)
 		}
 	}
+
+	// Flush coverage counters explicitly when GOCOVERDIR is set. Go's
+	// at-exit hook for `-cover` builds is unreliable on SIGTERM in
+	// containerized environments — the e2e CI was capturing covmeta but
+	// never covcounters, so pkg/ebpf runtime code showed as 0 % covered.
+	// runtime/coverage.WriteCountersDir is a no-op when the binary wasn't
+	// built with -cover, so this is safe in production.
+	flushCoverageCounters(setupLog)
 }
 
 // discoverTrustedDNSServers returns the list of trusted DNS server IPs.

--- a/cmd/kloak/coverage.go
+++ b/cmd/kloak/coverage.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"os"
+	"runtime/coverage"
+
+	"go.uber.org/zap"
+)
+
+// flushCoverageCounters writes covcounters to GOCOVERDIR before main returns.
+// Without this, the e2e CI consistently captured covmeta but never
+// covcounters — Go's automatic at-exit flush for -cover builds is racy on
+// SIGTERM under kubelet-managed grace periods. WriteCountersDir is a no-op
+// when the binary was built without -cover, so it's safe in production
+// images that don't pass GOCOVERDIR.
+func flushCoverageCounters(log *zap.SugaredLogger) {
+	dir := os.Getenv("GOCOVERDIR")
+	if dir == "" {
+		return
+	}
+	if err := coverage.WriteCountersDir(dir); err != nil {
+		log.Warnw("failed to flush coverage counters", "dir", dir, "error", err)
+		return
+	}
+	log.Infow("flushed coverage counters", "dir", dir)
+}

--- a/cmd/kloak/webhook.go
+++ b/cmd/kloak/webhook.go
@@ -85,4 +85,6 @@ func runWebhook(cmd *cobra.Command, args []string) {
 		_ = setupLog.Sync()
 		os.Exit(1)
 	}
+
+	flushCoverageCounters(setupLog)
 }


### PR DESCRIPTION
## Summary

PR #170 raised `terminationGracePeriodSeconds` and switched helm uninstall to `--wait`, but the coverage badge stayed at **33.3 %** on main after the merge.

Looking at run 25005479606:
- `helm uninstall --wait` returned in ~350 ms (it doesn't actually wait for pods to fully drain — only for the API call to ack)
- `kubectl wait --for=delete pod` then timed out at 90 s (pod still alive past the grace period)
- Only `covmeta.43812e25...` landed in `/tmp/kloak-coverage` — no `covcounters.*`
- Merge step took the **Unit only** branch again

Go's automatic at-exit hook for `-cover` builds is unreliable on SIGTERM under kubelet-managed grace periods. The fix is to **stop relying on it** and flush counters from kloak itself.

## Changes

- `cmd/kloak/coverage.go` (new) — `flushCoverageCounters` calls `runtime/coverage.WriteCountersDir(GOCOVERDIR)` if `GOCOVERDIR` is set. No-op when the binary wasn't built with `-cover`, so production images carry zero overhead.
- `cmd/kloak/controller.go` — invoke after `mgr.Start` returns and `uprobeMgr.Close()` finishes, so counters reflect the full run including shutdown-time cleanup.
- `cmd/kloak/webhook.go` — same on the webhook subcommand path.
- `.github/workflows/ci.yml` — strip bpf2go-generated `tlsuprobe_bpf{el,eb}.go` at the unit-test step too, not just at merge time. Cosmetic but makes the raw `coverage.out` artifact honest.

## On exclusions / generated files (the question that prompted this)

| Category | What's in coverage today | Action |
|---|---|---|
| `pkg/ebpf/tlsuprobe_bpf{el,eb}.go` (generated) | Was in raw unit profile, stripped at merge | Now stripped at unit step too — safe in all artifacts |
| `pkg/ebpf/uprobe.go`, `sync.go` (runtime BPF) | 0 % until e2e flush works | Keep — e2e is the right way to cover it; this PR enables it |
| `cmd/`, `tools/`, `test/e2e/` | Already excluded | Keep excluded |
| `pkg/controller/*::SetupWithManager` (~6 stmts boilerplate) | 0 % | Not worth excluding via tooling — accept |

No other generated files in the codebase (`grep -l "Code generated"` returns only the two bpf2go wrappers).

## Expected effect after merge

The flush call should appear in controller logs (`flushed coverage counters` at info level) and the next post-merge run should print `Combined unit + e2e coverage` in the merge step. Badge should jump well past the prior 51.4 % baseline as `pkg/ebpf` runtime functions get real e2e coverage.

## Test plan

- [ ] CI green on this PR
- [ ] After merge: `Collect e2e coverage` lists both `covmeta.*` AND `covcounters.*`
- [ ] `Merge unit and e2e coverage` prints `Combined unit + e2e coverage`
- [ ] Coverage badge jumps from 33.3 % to 50 %+

🤖 Generated with [Claude Code](https://claude.com/claude-code)