### PR TITLE
fix(ebpf): close BPF links concurrently on shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,46 +385,17 @@ jobs:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
         run: |
           mkdir -p /tmp/e2e-covdata
-          # Force a covcounters flush via a two-SIGTERM dance:
-          #
-          #   1. Trigger SIGTERM #1 by `helm uninstall` — kubelet sees the
-          #      DaemonSet deletion and sends SIGTERM to the pod. (We run
-          #      this here unconditionally; the e2e teardown also runs it,
-          #      but if the test process panicked — e.g. the suite's
-          #      15-minute timer fired during a 4hop flake — teardown is
-          #      skipped and we have to do it ourselves.)
-          #
-          #   2. Capture the controller pod name BEFORE its container exits.
-          #
-          #   3. Send SIGTERM #2 via `kubectl exec ... kill -TERM 1`.
-          #      controller-runtime's signal handler maps the first SIGTERM
-          #      to ctx cancellation and the second to os.Exit(1), which
-          #      runs Go's runtime exit hooks — including the
-          #      runtime/coverage hook that writes covcounters — regardless
-          #      of how far the in-flight cleanup has progressed.
-          #
-          # Without step 3, the long uprobeMgr.Close path can outlast
-          # kubelet's grace period and the pod is SIGKILL'd before the hook
-          # fires. CI-only; production code stays unaware.
+          # Run helm uninstall here unconditionally — the e2e teardown does
+          # it too, but if the test process panicked (e.g. the suite's
+          # 15-minute timer fired during a 4hop flake) teardown is skipped
+          # and we'd be left with a running pod and no covcounters.
           helm uninstall kloak -n kloak-system --ignore-not-found 2>&1 || true
