### PR TITLE
test(e2e): two-phase wait + bump timeouts to reduce JS/cipher flakes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
           ls -la /tmp/bpf-trace.log
 
       - name: Run E2E tests (with eBPF)
-        run: go test -v -timeout 1200s -tags=e2e_ebpf -count=1 ./test/e2e/
+        run: go test -v -timeout 1500s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -393,7 +393,7 @@ jobs:
           ls -la /tmp/bpf-trace.log
 
       - name: Run E2E tests (with eBPF)
-        run: go test -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
+        run: go test -v -timeout 1200s -tags=e2e_ebpf -count=1 ./test/e2e/
         env:
           KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ e2e-setup:
 # Run e2e tests (including eBPF) against an existing k3d cluster.
 e2e-run:
 	KUBECONFIG=$$(k3d kubeconfig write $(E2E_CLUSTER)) \
-	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 ./test/e2e/
+	$(GOTEST) -v -timeout 1500s -tags=e2e_ebpf -count=1 ./test/e2e/
 
 # Run e2e tests against the current kube context.
 # Builds images, pushes to ttl.sh (anonymous ephemeral registry, 2h TTL),
@@ -165,7 +165,7 @@ E2E_RUN ?=
 
 e2e-local-run:
 	E2E_REGISTRY=$(E2E_REGISTRY) E2E_SKIP_INSTALL=$(E2E_SKIP_INSTALL) \
-	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
+	$(GOTEST) -v -timeout 1500s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
 
 # Tear down e2e k3d cluster.
 e2e-cleanup:
@@ -212,7 +212,7 @@ e2e-k3s-setup:
 # Run e2e tests against local k3s.
 e2e-k3s-run:
 	KUBECONFIG=$(HOME)/.kube/k3s-e2e.yaml \
-	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
+	$(GOTEST) -v -timeout 1500s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
 
 # Tear down k3s.
 e2e-k3s-cleanup:

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ e2e-setup:
 # Run e2e tests (including eBPF) against an existing k3d cluster.
 e2e-run:
 	KUBECONFIG=$$(k3d kubeconfig write $(E2E_CLUSTER)) \
-	$(GOTEST) -v -timeout 900s -tags=e2e_ebpf -count=1 ./test/e2e/
+	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 ./test/e2e/
 
 # Run e2e tests against the current kube context.
 # Builds images, pushes to ttl.sh (anonymous ephemeral registry, 2h TTL),
@@ -165,7 +165,7 @@ E2E_RUN ?=
 
 e2e-local-run:
 	E2E_REGISTRY=$(E2E_REGISTRY) E2E_SKIP_INSTALL=$(E2E_SKIP_INSTALL) \
-	$(GOTEST) -v -timeout 900s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
+	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
 
 # Tear down e2e k3d cluster.
 e2e-cleanup:
@@ -212,7 +212,7 @@ e2e-k3s-setup:
 # Run e2e tests against local k3s.
 e2e-k3s-run:
 	KUBECONFIG=$(HOME)/.kube/k3s-e2e.yaml \
-	$(GOTEST) -v -timeout 900s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
+	$(GOTEST) -v -timeout 1200s -tags=e2e_ebpf -count=1 $(if $(E2E_RUN),-run $(E2E_RUN)) ./test/e2e/
 
 # Tear down k3s.
 e2e-k3s-cleanup:

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -213,18 +213,49 @@ func runEBPFRewriteTest(t *testing.T, tc ebpfRewriteTest) {
 		t.Fatalf("%s not ready: %v", tc.deploymentName, err)
 	}
 
-	// Poll app logs for the real secret value (definitive per-app check).
-	// This replaces the old arbitrary sleep — we poll until the app has
-	// made at least one request and the eBPF rewrite is visible in output.
-	pollCtx, pollCancel := context.WithTimeout(context.Background(), 90*time.Second)
-	defer pollCancel()
+	// Two-phase wait. The 90s single-budget approach was flaky on slow CI
+	// runners because it conflated three distinct delays (Node.js cold-
+	// start / TLS module init, DNS+RTT to httpbin.org, and the uprobe
+	// attach race) into one ceiling. Splitting them gives a clearer signal
+	// when something does break:
+	//
+	//   Phase 1 — wait until the demo has issued at least two requests
+	//   ("Request #2" appears in logs). All three demos use the same
+	//   `--- Request #N ---` prefix. Two requests means the runtime is
+	//   alive and the uprobe-attach race window has closed at least once,
+	//   so any subsequent rewrite failure points at the eBPF path rather
+	//   than at startup. 120s budget covers Node.js cold-start + first
+	//   public-internet RTT under load.
+	//
+	//   Phase 2 — poll for the rewritten secret in the demo logs. 180s
+	//   budget; the original 90s sat exactly at the failure edge for JS
+	//   on stressed runners.
+	demoActiveCtx, demoActiveCancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer demoActiveCancel()
 	var out string
