### PR TITLE
fix(controller): graceful shutdown on signal with bounded cleanup

### DIFF
--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -62,9 +63,16 @@ func runController(cmd *cobra.Command, args []string) {
 
 	setupLog.Infow("Starting Kloak controller", "ebpf", enableEBPF, "cgroupPath", cgroupPath)
 
+	// 30 s is well under the daemonset's 60 s terminationGracePeriodSeconds,
+	// leaving headroom for our own cleanup (uprobe/link Close) and any final
+	// log flush before kubelet's SIGKILL. Without this the manager defaults
+	// to 30 s anyway, but pinning it documents the budget and makes it
+	// obvious where to tune if shutdown ever pushes past the grace period.
+	gracefulShutdown := 30 * time.Second
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 scheme,
-		HealthProbeBindAddress: controllerProbeAddr,
+		Scheme:                  scheme,
+		HealthProbeBindAddress:  controllerProbeAddr,
+		GracefulShutdownTimeout: &gracefulShutdown,
 	})
 	if err != nil {
 		setupLog.Errorw("unable to start manager", "error", err)
@@ -160,16 +168,25 @@ func runController(cmd *cobra.Command, args []string) {
 	}
 
 	setupLog.Infow("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Errorw("problem running manager", "error", err)
+	signalCtx := ctrl.SetupSignalHandler()
+	startErr := mgr.Start(signalCtx)
+	// Past mgr.Start: signalCtx is done, manager has already given runnables
+	// up to GracefulShutdownTimeout to return. Log the trigger so the cause
+	// (signal vs runnable error) is unambiguous in post-mortem CI logs.
+	if signalCtx.Err() != nil {
+		setupLog.Infow("shutdown signal received, draining")
+	}
+	if startErr != nil {
+		setupLog.Errorw("problem running manager", "error", startErr)
 	}
 
-	// Cleanup
 	if uprobeMgr != nil {
 		if err := uprobeMgr.Close(); err != nil {
 			setupLog.Errorw("failed to close uprobe manager", "error", err)
 		}
 	}
+	setupLog.Infow("controller exited cleanly")
+	_ = setupLog.Sync()
 }
 
 // discoverTrustedDNSServers returns the list of trusted DNS server IPs.

--- a/cmd/kloak/webhook.go
+++ b/cmd/kloak/webhook.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -43,9 +44,11 @@ func runWebhook(cmd *cobra.Command, args []string) {
 
 	setupLog.Infow("Starting Kloak webhook")
 
+	gracefulShutdown := 30 * time.Second
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-		Scheme:                 webhookScheme,
-		HealthProbeBindAddress: webhookProbeAddr,
+		Scheme:                  webhookScheme,
+		HealthProbeBindAddress:  webhookProbeAddr,
+		GracefulShutdownTimeout: &gracefulShutdown,
 		WebhookServer: webhook.NewServer(webhook.Options{
 			Port:    9443,
 			CertDir: webhookCertDir,
@@ -80,9 +83,16 @@ func runWebhook(cmd *cobra.Command, args []string) {
 	}
 
 	setupLog.Infow("starting webhook server")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
-		setupLog.Errorw("problem running manager", "error", err)
+	signalCtx := ctrl.SetupSignalHandler()
+	startErr := mgr.Start(signalCtx)
+	if signalCtx.Err() != nil {
+		setupLog.Infow("shutdown signal received, draining")
+	}
+	if startErr != nil {
+		setupLog.Errorw("problem running manager", "error", startErr)
 		_ = setupLog.Sync()
 		os.Exit(1)
 	}
+	setupLog.Infow("webhook exited cleanly")
+	_ = setupLog.Sync()
 }


### PR DESCRIPTION
## Summary

The post-merge run after #170 still produced covmeta-only artifacts and a 33.3 % badge. The runtime symptom is the kloak DaemonSet pod not finishing its shutdown within kubelet's grace window before SIGKILL — and the manager wiring made it impossible to tell from logs whether shutdown even started.

This PR makes shutdown explicit, bounded, and observable, without touching production behaviour in steady state.

## Changes

- **Pin `Manager.GracefulShutdownTimeout` to 30 s** in both subcommands. With `terminationGracePeriodSeconds=60s` from PR #170, this leaves 30 s of headroom for our own cleanup (uprobe/link Close) plus final log writes before SIGKILL.
- **Log shutdown phases**: `"shutdown signal received, draining"` when the signal context flips done, `"controller exited cleanly"` (or `"webhook exited cleanly"`) right before return. Combined with the trace-level CI logs, post-mortems can now identify exactly where shutdown stalls if it ever does.
- **Sync the logger on the success path**. The error paths already called `setupLog.Sync()`; the success path didn't, so the final structured lines were at risk on fast teardown.

## What this is *not*

- No production code aware of testing/coverage. The only addition is timeouts + log lines, both standard hygiene.
- No change to the data plane.
- No new dependencies.

## Verification

- Local: `GOOS=linux go build ./cmd/kloak/` clean.
- CI: the new log lines should appear in `dumpLogs()` output and (more importantly) in the bpf-trace / controller log captures on the e2e job. If shutdown still doesn't complete, the logs will show *which phase* hung.

## Test plan

- [ ] CI green
- [ ] After merge, the post-merge main run's e2e logs include `controller exited cleanly` before the pod terminates
- [ ] If the badge still doesn't recover, the new logs will tell us whether mgr.Start is returning at all on signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)