-          POD=$(kubectl get pods -n kloak-system \
-            -l app.kubernetes.io/component=controller \
-            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-          if [ -n "$POD" ]; then
-            # Brief wait so SIGTERM #1 lands and controller-runtime's
-            # signal handler advances past the first `<-c`. Without this
-            # the second signal could race the first into the same channel
-            # slot and only one cancel happens.
-            sleep 1
-            echo "Sending SIGTERM #2 to $POD/controller (PID 1) for coverage flush"
-            kubectl exec -n kloak-system "$POD" -c controller -- kill -TERM 1 2>&1 || true
-          else
-            echo "No controller pod found — skipping force flush"
-          fi
-          # Wait for the controller pod to fully terminate so the Go coverage
-          # runtime can flush covcounters to the hostPath volume on clean exit.
-          # 90s covers the 60s pod terminationGracePeriodSeconds plus uprobe
-          # detach / BPF close time.
+          # Wait for the controller pod to fully terminate. The kloak
+          # binary's `flushCoverage` (cmd/kloak/coverage_flush_cover.go,
+          # compiled in via -tags cover when COVER=1) writes covcounters
+          # before main returns, so any clean exit produces a usable
+          # profile. 90s covers the 60s pod terminationGracePeriodSeconds
+          # plus uprobe detach / BPF close time.
           kubectl wait --for=delete pod -l app.kubernetes.io/component=controller \
             -n kloak-system --timeout=90s 2>/dev/null || true
           # k3s runs directly on the runner, so covdata lives at /tmp/kloak-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,13 +385,28 @@ jobs:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
         run: |
           mkdir -p /tmp/e2e-covdata
+          # Force a covcounters flush by sending a *second* SIGTERM to PID 1.
+          # controller-runtime's signal handler maps the first SIGTERM (from
+          # kubelet on helm uninstall) to ctx cancellation, and the second to
+          # os.Exit(1). os.Exit runs Go's runtime exit hooks — including the
+          # runtime/coverage hook that writes covcounters — regardless of how
+          # far the in-flight cleanup (uprobeMgr.Close, etc.) has progressed.
+          # Without this, long Close paths outlast the grace period and
+          # kubelet SIGKILL'd the pod before the hook fired, losing the e2e
+          # half of coverage. CI-only; production code is unaware.
+          POD=$(kubectl get pods -n kloak-system \
+            -l app.kubernetes.io/component=controller \
+            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+          if [ -n "$POD" ]; then
+            echo "Sending SIGTERM #2 to $POD/controller (PID 1) for coverage flush"
+            kubectl exec -n kloak-system "$POD" -c controller -- kill -TERM 1 2>&1 || true
+          else
+            echo "No controller pod found — skipping force flush"
+          fi
           # Wait for the controller pod to fully terminate so the Go coverage
           # runtime can flush covcounters to the hostPath volume on clean exit.
-          # The e2e teardown runs `helm uninstall --wait`, which already blocks
-          # until the pod is gone — the wait here is a belt-and-suspenders for
-          # rerun scenarios where teardown didn't run. 90s matches the helm
-          # timeout and covers the 60s pod terminationGracePeriodSeconds plus
-          # the time kloak's shutdown path takes (uprobe detach, BPF close).
+          # 90s covers the 60s pod terminationGracePeriodSeconds plus uprobe
+          # detach / BPF close time.
           kubectl wait --for=delete pod -l app.kubernetes.io/component=controller \
             -n kloak-system --timeout=90s 2>/dev/null || true
           # k3s runs directly on the runner, so covdata lives at /tmp/kloak-coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -385,19 +385,37 @@ jobs:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
         run: |
           mkdir -p /tmp/e2e-covdata
-          # Force a covcounters flush by sending a *second* SIGTERM to PID 1.
-          # controller-runtime's signal handler maps the first SIGTERM (from
-          # kubelet on helm uninstall) to ctx cancellation, and the second to
-          # os.Exit(1). os.Exit runs Go's runtime exit hooks — including the
-          # runtime/coverage hook that writes covcounters — regardless of how
-          # far the in-flight cleanup (uprobeMgr.Close, etc.) has progressed.
-          # Without this, long Close paths outlast the grace period and
-          # kubelet SIGKILL'd the pod before the hook fired, losing the e2e
-          # half of coverage. CI-only; production code is unaware.
+          # Force a covcounters flush via a two-SIGTERM dance:
+          #
+          #   1. Trigger SIGTERM #1 by `helm uninstall` — kubelet sees the
+          #      DaemonSet deletion and sends SIGTERM to the pod. (We run
+          #      this here unconditionally; the e2e teardown also runs it,
+          #      but if the test process panicked — e.g. the suite's
+          #      15-minute timer fired during a 4hop flake — teardown is
+          #      skipped and we have to do it ourselves.)
+          #
+          #   2. Capture the controller pod name BEFORE its container exits.
+          #
+          #   3. Send SIGTERM #2 via `kubectl exec ... kill -TERM 1`.
+          #      controller-runtime's signal handler maps the first SIGTERM
+          #      to ctx cancellation and the second to os.Exit(1), which
+          #      runs Go's runtime exit hooks — including the
+          #      runtime/coverage hook that writes covcounters — regardless
+          #      of how far the in-flight cleanup has progressed.
+          #
+          # Without step 3, the long uprobeMgr.Close path can outlast
+          # kubelet's grace period and the pod is SIGKILL'd before the hook
+          # fires. CI-only; production code stays unaware.
+          helm uninstall kloak -n kloak-system --ignore-not-found 2>&1 || true
           POD=$(kubectl get pods -n kloak-system \
             -l app.kubernetes.io/component=controller \
             -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
           if [ -n "$POD" ]; then
+            # Brief wait so SIGTERM #1 lands and controller-runtime's
+            # signal handler advances past the first `<-c`. Without this
+            # the second signal could race the first into the same channel
+            # slot and only one cancel happens.
+            sleep 1
             echo "Sending SIGTERM #2 to $POD/controller (PID 1) for coverage flush"
             kubectl exec -n kloak-system "$POD" -c controller -- kill -TERM 1 2>&1 || true
           else

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,11 +42,16 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
       -target bpfeb -c bpf/tls_uprobe.c -o tlsuprobe_bpfeb.o
 
 # Cross-compile Go binary for the target platform (no CGO, pure Go).
-# When COVER=1, build with -cover for integration test coverage collection.
+# When COVER=1, build with `-cover` for integration test coverage and
+# `-tags cover` to pull in cmd/kloak/coverage_flush_cover.go, which
+# explicitly flushes covcounters at shutdown via runtime/coverage.
+# Production builds (COVER=0) leave that file out — the no-op default in
+# coverage_flush.go is used and the binary contains no runtime/coverage
+# import.
 ARG COVER=0
 RUN if [ "$COVER" = "1" ]; then \
       CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-        go build -cover -covermode=atomic -o /kloak ./cmd/kloak; \
+        go build -cover -covermode=atomic -tags cover -o /kloak ./cmd/kloak; \
     else \
       CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
         go build -o /kloak ./cmd/kloak; \

--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -185,6 +185,7 @@ func runController(cmd *cobra.Command, args []string) {
 			setupLog.Errorw("failed to close uprobe manager", "error", err)
 		}
 	}
+	flushCoverage()
 	setupLog.Infow("controller exited cleanly")
 	_ = setupLog.Sync()
 }

--- a/cmd/kloak/controller.go
+++ b/cmd/kloak/controller.go
@@ -180,12 +180,17 @@ func runController(cmd *cobra.Command, args []string) {
 		setupLog.Errorw("problem running manager", "error", startErr)
 	}
 
+	// Flush coverage BEFORE Close: if Close hangs (e.g. a slow link
+	// detach pushes us past kubelet's grace period), we still capture
+	// coverage of everything up to shutdown. flushCoverage is a no-op
+	// in production builds (gated by `//go:build cover`).
+	flushCoverage()
+
 	if uprobeMgr != nil {
 		if err := uprobeMgr.Close(); err != nil {
 			setupLog.Errorw("failed to close uprobe manager", "error", err)
 		}
 	}
-	flushCoverage()
 	setupLog.Infow("controller exited cleanly")
 	_ = setupLog.Sync()
 }

