### PR TITLE
ci: skip Coverage Report job for fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,9 +121,17 @@ jobs:
 
   # Coverage Report runs on pull requests and comments a diff summary.
   # Depends on e2e so it can work against the merged unit + e2e profile.
+  #
+  # Skipped for pull requests originating from forks: GitHub strips
+  # `pull-requests: write` from the GITHUB_TOKEN of fork PRs as a security
+  # measure, regardless of the `permissions:` block below. The action
+  # successfully downloads coverage and computes the diff but fails at the
+  # final `gh pr comment` step with "Resource not accessible by integration
+  # (addComment)" — turning a clean PR red for an issue the contributor
+  # cannot fix. Same-repo PRs and pushes still get the coverage comment.
   coverage:
     name: Coverage Report
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
     runs-on: ubuntu-latest
     needs: [e2e]
     permissions:


### PR DESCRIPTION
## Summary

- Add \`github.event.pull_request.head.repo.fork == false\` to the Coverage Report job's \`if:\` condition so it doesn't run on PRs from forks.
- Same-repo PRs and pushes are unaffected.

## Why

Fork PRs run with a \`GITHUB_TOKEN\` that GitHub strips of \`pull-requests: write\`, regardless of what the workflow declares. The \`fgrosse/go-coverage-report\` action successfully downloads coverage and computes the diff, then fails at \`gh pr comment\` with:

\`\`\`
GraphQL: Resource not accessible by integration (addComment)
##[error]Process completed with exit code 1.
\`\`\`

Surfaced again on [PR #185](https://github.com/spinningfactory/kloak/pull/185) after PR #189 unblocked the e2e build phase. Same fork-PR token-permissions class of failure as PR #189 (cache push) — the contributor can't do anything about it from their fork.

## What changes

- \`.github/workflows/ci.yml\`: gate the \`coverage\` job on \`!github.event.pull_request.head.repo.fork\`. The job is skipped on fork PRs (no red check, no useless work — the comment was the only output).
- Adds an explanatory comment block above the job so the reason is obvious to anyone editing it later.

## Test plan

- [ ] Same-repo PR run (this PR): Coverage Report still runs and posts a comment
- [ ] Re-run of #185 after merge: Coverage Report skipped (not red)

🤖 Generated with [Claude Code](https://claude.com/claude-code)