+	for {
+		select {
+		case <-demoActiveCtx.Done():
+			t.Logf("=== %s final logs ===\n%s", tc.name, out)
+			t.Logf("=== Controller logs ===\n%s", controllerLogs())
+			t.Fatalf("[%s] demo runtime never reached its second request — image, network, or scheduling problem (not an eBPF rewrite issue)", tc.name)
+		default:
+		}
+		out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=200")
+		if strings.Contains(out, "Request #2") {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer pollCancel()
 	for {
 		select {
 		case <-pollCtx.Done():
 			t.Logf("=== %s final logs ===\n%s", tc.name, out)
 			t.Logf("=== Controller logs ===\n%s", controllerLogs())
-			t.Fatalf("[%s] timed out waiting for allowed secret in app logs", tc.name)
+			t.Fatalf("[%s] timed out waiting for allowed secret in app logs (demo runtime is healthy — uprobe path failed to rewrite)", tc.name)
 		default:
 		}
 		out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=200")

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -219,10 +219,12 @@ func runEBPFRewriteTest(t *testing.T, tc ebpfRewriteTest) {
 	// attach race) into one ceiling. Splitting them gives a clearer signal
 	// when something does break:
 	//
-	//   Phase 1 — wait until the demo has issued at least two requests
-	//   ("Request #2" appears in logs). All three demos use the same
-	//   `--- Request #N ---` prefix. Two requests means the runtime is
-	//   alive and the uprobe-attach race window has closed at least once,
+	//   Phase 1 — wait until the demo has issued at least two requests.
+	//   All three demos use the same `--- Request #N ---` prefix; counting
+	//   occurrences (rather than matching `Request #2` literally) stays
+	//   correct after `Request #1` scrolls out of the kubectl --tail
+	//   window on long phase-1 waits. Two requests means the runtime is
+	//   alive AND the uprobe-attach race window has closed at least once,
 	//   so any subsequent rewrite failure points at the eBPF path rather
 	//   than at startup. 120s budget covers Node.js cold-start + first
 	//   public-internet RTT under load.
@@ -230,40 +232,40 @@ func runEBPFRewriteTest(t *testing.T, tc ebpfRewriteTest) {
 	//   Phase 2 — poll for the rewritten secret in the demo logs. 180s
 	//   budget; the original 90s sat exactly at the failure edge for JS
 	//   on stressed runners.
+	//
+	// `--tail=500` (was 200) gives ~70-100 request cycles of headroom
+	// before the marker we're looking for can scroll out — generous even
+	// for js (REQUEST_INTERVAL=1s) on a slow runner.
+	var out string
+	pollLogsFor := func(ctx context.Context, match func(string) bool, failMsg string) {
+		t.Helper()
+		for {
+			select {
+			case <-ctx.Done():
+				t.Logf("=== %s final logs ===\n%s", tc.name, out)
+				t.Logf("=== Controller logs ===\n%s", controllerLogs())
+				t.Fatalf("[%s] %s", tc.name, failMsg)
+			default:
+			}
+			out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=500")
+			if match(out) {
+				return
+			}
+			time.Sleep(pollInterval)
+		}
+	}
+
 	demoActiveCtx, demoActiveCancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer demoActiveCancel()
-	var out string
-	for {
-		select {
-		case <-demoActiveCtx.Done():
-			t.Logf("=== %s final logs ===\n%s", tc.name, out)
-			t.Logf("=== Controller logs ===\n%s", controllerLogs())
-			t.Fatalf("[%s] demo runtime never reached its second request — image, network, or scheduling problem (not an eBPF rewrite issue)", tc.name)
-		default:
-		}
-		out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=200")
-		if strings.Contains(out, "Request #2") {
-			break
-		}
-		time.Sleep(pollInterval)
-	}
+	pollLogsFor(demoActiveCtx,
+		func(s string) bool { return strings.Count(s, "Request #") >= 2 },
+		"demo runtime never reached its second request — image, network, or scheduling problem (not an eBPF rewrite issue)")
 
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer pollCancel()
-	for {
-		select {
-		case <-pollCtx.Done():
-			t.Logf("=== %s final logs ===\n%s", tc.name, out)
-			t.Logf("=== Controller logs ===\n%s", controllerLogs())
-			t.Fatalf("[%s] timed out waiting for allowed secret in app logs (demo runtime is healthy — uprobe path failed to rewrite)", tc.name)
-		default:
-		}
-		out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=200")
-		if strings.Contains(out, "REAL-ALLOWED-KEY-12345") {
-			break
-		}
-		time.Sleep(pollInterval)
-	}
+	pollLogsFor(pollCtx,
+		func(s string) bool { return strings.Contains(s, "REAL-ALLOWED-KEY-12345") },
+		"timed out waiting for allowed secret in app logs (demo runtime is healthy — uprobe path failed to rewrite)")
 	t.Logf("=== %s demo app logs ===\n%s", tc.name, out)
 
 	if strings.Contains(out, "REAL-BLOCKED-KEY-67890") {

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -62,6 +62,37 @@ func controllerLogs() string {
 	return out
 }
 
+// pollDemoLogs polls `kubectl logs -l <appLabel>` every pollInterval
+// until match(out) returns true or ctx expires. On expiry the most
+// recent tail and the kloak controller logs are tagged onto t.Fatalf
+// for postmortem; failTag identifies which subtest fired (e.g. "js"
+// vs "demo-python-raw-tls") so a cascade is debuggable.
+//
+// Returns the final log output so the caller can run negative
+// assertions on it (e.g. blocked-secret leakage).
+//
+// `--tail=500` matches the per-cycle log volume of the slowest demo
+// (js, REQUEST_INTERVAL=1s) — gives ~70-100 cycles of headroom before
+// the marker the caller is looking for can scroll out of the window.
+func pollDemoLogs(t *testing.T, ctx context.Context, appLabel, failTag, failMsg string, match func(string) bool) string {
+	t.Helper()
+	var out string
+	for {
+		select {
+		case <-ctx.Done():
+			t.Logf("=== %s final logs ===\n%s", failTag, out)
+			t.Logf("=== Controller logs ===\n%s", controllerLogs())
+			t.Fatalf("[%s] %s", failTag, failMsg)
+		default:
+		}
+		out, _ = kubectl("logs", "-n", testNamespace, "-l", appLabel, "--tail=500")
+		if match(out) {
+			return out
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
 // ebpfRewriteTest describes a single eBPF rewrite test case for a specific runtime.
 type ebpfRewriteTest struct {
 	name           string
@@ -141,24 +172,14 @@ func TestEBPFRawTLSHostFiltering(t *testing.T) {
 		t.Fatalf("demo-python-raw-tls not ready: %v", err)
 	}
 
-	// Poll app logs for the real secret value
-	pollCtx, pollCancel := context.WithTimeout(context.Background(), 90*time.Second)
+	// Same flake class as TestEBPFSecretRewrite — bumped to 180s + 500-line
+	// tail for parity with `runEBPFRewriteTest`. This test was at the same
+	// 95s edge in recent CI cascades.
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer pollCancel()
-	var out string
-	for {
-		select {
-		case <-pollCtx.Done():
-			t.Logf("=== demo-python-raw-tls final logs ===\n%s", out)
-			t.Logf("=== Controller logs ===\n%s", controllerLogs())
-			t.Fatalf("timed out waiting for allowed secret in raw TLS demo logs")
-		default:
-		}
-		out, _ = kubectl("logs", "-n", testNamespace, "-l", "app=demo-python-raw-tls", "--tail=200")
-		if strings.Contains(out, "REAL-ALLOWED-KEY-12345") {
-			break
-		}
-		time.Sleep(pollInterval)
-	}
+	out := pollDemoLogs(t, pollCtx, "app=demo-python-raw-tls", "demo-python-raw-tls",
+		"timed out waiting for allowed secret in raw TLS demo logs",
+		func(s string) bool { return strings.Contains(s, "REAL-ALLOWED-KEY-12345") })
 	t.Logf("=== demo-python-raw-tls logs ===\n%s", out)
 
 	if strings.Contains(out, "REAL-BLOCKED-KEY-67890") {
@@ -233,39 +254,17 @@ func runEBPFRewriteTest(t *testing.T, tc ebpfRewriteTest) {
 	//   budget; the original 90s sat exactly at the failure edge for JS
 	//   on stressed runners.
 	//
-	// `--tail=500` (was 200) gives ~70-100 request cycles of headroom
-	// before the marker we're looking for can scroll out — generous even
-	// for js (REQUEST_INTERVAL=1s) on a slow runner.
-	var out string
-	pollLogsFor := func(ctx context.Context, match func(string) bool, failMsg string) {
-		t.Helper()
-		for {
-			select {
-			case <-ctx.Done():
-				t.Logf("=== %s final logs ===\n%s", tc.name, out)
-				t.Logf("=== Controller logs ===\n%s", controllerLogs())
-				t.Fatalf("[%s] %s", tc.name, failMsg)
-			default:
-			}
-			out, _ = kubectl("logs", "-n", testNamespace, "-l", tc.appLabel, "--tail=500")
-			if match(out) {
-				return
-			}
-			time.Sleep(pollInterval)
-		}
-	}
-
 	demoActiveCtx, demoActiveCancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer demoActiveCancel()
-	pollLogsFor(demoActiveCtx,
-		func(s string) bool { return strings.Count(s, "Request #") >= 2 },
-		"demo runtime never reached its second request — image, network, or scheduling problem (not an eBPF rewrite issue)")
+	pollDemoLogs(t, demoActiveCtx, tc.appLabel, tc.name,
+		"demo runtime never reached its second request — image, network, or scheduling problem (not an eBPF rewrite issue)",
+		func(s string) bool { return strings.Count(s, "Request #") >= 2 })
 
 	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer pollCancel()
-	pollLogsFor(pollCtx,
-		func(s string) bool { return strings.Contains(s, "REAL-ALLOWED-KEY-12345") },
-		"timed out waiting for allowed secret in app logs (demo runtime is healthy — uprobe path failed to rewrite)")
+	out := pollDemoLogs(t, pollCtx, tc.appLabel, tc.name,
+		"timed out waiting for allowed secret in app logs (demo runtime is healthy — uprobe path failed to rewrite)",
+		func(s string) bool { return strings.Contains(s, "REAL-ALLOWED-KEY-12345") })
 	t.Logf("=== %s demo app logs ===\n%s", tc.name, out)
 
 	if strings.Contains(out, "REAL-BLOCKED-KEY-67890") {


### PR DESCRIPTION
## Summary

PRs B + C from the e2e flakiness investigation. PR A (moving demos off httpbin.org) is deferred.

Recent CI failures across **6 unrelated runs** (including dependabot YAML-only PRs touching zero production code) cluster on `TestEBPFSecretRewrite/js` at **exactly 92-93s**, with cascading failures on the next 90s-budget tests when the runner is slow. The 90s budget was the failure point — confirmed by the timing: every flake fires within ±2s of 90s, never well below or well above.

### Changes

- **Two-phase wait in `runEBPFRewriteTest`** (`test/e2e/ebpf_test.go`):
  - Phase 1 (120s): wait until the demo issues at least two requests (counted via `strings.Count(out, "Request #") >= 2` so it stays correct after `Request #1` scrolls out of the kubectl --tail window). Two requests proves runtime is alive **and** the uprobe-attach race window has closed at least once.
  - Phase 2 (180s): poll for the rewritten secret, same as before.
  - Failure messages now distinguish "demo runtime never came up" (image, network, scheduling) from "uprobe path failed to rewrite" (the actual eBPF flake).
- **Promote the polling loop into a package-level `pollDemoLogs` helper** (replaces a local closure). Reused in both `runEBPFRewriteTest` phases AND in `TestEBPFRawTLSHostFiltering` — same flake class, same 95s-edge symptom.
- **Bump kubectl `--tail` from 200 → 500** so phase 1's marker has ~70-100 request cycles of headroom before scrolling out (generous for js with `REQUEST_INTERVAL=1s`).
- **Bump `TestEBPFRawTLSHostFiltering` poll budget 90s → 180s** for parity — was at the same 95s edge in recent cascades.
- **Bump `-timeout` 900s → 1500s** in `.github/workflows/ci.yml` and three Makefile e2e targets so cascading failures don't panic the binary mid-run and lose the failure logs. (Gemini suggested 2400s on review; 1500s is the compromise — accommodates a triple-cascade with the new 305s/subtest worst case while still failing fast on a truly hung test.)

### Why not just bump the existing 90s?

The 90s budget conflated three independent delays into one ceiling:
1. Node.js cold-start + lazy `https`/OpenSSL import (most expensive on JS).
2. DNS + public-internet RTT to httpbin.org.
3. Uprobe attach race (kloak controller walks `/proc/<pid>/maps` after pod-create event).

A single bump masks which one is slow when it eventually fails. The two-phase split surfaces that signal in the test output.

## Test plan

- [x] `gofmt -l test/e2e/ebpf_test.go` clean.
- [x] `GOOS=linux go vet -tags=e2e_ebpf ./test/e2e/` clean.
- [x] `GOOS=linux go test -tags=e2e_ebpf -run '^\$' ./test/e2e/` — test binary compiles with the new code.
- [ ] CI E2E job passes on this PR.
- [ ] Re-run E2E a few times across PRs in the next few days and observe whether the JS-at-92s pattern goes away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)