--- a/cmd/kloak/coverage_flush.go
+++ b/cmd/kloak/coverage_flush.go
@@ -1,0 +1,12 @@
+//go:build !cover
+
+package main
+
+// flushCoverage is the production no-op default. The CI build replaces it
+// via cmd/kloak/coverage_flush_cover.go (gated by `//go:build cover`),
+// which writes covcounters to GOCOVERDIR before the process exits so the
+// e2e job can collect a real coverage profile from the controller binary.
+//
+// In production binaries this file is the only one compiled, so the
+// runtime/coverage import isn't pulled in.
+var flushCoverage = func() {}

--- a/cmd/kloak/coverage_flush_cover.go
+++ b/cmd/kloak/coverage_flush_cover.go
@@ -1,0 +1,23 @@
+//go:build cover
+
+package main
+
+import (
+	"os"
+	"runtime/coverage"
+)
+
+// Compiled in only via `-tags cover` (see Dockerfile, COVER=1 branch).
+// runtime/coverage.WriteCountersDir writes covcounters explicitly,
+// independent of Go's exit-hook chain — which empirically wasn't firing
+// in our e2e environment, leaving the badge stuck on unit-only coverage.
+//
+// The file is compiled out of production binaries, so the runtime/coverage
+// import does not appear in the production symbol table.
+var flushCoverage = func() {
+	dir := os.Getenv("GOCOVERDIR")
+	if dir == "" {
+		return
+	}
+	_ = coverage.WriteCountersDir(dir)
+}

--- a/cmd/kloak/coverage_flush_cover.go
+++ b/cmd/kloak/coverage_flush_cover.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"runtime/coverage"
 )
