### PR TITLE
ci: fix Coverage Badge job missing checkout — gist was getting empty %

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
     runs-on: ubuntu-latest
     needs: [e2e]
     steps:
+      # `go tool cover -func` resolves the package paths in the coverage
+      # profile (e.g. github.com/spinningfactory/kloak/cmd/kloak/main.go:9)
+      # against go.mod, so the source tree must be present. Without checkout
+      # the command fails with "go.mod file not found" and PCT becomes empty,
+      # which falls through to color=red regardless of the real coverage.
+      - name: Checkout code
+        uses: actions/checkout@v6
+
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
@@ -175,9 +183,14 @@ jobs:
       - name: Extract coverage percentage
         id: coverage
         run: |
+          set -euo pipefail
           # `go tool cover -func` final line: "total: (statements) <pct>%"
           PCT=$(go tool cover -func=/tmp/combined-coverage/combined-coverage.out \
                 | tail -1 | awk '{print $NF}' | sed 's/%//')
+          if [ -z "$PCT" ]; then
+            echo "::error::could not extract coverage percentage from combined-coverage.out"
+            exit 1
+          fi
           # Color thresholds match shields.io conventions.
           if   awk "BEGIN{exit !($PCT >= 85)}"; then COLOR=brightgreen
           elif awk "BEGIN{exit !($PCT >= 70)}"; then COLOR=green


### PR DESCRIPTION
## Summary

Restore the Checkout step in the \`coverage-badge\` job and add a hard guard so a silent extraction failure can't produce a misleading red badge again.

## Why

After PR #192 migrated the coverage badge to a gist endpoint, every push to main has been writing this to the gist:

\`\`\`json
{"label":"coverage","message":"%","schemaVersion":1,"color":"red"}
\`\`\`

Empty percentage, color forced to red. The README badge has been visibly wrong since #192 merged.

Root cause from CI logs:

\`\`\`
cover: no required module provides package
github.com/spinningfactory/kloak/cmd/kloak: go.mod file not found in
current directory or any parent directory; see 'go help modules'
\`\`\`

\`go tool cover -func\` resolves package paths in the coverage profile against \`go.mod\` in the working directory. PR #192's badge job didn't check out the source (I dropped the Checkout step thinking we just needed the artifact), so the resolution fails. The bash script wasn't running \`set -e\`, so the cover error didn't fail the step — \`PCT\` came back empty, every \`awk \"BEGIN{exit !($PCT >= N)}\"\` evaluated as \`!= 85)\` (syntax error), and the bash conditional fell through to the \`else\` branch with \`COLOR=red\`. \`echo \"pct=\${PCT}\"\` produced \`pct=\`, which the dynamic-badges-action faithfully wrote as message=\`%\`.

## What changes

\`.github/workflows/ci.yml\` — \`coverage-badge\` job:

1. Add the \`actions/checkout@v6\` step back as the first step. Comment explains why it's needed.
2. \`set -euo pipefail\` in the extract step so any failure halts the job loudly.
3. Explicit guard that fails the step with \`::error::\` annotation if PCT is empty after extraction, rather than producing a misleading red badge.

## Why I didn't catch this in PR #192

The badge job only runs on push-to-main, not on the PR itself. The first time it ever ran the new code path was the merge commit. By then PR #192 was closed. Catching this earlier would have required either (a) running the job in PR mode for verification, or (b) running \`go tool cover -func\` locally against the actual e2e artifact before shipping. Neither is in our current loop. Worth considering whether to add a smoke test that exercises the badge job on PRs without actually pushing to the gist.

## Test plan

- [ ] CI passes on this PR (badge job stays gated on push-to-main, so it won't run here)
- [ ] Merge → next push-to-main triggers the new flow → gist content updates with a real percentage and matching color → README badge renders correctly within ~5 min (shields.io CDN cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)