### PR TITLE
feat(ebpf): populate Go TLS offset table for 1.20–1.24 + table-driven tests (closes #103)

### DIFF
--- a/.github/workflows/go-tls-offsets.yml
+++ b/.github/workflows/go-tls-offsets.yml
@@ -1,0 +1,91 @@
+name: Go TLS Offset Discovery
+
+# On-demand discovery workflow. Run this when:
+#   - Adding support for a new Go version (after Go N.N+1 ships).
+#   - Verifying offset stability across a Go patch release.
+#   - Investigating a discrepancy reported by TestGoTLSOffsets_AgainstReferenceJSON.
+#
+# Each matrix cell builds the fixture against `golang:<version>` and runs
+# the discovery tool, producing one JSON per (version, arch). Results are
+# uploaded as artifacts; a maintainer downloads + diffs against the
+# committed `tools/go-tls-offsets/results/` files and commits any updates.
+#
+# Mirrors the on-demand `openssl-offsets.yml` pattern. Containers spin
+# once per matrix cell, in parallel — never per test.
+
+on:
+  workflow_dispatch:
+    inputs:
+      go_min_version:
+        description: 'Lowest Go major.minor to discover (e.g. 1.20). Defaults to 1.20.'
+        required: false
+        default: '1.20'
+
+jobs:
+  discover:
+    name: Discover Go ${{ matrix.go }} on ${{ matrix.platform }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [linux/amd64, linux/arm64]
+        # Pinned list mirrors tools/go-tls-offsets/build-fixtures.sh defaults.
+        # Keep in sync; the build-fixtures script auto-discovers from go.dev,
+        # but a workflow matrix can't dynamically resolve at parse time. The
+        # nightly `go-versions-nightly.yml` workflow (PR 3) detects new
+        # versions and opens an auto-PR that updates this list.
+        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26"]
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Compute arch label
+        id: arch
+        run: |
+          case "${{ matrix.platform }}" in
+            linux/amd64) echo "arch=amd64" >> "$GITHUB_OUTPUT" ;;
+            linux/arm64) echo "arch=arm64" >> "$GITHUB_OUTPUT" ;;
+          esac
+
+      - name: Build discovery image
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --build-arg GO_VERSION=${{ matrix.go }} \
+            --load \
+            -t go-tls-offsets:${{ matrix.go }}-${{ steps.arch.outputs.arch }} \
+            tools/go-tls-offsets/
+
+      - name: Run discovery
+        run: |
+          mkdir -p out
+          docker run --rm --platform ${{ matrix.platform }} \
+            go-tls-offsets:${{ matrix.go }}-${{ steps.arch.outputs.arch }} \
+            > out/go-${{ matrix.go }}-${{ steps.arch.outputs.arch }}.json
+          echo "=== discovered ==="
+          cat out/go-${{ matrix.go }}-${{ steps.arch.outputs.arch }}.json
+
+      - name: Diff against committed JSON
+        run: |
+          existing=tools/go-tls-offsets/results/go-${{ matrix.go }}-${{ steps.arch.outputs.arch }}.json
+          new=out/go-${{ matrix.go }}-${{ steps.arch.outputs.arch }}.json
+          if [ ! -f "$existing" ]; then
+            echo "::warning::no committed reference for Go ${{ matrix.go }} ${{ steps.arch.outputs.arch }} — first-time discovery"
+            exit 0
+          fi
+          # Normalize via jq so whitespace/key-order differences don't trip the diff.
+          if ! diff <(jq -S . "$existing") <(jq -S . "$new"); then
+            echo "::warning::offsets drifted for Go ${{ matrix.go }} ${{ steps.arch.outputs.arch }} — review the artifact"
+          fi
+
+      - name: Upload result
+        uses: actions/upload-artifact@v7
+        with:
+          name: go-tls-offsets-${{ matrix.go }}-${{ steps.arch.outputs.arch }}
+          path: out/go-${{ matrix.go }}-${{ steps.arch.outputs.arch }}.json
+          retention-days: 30

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -46,17 +46,28 @@ type goTLSOffsetEntry struct {
 
 // goTLSOffsetTableBase maps Go major.minor versions to base struct offsets.
 // Discovered by running tools/go-tls-offsets against binaries built
-// with each Go version.
+// with each Go version (see tools/go-tls-offsets/results/go-<v>-<arch>.json
+// for the canonical reference values; the test in
+// pkg/ebpf/go_tls_offsets_test.go asserts this table matches them).
 //
-// TODO: Populate with offsets for Go 1.21, 1.22, 1.23 via the offset tool.
+// Two distinct shapes:
+//   Go 1.20–1.23: GCM struct is `crypto/cipher.gcm` (size 288, productTable
+//                 at offset 32 → PDBase = 32 + 224 = 256).
+//   Go 1.24+:     GCM moved into `crypto/internal/fips140/aes/gcm.GCM` with
+//                 a gcmPlatformData wrapper (gcmPlatformData=504,
+//                 productTable=0 → PDBase = 504 + 0 + 224 = 728).
+//
+// To regenerate / extend (a new Go release ships):
+//   make go-tls-discover    (Docker; rebuilds fixtures + JSONs)
+//   then mirror the JSON values into a new entry below.
 var goTLSOffsetTableBase = map[string]goTLSOffsetEntry{
-	// Go 1.25/1.26 (FIPS module, gcmPlatformData):
-	//   Conn.out=520, halfConn.cipher=32, prefixNonceAEAD.aead=16
-	//   GCM.gcmPlatformData=504, gcmPlatformData.productTable=0
-	//   H×2 at productTable offset 224 → PDBase = 504 + 0 + 224 = 728
-	//   ConnToCipher = 520 + 32 + 8 = 560
-	//   AEADIfaceOff = 16 + 8 = 24
-	// Conn.vers is at offset 72 in Go 1.25/1.26 (confirmed via DWARF).
+	// Go 1.20–1.23: crypto/cipher.gcm (PDBase = 32 + 224 = 256).
+	"1.20": {ConnToCipher: 552, AEADIfaceOff: 24, PDBase: 256, ConnVersOff: 64},
+	"1.21": {ConnToCipher: 568, AEADIfaceOff: 24, PDBase: 256, ConnVersOff: 72},
+	"1.22": {ConnToCipher: 568, AEADIfaceOff: 24, PDBase: 256, ConnVersOff: 72},
+	"1.23": {ConnToCipher: 576, AEADIfaceOff: 24, PDBase: 256, ConnVersOff: 72},
+	// Go 1.24+: FIPS module, gcmPlatformData (PDBase = 504 + 0 + 224 = 728).
+	"1.24": {ConnToCipher: 576, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 	"1.25": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 	"1.26": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 }

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -51,15 +51,17 @@ type goTLSOffsetEntry struct {
 // pkg/ebpf/go_tls_offsets_test.go asserts this table matches them).
 //
 // Two distinct shapes:
-//   Go 1.20–1.23: GCM struct is `crypto/cipher.gcm` (size 288, productTable
-//                 at offset 32 → PDBase = 32 + 224 = 256).
-//   Go 1.24+:     GCM moved into `crypto/internal/fips140/aes/gcm.GCM` with
-//                 a gcmPlatformData wrapper (gcmPlatformData=504,
-//                 productTable=0 → PDBase = 504 + 0 + 224 = 728).
+//
+//	Go 1.20–1.23: GCM struct is `crypto/cipher.gcm` (size 288, productTable
+//	              at offset 32 → PDBase = 32 + 224 = 256).
+//	Go 1.24+:     GCM moved into `crypto/internal/fips140/aes/gcm.GCM` with
+//	              a gcmPlatformData wrapper (gcmPlatformData=504,
+//	              productTable=0 → PDBase = 504 + 0 + 224 = 728).
 //
 // To regenerate / extend (a new Go release ships):
-//   make go-tls-discover    (Docker; rebuilds fixtures + JSONs)
-//   then mirror the JSON values into a new entry below.
+//
+//	make go-tls-discover    (Docker; rebuilds fixtures + JSONs)
+//	then mirror the JSON values into a new entry below.
 var goTLSOffsetTableBase = map[string]goTLSOffsetEntry{
 	// Go 1.20–1.23: crypto/cipher.gcm (PDBase = 32 + 224 = 256).
 	"1.20": {ConnToCipher: 552, AEADIfaceOff: 24, PDBase: 256, ConnVersOff: 64},

--- a/pkg/ebpf/go_tls_offsets_test.go
+++ b/pkg/ebpf/go_tls_offsets_test.go
@@ -1,6 +1,13 @@
 package ebpf
 
-import "testing"
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestExtractGoMajorMinor(t *testing.T) {
 	tests := []struct {
@@ -65,5 +72,147 @@ func TestGoTLSOffsetsForArch(t *testing.T) {
 	// ARM64 VREV64: hi at +0, lo at +8
 	if arm64.H2HiOff != 728 || arm64.H2LoOff != 736 {
 		t.Errorf("arm64: H2HiOff=%d (want 728), H2LoOff=%d (want 736)", arm64.H2HiOff, arm64.H2LoOff)
+	}
+}
+
+// referenceJSON matches the OffsetResult shape emitted by
+// tools/go-tls-offsets/main.go. Subset of fields — we only assert on what
+// the table needs to populate.
+type referenceJSON struct {
+	GoVersion    string `json:"go_version"`
+	Arch         string `json:"arch"`
+	ConnToCipher uint32 `json:"conn_to_cipher"`
+	AEADIfaceOff uint32 `json:"aead_iface_off"`
+	H2HiOff      uint32 `json:"h2_hi_off"`
+	H2LoOff      uint32 `json:"h2_lo_off"`
+	ConnVersOff  uint32 `json:"conn_vers_off"`
+	Notes        string `json:"notes,omitempty"`
+}
+
+// parseFixtureFilename extracts (version, arch) from a `go-<v>-<arch>.json`
+// or `go-<v>-<arch>.elf` filename.
+func parseFixtureFilename(base string) (version, arch string, ok bool) {
+	stripped := strings.TrimSuffix(strings.TrimSuffix(base, ".json"), ".elf")
+	stripped = strings.TrimPrefix(stripped, "go-")
+	idx := strings.LastIndex(stripped, "-")
+	if idx < 0 {
+		return "", "", false
+	}
+	return stripped[:idx], stripped[idx+1:], true
+}
+
+// TestGoTLSOffsets_AgainstReferenceJSON is the primary CI check: every
+// committed reference JSON in tools/go-tls-offsets/results/ must agree with
+// goTLSOffsetTableBase resolved through goTLSOffsetsForArch. Catches drift
+// between the table and the canonical discovery output.
+//
+// Runs as a single Go test process, no Docker, no network — just file I/O.
+// Subtests are named `<version>-<arch>` so failures point at exactly the
+// (version, arch) cell that drifted.
+func TestGoTLSOffsets_AgainstReferenceJSON(t *testing.T) {
+	pattern := filepath.Join("..", "..", "tools", "go-tls-offsets", "results", "go-*.json")
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %q: %v", pattern, err)
+	}
+	if len(paths) == 0 {
+		t.Skipf("no reference JSONs at %s — run `make go-tls-discover`", pattern)
+	}
+
+	for _, p := range paths {
+		base := filepath.Base(p)
+		version, arch, ok := parseFixtureFilename(base)
+		if !ok {
+			t.Errorf("unparseable result filename: %s", base)
+			continue
+		}
+		t.Run(fmt.Sprintf("%s-%s", version, arch), func(t *testing.T) {
+			data, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			var ref referenceJSON
+			if err := json.Unmarshal(data, &ref); err != nil {
+				t.Fatalf("parse %s: %v", p, err)
+			}
+			if ref.Notes != "" {
+				t.Fatalf("reference JSON %s has notes=%q (the discovery tool reported missing offsets); regenerate via `make go-tls-discover`", base, ref.Notes)
+			}
+
+			entry, ok := goTLSOffsetTableBase[version]
+			if !ok {
+				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s — add it from %s", version, base)
+			}
+			got := goTLSOffsetsForArch(entry, arch)
+
+			if got.ConnToCipher != ref.ConnToCipher {
+				t.Errorf("ConnToCipher mismatch: table=%d ref=%d", got.ConnToCipher, ref.ConnToCipher)
+			}
+			if got.AEADIfaceOff != ref.AEADIfaceOff {
+				t.Errorf("AEADIfaceOff mismatch: table=%d ref=%d", got.AEADIfaceOff, ref.AEADIfaceOff)
+			}
+			if got.H2HiOff != ref.H2HiOff {
+				t.Errorf("H2HiOff mismatch: table=%d ref=%d", got.H2HiOff, ref.H2HiOff)
+			}
+			if got.H2LoOff != ref.H2LoOff {
+				t.Errorf("H2LoOff mismatch: table=%d ref=%d", got.H2LoOff, ref.H2LoOff)
+			}
+			if got.ConnVersOff != ref.ConnVersOff {
+				t.Errorf("ConnVersOff mismatch: table=%d ref=%d", got.ConnVersOff, ref.ConnVersOff)
+			}
+		})
+	}
+}
+
+// TestGoTLSOffsets_AgainstFixtureDWARF is the deeper local check: it parses
+// each ELF fixture's DWARF directly and confirms the result matches what
+// the table produces. Validates the DWARF parser itself, not just
+// table-vs-JSON equality. Skips when fixtures aren't present (the default
+// in CI; developers running `make go-tls-fixtures` locally get this for free).
+func TestGoTLSOffsets_AgainstFixtureDWARF(t *testing.T) {
+	pattern := filepath.Join("..", "..", "pkg", "ebpf", "testdata", "go-tls-fixtures", "go-*.elf")
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %q: %v", pattern, err)
+	}
+	if len(paths) == 0 {
+		t.Skipf("no ELF fixtures at %s — run `make go-tls-fixtures`", pattern)
+	}
+
+	for _, p := range paths {
+		base := filepath.Base(p)
+		version, arch, ok := parseFixtureFilename(base)
+		if !ok {
+			t.Errorf("unparseable fixture filename: %s", base)
+			continue
+		}
+		t.Run(fmt.Sprintf("%s-%s", version, arch), func(t *testing.T) {
+			_, dwarfOffsets, err := detectGoTLSFromDWARF(p)
+			if err != nil {
+				t.Fatalf("detectGoTLSFromDWARF(%s): %v", base, err)
+			}
+
+			entry, ok := goTLSOffsetTableBase[version]
+			if !ok {
+				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s", version)
+			}
+			tableOffsets := goTLSOffsetsForArch(entry, arch)
+
+			if dwarfOffsets.ConnToCipher != tableOffsets.ConnToCipher {
+				t.Errorf("ConnToCipher: dwarf=%d table=%d", dwarfOffsets.ConnToCipher, tableOffsets.ConnToCipher)
+			}
+			if dwarfOffsets.AEADIfaceOff != tableOffsets.AEADIfaceOff {
+				t.Errorf("AEADIfaceOff: dwarf=%d table=%d", dwarfOffsets.AEADIfaceOff, tableOffsets.AEADIfaceOff)
+			}
+			if dwarfOffsets.H2HiOff != tableOffsets.H2HiOff {
+				t.Errorf("H2HiOff: dwarf=%d table=%d", dwarfOffsets.H2HiOff, tableOffsets.H2HiOff)
+			}
+			if dwarfOffsets.H2LoOff != tableOffsets.H2LoOff {
+				t.Errorf("H2LoOff: dwarf=%d table=%d", dwarfOffsets.H2LoOff, tableOffsets.H2LoOff)
+			}
+			if dwarfOffsets.ConnVersOff != tableOffsets.ConnVersOff {
+				t.Errorf("ConnVersOff: dwarf=%d table=%d", dwarfOffsets.ConnVersOff, tableOffsets.ConnVersOff)
+			}
+		})
 	}
 }

--- a/pkg/ebpf/go_tls_offsets_test.go
+++ b/pkg/ebpf/go_tls_offsets_test.go
@@ -139,9 +139,10 @@ func TestGoTLSOffsets_AgainstReferenceJSON(t *testing.T) {
 				t.Fatalf("reference JSON %s has notes=%q (the discovery tool reported missing offsets); regenerate via `make go-tls-discover`", base, ref.Notes)
 			}
 
-			entry, ok := goTLSOffsetTableBase[version]
+			majorMinor := extractGoMajorMinor(version)
+			entry, ok := goTLSOffsetTableBase[majorMinor]
 			if !ok {
-				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s — add it from %s", version, base)
+				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s — add it from %s", majorMinor, base)
 			}
 			got := goTLSOffsetsForArch(entry, arch)
 
@@ -192,9 +193,10 @@ func TestGoTLSOffsets_AgainstFixtureDWARF(t *testing.T) {
 				t.Fatalf("detectGoTLSFromDWARF(%s): %v", base, err)
 			}
 
-			entry, ok := goTLSOffsetTableBase[version]
+			majorMinor := extractGoMajorMinor(version)
+			entry, ok := goTLSOffsetTableBase[majorMinor]
 			if !ok {
-				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s", version)
+				t.Fatalf("goTLSOffsetTableBase has no entry for Go %s", majorMinor)
 			}
 			tableOffsets := goTLSOffsetsForArch(entry, arch)
 

--- a/tools/go-tls-offsets/fixture/main.go
+++ b/tools/go-tls-offsets/fixture/main.go
@@ -1,13 +1,18 @@
-// Build fixture: a tiny Go program that forces the linker to retain
-// crypto/tls and the GCM struct so DWARF debug info still references them
-// after compilation. Used by `tools/go-tls-offsets` to discover struct
-// offsets per Go version.
+// Build fixture: a tiny Go program that forces the linker to retain the
+// crypto/tls structs AND the AES-GCM cipher implementation so DWARF debug
+// info still references them after compilation. Used by `tools/go-tls-offsets`
+// to discover struct offsets per Go version.
 //
-// The binary itself does nothing useful at runtime; only the symbol table
-// and DWARF entries matter.
+// IMPORTANT: merely referencing tls.Conn / tls.Config is not enough — Go
+// <1.24's `crypto/cipher.gcmAES` struct is dead-code-eliminated unless an
+// AES-GCM cipher is actually constructed somewhere reachable from main.
+// We do that below; the binary itself does nothing useful at runtime, only
+// the DWARF entries matter.
 package main
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
 	"crypto/tls"
 	"fmt"
 )
@@ -16,8 +21,19 @@ import (
 var sink any
 
 func main() {
-	cfg := &tls.Config{}
-	sink = cfg
+	// Pull crypto/tls.Conn and friends into the binary (and DWARF).
+	sink = &tls.Config{}
 	sink = &tls.Conn{}
+
+	// Construct an AES-GCM cipher to force the linker to retain
+	// crypto/cipher.gcmAES (Go <1.24) or
+	// crypto/internal/fips140/aes/gcm.GCM (Go 1.24+).
+	block, err := aes.NewCipher(make([]byte, 16))
+	if err == nil {
+		if g, err := cipher.NewGCM(block); err == nil {
+			sink = g
+		}
+	}
+
 	fmt.Println("kloak go-tls-offsets fixture")
 }

--- a/tools/go-tls-offsets/results/go-1.20-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.20-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.20.14",
+  "arch": "amd64",
+  "conn_to_cipher": 552,
+  "aead_iface_off": 24,
+  "h2_hi_off": 264,
+  "h2_lo_off": 256,
+  "conn_vers_off": 64,
+  "raw": {
+    "conn_out": 512,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.20-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.20-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.20.14",
+  "arch": "arm64",
+  "conn_to_cipher": 552,
+  "aead_iface_off": 24,
+  "h2_hi_off": 256,
+  "h2_lo_off": 264,
+  "conn_vers_off": 64,
+  "raw": {
+    "conn_out": 512,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.21-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.21-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.21.13",
+  "arch": "amd64",
+  "conn_to_cipher": 568,
+  "aead_iface_off": 24,
+  "h2_hi_off": 264,
+  "h2_lo_off": 256,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 528,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.21-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.21-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.21.13",
+  "arch": "arm64",
+  "conn_to_cipher": 568,
+  "aead_iface_off": 24,
+  "h2_hi_off": 256,
+  "h2_lo_off": 264,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 528,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.22-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.22-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.22.12",
+  "arch": "amd64",
+  "conn_to_cipher": 568,
+  "aead_iface_off": 24,
+  "h2_hi_off": 264,
+  "h2_lo_off": 256,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 528,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.22-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.22-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.22.12",
+  "arch": "arm64",
+  "conn_to_cipher": 568,
+  "aead_iface_off": 24,
+  "h2_hi_off": 256,
+  "h2_lo_off": 264,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 528,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.23-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.23-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.23.12",
+  "arch": "amd64",
+  "conn_to_cipher": 576,
+  "aead_iface_off": 24,
+  "h2_hi_off": 264,
+  "h2_lo_off": 256,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 536,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.23-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.23-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.23.12",
+  "arch": "arm64",
+  "conn_to_cipher": 576,
+  "aead_iface_off": 24,
+  "h2_hi_off": 256,
+  "h2_lo_off": 264,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 536,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 32,
+    "pd_base": 256
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.24-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.24-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.24.13",
+  "arch": "amd64",
+  "conn_to_cipher": 576,
+  "aead_iface_off": 24,
+  "h2_hi_off": 736,
+  "h2_lo_off": 728,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 536,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.24-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.24-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.24.13",
+  "arch": "arm64",
+  "conn_to_cipher": 576,
+  "aead_iface_off": 24,
+  "h2_hi_off": 728,
+  "h2_lo_off": 736,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 536,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.25-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.25-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.25.9",
+  "arch": "amd64",
+  "conn_to_cipher": 560,
+  "aead_iface_off": 24,
+  "h2_hi_off": 736,
+  "h2_lo_off": 728,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 520,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.25-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.25-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.25.9",
+  "arch": "arm64",
+  "conn_to_cipher": 560,
+  "aead_iface_off": 24,
+  "h2_hi_off": 728,
+  "h2_lo_off": 736,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 520,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.26-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.26-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.26.2",
+  "arch": "amd64",
+  "conn_to_cipher": 560,
+  "aead_iface_off": 24,
+  "h2_hi_off": 736,
+  "h2_lo_off": 728,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 520,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.26-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.26-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.26.2",
+  "arch": "arm64",
+  "conn_to_cipher": 560,
+  "aead_iface_off": 24,
+  "h2_hi_off": 728,
+  "h2_lo_off": 736,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 520,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}


### PR DESCRIPTION
## Summary

PR 2 of the issue #103 series. Builds on the tooling foundation merged in #197.

- Populates `goTLSOffsetTableBase` for **Go 1.20, 1.21, 1.22, 1.23, 1.24** (1.25 / 1.26 were already there).
- Commits 14 canonical reference JSONs (`tools/go-tls-offsets/results/go-<v>-<arch>.json`, ~250 B each) — generated by running `make go-tls-discover` and used as the source of truth for the table.
- Adds two table-driven tests over **all 7 supported Go versions × both arches** that run as Go unit tests — no Docker, no network, no per-test container.
- Adds an on-demand `.github/workflows/go-tls-offsets.yml` for regenerating offsets when a Go release ships.
- Includes one apology commit for a slip on PR #197 (Gemini was right; I'm fixing it).

Closes #103.

## What lands per commit

### `73a8455` fix(tooling): finish what PR #197 was supposed to do — actually call cipher.NewGCM

PR #197's commit `268192e` claimed to add `crypto/aes` + `crypto/cipher` imports and a `cipher.NewGCM` call to the fixture so the linker would retain `crypto/cipher.gcm` in DWARF for Go 1.20–1.23. **The commit only touched the tool, not the fixture.** Two HIGH-priority Gemini comments said exactly this; I marked them stale by checking my dirty working tree instead of the actual committed state. The merged `b8ae8ee` on main has the original simpler fixture. This commit is the actual fixture content Gemini asked for, plus an explanatory comment block.

### `aa33fd4` feat(ebpf): populate Go TLS offset table for 1.20–1.24 + add table-driven tests

The substantive change. Three sub-pieces:

**(1) 14 reference JSONs** — produced by re-running `make go-tls-discover` against the corrected fixture. Same shape as `tools/openssl-offsets/results/`. Tiny, gitops-friendly, the canonical record.

**(2) Table populated**:

| Version | ConnToCipher | AEADIfaceOff | PDBase | ConnVersOff |
|---------|--------------|--------------|--------|-------------|
| 1.20 | 552 | 24 | 256 | 64 |
| 1.21 | 568 | 24 | 256 | 72 |
| 1.22 | 568 | 24 | 256 | 72 |
| 1.23 | 576 | 24 | 256 | 72 |
| 1.24 | 576 | 24 | **728** | 72 |
| 1.25 | 560 | 24 | 728 | 72 |
| 1.26 | 560 | 24 | 728 | 72 |

The PDBase jump at 1.24 reflects the FIPS module move (`crypto/cipher.gcm` → `crypto/internal/fips140/aes/gcm.GCM` with a `gcmPlatformData` wrapper). ConnToCipher and ConnVersOff shift on different version boundaries because the Conn / halfConn struct layouts changed. The arch-independent base offsets are identical between amd64 and arm64 within a single Go version — only H2 word order differs, applied at lookup time. The pre-existing TODO is removed.

**(3) Two new tests**:

- `TestGoTLSOffsets_AgainstReferenceJSON` — primary CI check. Walks `tools/go-tls-offsets/results/go-*.json`, parses (version, arch) from each filename, asserts every field of `goTLSOffsetTableBase[version]` resolved through `goTLSOffsetsForArch(arch)` matches the reference JSON. Subtest per (version, arch); failures point at exactly the cell that drifted. **~5 ms total in CI, pure file I/O, no Docker.**
- `TestGoTLSOffsets_AgainstFixtureDWARF` — deeper check. Walks ELF fixtures (gitignored), runs `detectGoTLSFromDWARF`, asserts parser output matches the table. Skips when fixtures absent (default in CI; developers running `make go-tls-fixtures` get it for free). Validates the DWARF parser, not just table-vs-JSON.

### `ee8d863` ci: on-demand workflow for Go TLS offset discovery

`.github/workflows/go-tls-offsets.yml`. `workflow_dispatch` only — used when adding a new Go version, verifying patch-release stability, or investigating a discrepancy. Matrix of 7 versions × 2 platforms = 14 cells, parallel. Each cell builds the multi-stage Dockerfile, runs the discovery binary under `--platform linux/<arch>` via QEMU, diffs against the committed JSON, uploads the new result as an artifact. Diff is `jq -S` normalized so key-order doesn't trip false positives. Drift is a workflow **warning**, not a failure — the human decides whether to commit.

PR 3 (templated demo-go + nightly multi-version e2e + auto-PR for new releases) follows.

## Verified locally

- `go test -run 'TestGoTLSOffsets' -v ./pkg/ebpf/`: both new tests pass with 14 subtests each (one per `version-arch`). The 3 existing tests still pass.
- Hand-roll regression check: edited `goTLSOffsetTableBase[\"1.22\"].ConnToCipher` to a wrong value, re-ran tests, both 1.22 subtests fail with clear field-level diff messages.
- `make go-tls-fixtures && make go-tls-discover` against the corrected fixture: all 14 JSONs report `notes:\"\"` (no missing fields). Total runtime ~10 minutes on cold Docker (image pulls), ~30 s on warm.
- `helm lint` n/a; `GOOS=linux go vet ./...` clean; `GOOS=linux go build ./...` clean.

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge, trigger `go-tls-offsets.yml` manually to confirm all 14 matrix cells succeed and produce JSONs that diff cleanly against the committed ones.
- [ ] Hand-spike check: in a follow-up branch, set up a Go 1.21 demo pod and verify kloak's controller reports `\"version\":\"go1.21\"` + `\"offsets\":{...}` with the new table values, instead of falling back to DWARF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)