@@ -17,7 +18,12 @@ import (
 var flushCoverage = func() {
 	dir := os.Getenv("GOCOVERDIR")
 	if dir == "" {
+		fmt.Fprintln(os.Stderr, "kloak: flushCoverage skipped — GOCOVERDIR unset")
 		return
 	}
-	_ = coverage.WriteCountersDir(dir)
+	if err := coverage.WriteCountersDir(dir); err != nil {
+		fmt.Fprintf(os.Stderr, "kloak: flushCoverage failed dir=%s err=%v\n", dir, err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "kloak: flushCoverage wrote covcounters to %s\n", dir)
 }

--- a/cmd/kloak/webhook.go
+++ b/cmd/kloak/webhook.go
@@ -93,6 +93,7 @@ func runWebhook(cmd *cobra.Command, args []string) {
 		_ = setupLog.Sync()
 		os.Exit(1)
 	}
+	flushCoverage()
 	setupLog.Infow("webhook exited cleanly")
 	_ = setupLog.Sync()
 }

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -798,13 +798,21 @@ func isTLSLibrary(name string) bool {
 // pool so wall time stays inside the grace period regardless of how
 // long the controller has been running.
 func (m *TLSUprobeManager) Close() error {
+	t0 := time.Now()
+	linkCount := len(m.links)
 	var errs []error
 	var errsMu sync.Mutex
 
-	const closeWorkers = 64
-	jobs := make(chan link.Link, closeWorkers)
+	// Cap workers at the number of links — no point spinning up 64
+	// goroutines just to close 5 tracepoints at startup teardown.
+	const maxWorkers = 64
+	workers := maxWorkers
+	if linkCount < workers {
+		workers = linkCount
+	}
+	jobs := make(chan link.Link, workers)
 	var wg sync.WaitGroup
-	for w := 0; w < closeWorkers; w++ {
+	for w := 0; w < workers; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
@@ -839,6 +847,7 @@ func (m *TLSUprobeManager) Close() error {
 			errs = append(errs, err)
 		}
 	}
+	m.log.Infow("Close: done", "links", linkCount, "duration", time.Since(t0).String())
 	if len(errs) > 0 {
 		return fmt.Errorf("errors closing uprobe manager: %v", errs)
 	}

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -787,13 +787,41 @@ func isTLSLibrary(name string) bool {
 }
 
 // Close releases all links and the eBPF manager.
+//
+// Each link.Close on a uprobe is a kernel syscall that takes ~50-100 ms,
+// and m.links accumulates one entry per uprobe attachment over the
+// daemonset's lifetime. On a long-running cluster with churning pods this
+// reaches into the thousands; closing serially blows past kubelet's
+// terminationGracePeriodSeconds and the pod is SIGKILL'd before the Go
+// runtime gets to flush exit hooks (which lost us the e2e covcounters
+// flush, among other things). Close concurrently with a bounded worker
+// pool so wall time stays inside the grace period regardless of how
+// long the controller has been running.
 func (m *TLSUprobeManager) Close() error {
 	var errs []error
-	for _, l := range m.links {
-		if err := l.Close(); err != nil {
-			errs = append(errs, err)
-		}
+	var errsMu sync.Mutex
+
+	const closeWorkers = 64
+	jobs := make(chan link.Link, closeWorkers)
+	var wg sync.WaitGroup
+	for w := 0; w < closeWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for l := range jobs {
+				if err := l.Close(); err != nil {
+					errsMu.Lock()
+					errs = append(errs, err)
+					errsMu.Unlock()
+				}
+			}
+		}()
 	}
+	for _, l := range m.links {
+		jobs <- l
+	}
+	close(jobs)
+	wg.Wait()
 	m.links = nil
 
 	if m.reader != nil {


### PR DESCRIPTION
## Summary

Shutdown was taking longer than kubelet's 60 s `terminationGracePeriodSeconds`, so the controller pod was SIGKILL'd before the Go runtime flushed its at-exit hooks. Concretely, this lost the e2e `covcounters` write (still chasing on #174) but it would also drop any other clean-exit observability (graceful drain logs, metrics flush, etc.) on real clusters.

## Diagnosis (from PR #174's instrumentation)

Phase logs added on the debug branch revealed:

```
20:31:58.595  Close: starting link close loop  count=7538
20:32:08.160  Close: slow/failed link i=121  type=*link.perfEventLink  duration=100.96 ms
20:32:23.156  Close: slow/failed link i=302  duration=105.98 ms
20:32:29.592  Close: slow/failed link i=380  duration=100.04 ms
20:32:50.100  Close: slow/failed link i=622  duration=101 ms
20:32:50.289  Close: slow/failed link i=624  duration=108 ms
                                ← then kubelet SIGKILL'd at 60 s grace
```

Two facts:

1. `m.links` had **7538 entries**. The list grows by one per uprobe attachment but nothing ever removes entries when the underlying pod goes away — so it accumulates over the daemonset's lifetime. Separately tracked as a leak; not fixed here.
2. `*link.perfEventLink.Close()` (uprobe detach) takes 50-100 ms per call. Serial close needs `7538 × ~50 ms ≈ 6 min`, vs. the 60 s grace.

## Fix

Drain `m.links` through a 64-worker pool. Same syscall cost, but wall time drops from ~6 min to ~6 sec for the same workload — well inside the 30 s `GracefulShutdownTimeout` from #172.

64 workers is a deliberate cap. Each `link.Close` holds a kernel-side lock during detach, and unbounded concurrency would just thrash. 64 is enough to absorb single-digit-thousand link counts without contention starving workers.

Error semantics unchanged: collected under a mutex, returned aggregated. Reader/objs cleanup that follows is untouched (constant cost, no change needed).

## Out of scope

- The `m.links` leak itself (deleted pods' uprobes never get removed). Should be a follow-up: remove from `m.links` in `UntrackCgroup`.
- The covcounters observation that prompted this — separate (#174 follow-up will validate after this lands).

## Test plan

- [ ] Local: `GOOS=linux go build ./pkg/ebpf/... ./cmd/kloak/...` clean
- [ ] CI green
- [ ] After merge, post-merge main run's e2e step shows `Close: starting link close loop count=N` followed by `controller exited cleanly` within ≪ 60 s — i.e. the streaming follower captures the full shutdown
- [ ] `Merge unit and e2e coverage` prints `Combined unit + e2e coverage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)