### PR TITLE
feat(ebpf): hook EVP_CipherInit_ex on main exe for statically-linked OpenSSL (Node.js)

### DIFF
--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -660,14 +660,31 @@ const (
 )
 
 // attachLibcryptoCipherInit attaches the EVP_CipherInit_ex entry+uretprobe
-// pair to libcrypto.so for the given pid. Returns true if at least one library
-// was successfully hooked, in which case the caller should mark the process
-// as STRATEGY_LIBCRYPTO_HOOK.
+// pair so the libcrypto-hook H-extraction path activates for this process.
+// Returns true if any attach point succeeded, in which case the caller marks
+// the process as STRATEGY_LIBCRYPTO_HOOK.
 //
-// Tries EVP_CipherInit_ex2 first (OpenSSL 3.0+), then EVP_CipherInit_ex
-// (1.1+). BoringSSL doesn't expose either via libcrypto and routes AES-GCM
-// through EVP_AEAD_CTX_new — those processes will simply have no library
-// to attach to here and stay on STRATEGY_KPROBE_WALK.
+// Tries two attach points:
+//
+//  1. The main executable (/proc/<pid>/exe), PID-scoped. This catches apps
+//     that statically link OpenSSL into the binary — most notably Node.js,
+//     which bundles OpenSSL 3.x inside the `node` ELF and exports
+//     EVP_CipherInit_ex / _ex2 directly. PID-scoped because the exe is
+//     unique per container and we don't want the hook firing for unrelated
+//     copies on the host.
+//
+//  2. Each libcrypto.so found in containerLibs, system-wide. This catches
+//     apps that dynamically link to system libcrypto (curl, python, ruby,
+//     ...). System-wide because the BPF cgroup filter narrows it to tracked
+//     containers and one attach covers every process linking the same .so
+//     copy.
+//
+// Order matters only for log clarity — both attach points fire independently
+// and double-attach for the same EVP_CIPHER_CTX is idempotent at the cache.
+//
+// BoringSSL apps that don't expose EVP_CipherInit_ex anywhere (rare in
+// practice — Node.js publishes as OpenSSL despite the historical "uses
+// BoringSSL" reputation) stay on STRATEGY_KPROBE_WALK.
 func (m *TLSUprobeManager) attachLibcryptoCipherInit(pid int, containerLibs []string) bool {
 	// OpenSSL 3.x exposes two independent cipher-init entry points:
 	//   - EVP_CipherInit_ex  (1.1+ compat): calls evp_cipher_init_internal directly
@@ -678,8 +695,40 @@ func (m *TLSUprobeManager) attachLibcryptoCipherInit(pid int, containerLibs []st
 	// safe because the cache write is idempotent for the same EVP_CIPHER_CTX *.
 	cipherInitSymbols := []string{"EVP_CipherInit_ex", "EVP_CipherInit_ex2"}
 	attached := false
-	libcryptoFound := false
 
+	// 1. Main executable, PID-scoped — for statically-linked OpenSSL (Node.js).
+	exePath := fmt.Sprintf("/proc/%d/exe", pid)
+	if exeEx, err := link.OpenExecutable(exePath); err == nil {
+		exeAttached := false
+		for _, sym := range cipherInitSymbols {
+			up, errEntry := exeEx.Uprobe(sym, m.objs.BpfUprobeEvpCipherInit,
+				&link.UprobeOptions{PID: pid})
+			if errEntry != nil {
+				continue
+			}
+			ret, errRet := exeEx.Uretprobe(sym, m.objs.BpfUretprobeEvpCipherInit,
+				&link.UprobeOptions{PID: pid})
+			if errRet != nil {
+				_ = up.Close()
+				continue
+			}
+			m.links = append(m.links, up, ret)
+			m.log.Debugw("Attached EVP_CipherInit hooks (main exe, PID-scoped)",
+				"pid", pid, "symbol", sym)
+			attached = true
+			exeAttached = true
+		}
+		if !exeAttached {
+			m.log.Debugw("Main exe has no EVP_CipherInit symbols — likely dynamically links libcrypto",
+				"pid", pid)
+		}
+	} else {
+		m.log.Debugw("Failed to open main exe for cipher_init attach",
+			"pid", pid, "error", err)
+	}
+
+	// 2. libcrypto.so libraries, system-wide — for dynamically-linked apps.
+	libcryptoFound := false
 	for _, containerPath := range containerLibs {
 		base := filepath.Base(containerPath)
 		if !strings.HasPrefix(base, "libcrypto.so") {
@@ -709,7 +758,7 @@ func (m *TLSUprobeManager) attachLibcryptoCipherInit(pid int, containerLibs []st
 				continue
 			}
 			m.links = append(m.links, up, ret)
-			m.log.Debugw("Attached EVP_CipherInit hooks",
+			m.log.Debugw("Attached EVP_CipherInit hooks (libcrypto.so, system-wide)",
 				"pid", pid, "symbol", sym, "lib", containerPath)
 			attached = true
 			libAttached = true
@@ -720,8 +769,8 @@ func (m *TLSUprobeManager) attachLibcryptoCipherInit(pid int, containerLibs []st
 		}
 	}
 
-	if !libcryptoFound {
-		m.log.Debugw("No libcrypto.so found in containerLibs — staying on KPROBE_WALK",
+	if !attached && !libcryptoFound {
+		m.log.Debugw("No libcrypto.so and no exe symbols — staying on KPROBE_WALK",
 			"pid", pid, "containerLibs", containerLibs)
 	}
 


### PR DESCRIPTION
## Summary

Follow-up to #188. Extends the libcrypto-hook H-extraction path to processes that statically link OpenSSL into their main binary — most notably Node.js, which bundles OpenSSL 3.x inside the \`node\` ELF.

PR #188 only attached \`EVP_CipherInit_ex\` to \`libcrypto.so\` found via \`findContainerTLSLibraries\`. That covered curl, python, ruby — anything dynamically linking system libcrypto. It missed Node.js: \`ldd /usr/local/bin/node\` shows no SSL libraries because OpenSSL is statically baked in. Every Node.js process stayed on \`STRATEGY_KPROBE_WALK\`, exactly the flaky chain-walk path that #175 was about.

## Local verification (demo-js container)

\`\`\`
$ nm /usr/local/bin/node | grep -E "EVP_CipherInit|SSL_write"
0000000002030d80 T EVP_CipherInit_ex
0000000002030cc0 T EVP_CipherInit_ex2
0000000001e877a0 T SSL_write

$ strings /usr/local/bin/node | grep "OpenSSL [0-9]"
OpenSSL 3.5.5 27 Jan 2026
\`\`\`

Node.js 22 alpine bundles the same OpenSSL we already know how to hook — same symbols, same struct layout. \"BoringSSL follow-up\" turned out not to need a BoringSSL hook at all; it just needed us to also probe the main exe.

## What changes

\`attachLibcryptoCipherInit\` now tries **two** attach points:

1. \`/proc/<pid>/exe\` PID-scoped — catches statically-linked OpenSSL (Node.js, anything else with bundled libcrypto).
2. Each \`libcrypto.so\` in \`containerLibs\` system-wide — unchanged from #188; covers dynamically-linked apps.

Both are tried independently. On Node.js the main-exe attach succeeds and the libcrypto.so loop is a no-op. On curl/python the main exe loop is a no-op and the libcrypto.so loop does the real work. The existing \`pushTLSOffsets\` already tries the main exe first for version detection, so OpenSSL 3.5.5's offsets are correctly pushed for Node.js — \`bpf_h_extract\`'s SSL → wrl → enc_ctx walk works with those offsets.

PID-scoped on the main exe because the \`node\` binary is unique per container; we don't want the hook firing for unrelated copies elsewhere on the host. System-wide on libcrypto.so because the BPF cgroup filter narrows it to tracked containers and one attach covers every process linking the same shared object.

## What does NOT change

- BPF C code: zero changes. Same BPF program, same tail-call wiring, same caches.
- BoringSSL hooks: not added. If a real BoringSSL app surfaces later (Chromium-derived, gRPC C++ standalone, ...), that's a separate follow-up.
- KPROBE_WALK fallback: still in place for processes where neither main-exe nor libcrypto.so has the symbols.

## Verification matrix

- \`TestEBPFSecretRewrite/js\` must remain at 100 % AND now route through \`STRATEGY_LIBCRYPTO_HOOK\` (was \`STRATEGY_KPROBE_WALK\` after #188).
- All other tests unchanged.
- Counter pattern: \`Attached EVP_CipherInit hooks (main exe, PID-scoped)\` should appear in controller logs for node processes; \`h_extract_cache_hit\` should grow for node tgids; \`kprobe_walk_legacy\` should drop to ~zero for node traffic.

## Test plan

- [ ] CI passes
- [ ] After merge: BPF trace from a re-run shows no \`H-fail: 4hop enc_ctx null wrl=...\` for node processes (the \"globalsi\" stale-read pattern that PR #188 still saw twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)