### PR TITLE
fix(controller): exit on eBPF init failure instead of select {}

### DIFF
--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -78,9 +78,9 @@ func runController(cmd *cobra.Command, args []string) {
 	if enableEBPF {
 		uprobeMgr, err = ebpf.NewTLSUprobeManager(mgr.GetClient(), cgroupPath, setupLog)
 		if err != nil {
-			setupLog.Errorw("failed to initialize eBPF uprobe manager — sleeping to preserve logs", "error", err)
+			setupLog.Errorw("failed to initialize eBPF uprobe manager", "error", err)
 			_ = setupLog.Sync()
-			select {} // Block forever so the container doesn't restart and logs are preserved.
+			os.Exit(1)
 		}
 		setupLog.Infow("eBPF TLS uprobes enabled")
 	} else {


### PR DESCRIPTION
## Summary

Replace `select {}` on the eBPF init-failure path with `os.Exit(1)`.

## Why

`select {}` was intended to keep the container alive after a failed init "to preserve logs", but it has two real downsides:

1. **Masks failures as healthy.** The pod sits in Ready forever doing nothing — kubelet never restarts the DaemonSet, no CrashLoopBackoff surfaces, and operators only notice when downstream traffic that should be intercepted isn't being intercepted. Logs are still accessible via `kubectl logs --previous` after a normal exit, so the original justification doesn't hold.
2. **Fragile to refactoring.** Today this runs *before* `ctrl.SetupSignalHandler` installs `signal.Notify`, so SIGTERM uses Go's default disposition and the container exits. The moment signal handling is moved earlier (a reasonable refactor), SIGTERM gets buffered into the controller-runtime channel, only cancels ctx (no effect on `select {}`), and the goroutine waits for a second signal that kubelet never sends — pod hangs the full grace period and eats SIGKILL. That's the exact graceful-shutdown failure mode we're already chasing.

## Change

Log the error, sync, `os.Exit(1)`. Kubelet sees the failure, restarts the pod (or surfaces CrashLoopBackoff if it's persistent).

## Test plan

- [ ] CI green
- [ ] Verified locally that `GOOS=linux go build ./cmd/kloak/` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)