### PR TITLE
ci: migrate coverage badge to gist endpoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,25 +144,27 @@ jobs:
           coverage-artifact-name: combined-coverage
           coverage-file-name: combined-coverage.out
 
-  # Coverage Badge runs on push-to-main and commits the updated badge to README.
+  # Coverage Badge updates a public gist that the README references via a
+  # shields.io endpoint URL. This avoids committing to main on every push,
+  # so branch protection on main can stay strict (no bypass required for
+  # github-actions[bot]).
+  #
+  # Setup (one-time):
+  #   - GIST_ID: hardcoded below — public gist owned by a maintainer.
+  #   - GIST_TOKEN: repo secret, classic PAT with `gist` scope only.
+  #     The PAT is tied to the gist owner. If that user leaves the org,
+  #     the badge updates stop until a replacement PAT is configured.
   coverage-badge:
     name: Coverage Badge
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [e2e]
-    permissions:
-      contents: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
           go-version: ${{ env.GO_VERSION }}
-          cache: true
+          cache: false
 
       - name: Download combined coverage
         uses: actions/download-artifact@v8
@@ -170,29 +172,31 @@ jobs:
           name: combined-coverage
           path: /tmp/combined-coverage
 
-      - name: Prepare coverage for badge
+      - name: Extract coverage percentage
+        id: coverage
         run: |
-          go tool cover -func=/tmp/combined-coverage/combined-coverage.out -o=coverage.out
+          # `go tool cover -func` final line: "total: (statements) <pct>%"
+          PCT=$(go tool cover -func=/tmp/combined-coverage/combined-coverage.out \
+                | tail -1 | awk '{print $NF}' | sed 's/%//')
+          # Color thresholds match shields.io conventions.
+          if   awk "BEGIN{exit !($PCT >= 85)}"; then COLOR=brightgreen
+          elif awk "BEGIN{exit !($PCT >= 70)}"; then COLOR=green
+          elif awk "BEGIN{exit !($PCT >= 50)}"; then COLOR=yellow
+          else                                       COLOR=red
+          fi
+          echo "Coverage ${PCT}% (${COLOR})"
+          echo "pct=${PCT}" >> "$GITHUB_OUTPUT"
+          echo "color=${COLOR}" >> "$GITHUB_OUTPUT"
 
-      - name: Update coverage badge
-        uses: tj-actions/coverage-badge-go@v3
+      - name: Update coverage gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
         with:
-          filename: coverage.out
-
-      - name: Verify changed files
-        uses: tj-actions/verify-changed-files@v20
-        id: verify-changed-files
-        with:
-          files: README.md
-
-      - name: Commit coverage badge
-        if: steps.verify-changed-files.outputs.files_changed == 'true'
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add README.md
-          git commit -m "chore: update coverage badge"
-          git push
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: 2d4be46e60ee478d5703d8b009dbd6e9
+          filename: kloak-coverage.json
+          label: coverage
+          message: ${{ steps.coverage.outputs.pct }}%
+          color: ${{ steps.coverage.outputs.color }}
 
   docker:
     name: Docker Build & Push

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <div align="center">
 
 [![CI](https://github.com/spinningfactory/kloak/actions/workflows/ci.yml/badge.svg)](https://github.com/spinningfactory/kloak/actions/workflows/ci.yml)
-![Coverage](https://img.shields.io/badge/Coverage-77.1%25-brightgreen)
+[![Coverage](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/dhiaayachi/2d4be46e60ee478d5703d8b009dbd6e9/raw/kloak-coverage.json)](https://gist.github.com/dhiaayachi/2d4be46e60ee478d5703d8b009dbd6e9)
 [![Go Version](https://img.shields.io/badge/Go-1.26+-00ADD8?logo=go)](https://go.dev/)
 [![Kubernetes](https://img.shields.io/badge/Kubernetes-1.28+-326CE5?logo=kubernetes)](https://kubernetes.io/)
 [![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)


### PR DESCRIPTION
## Summary

- Replace the in-repo coverage badge (committed to README.md by CI) with a [shields.io endpoint](https://shields.io/badges/endpoint-badge) backed by a public gist.
- CI no longer pushes to \`main\` for badge updates → branch protection on main can stay strict, no bypass for \`github-actions[bot]\` needed.

## Why

The previous \`coverage-badge\` job committed README.md and pushed straight to \`main\` after every successful build. With branch protection now enforcing required status checks on main, the push hits:

\`\`\`
! [remote rejected] main -> main (push declined due to repository rule violations)
\`\`\`

\`github-actions[bot]\` isn't selectable in Rulesets bypass lists (it's a per-workflow synthetic identity, not a selectable actor). The alternatives — PR-then-auto-merge or a fine-grained PAT — both add churn or sprawl. Migrating the badge to a gist sidesteps the problem entirely.

## What changes

### \`.github/workflows/ci.yml\` — \`coverage-badge\` job

- Drop the README-commit-and-push steps.
- Add an \"Extract coverage percentage\" step that derives \`pct\` and a \`color\` (red/yellow/green/brightgreen by threshold).
- Add an \"Update coverage gist\" step using \`schneegans/dynamic-badges-action@v1.7.0\` to write the shields.io endpoint JSON to gist [\`2d4be46e60ee478d5703d8b009dbd6e9\`](https://gist.github.com/dhiaayachi/2d4be46e60ee478d5703d8b009dbd6e9), file \`kloak-coverage.json\`.
- Auth via repo secret \`GIST_TOKEN\` (classic PAT with \`gist\` scope only).

### \`README.md\`

- Coverage badge URL changes from a static \`shields.io/badge/...\` to \`shields.io/endpoint?url=<gist-raw-url>\`. The image URL is static from now on; only the underlying JSON changes.

## Setup already done by maintainer

- [x] Public gist created: https://gist.github.com/dhiaayachi/2d4be46e60ee478d5703d8b009dbd6e9
- [x] PAT (\`gist\` scope) generated
- [x] Repo secret \`GIST_TOKEN\` configured

## Tradeoffs

**Wins:**
- No commits to main on badge update; branch protection stays strict.
- Real-time updates (subject to shields.io's CDN cache, ~minutes).

**Losses:**
- Git log loses the per-update \`chore: update coverage badge\` commits. The workflow run output prints the percentage instead.
- PAT is tied to a personal user account. If that user leaves, badge updates stop until a new PAT is configured. Mitigation if it becomes a problem: move the gist + PAT to an org service account.
- Two external dependencies (shields.io + gist.githubusercontent.com) for the badge to render. Both rarely fail; when they do, the README image is broken for a few minutes.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, \`Coverage Badge\` job runs on the merge commit and reaches the \"Update coverage gist\" step successfully
- [ ] Gist content updates with the new pct/color
- [ ] README badge renders correctly (give shields.io ~5 min to refresh CDN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)