### PR TITLE
feat(cli): add `kloak version` subcommand (release tag + commit hash)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,11 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}:${{ needs.validate.outputs.version }}
             ghcr.io/${{ github.repository }}:latest
+          # Re-prefix with `v` so the on-binary version exactly matches
+          # the pushed git tag (validate strips the `v` for image tags
+          # but the binary should advertise the canonical tag form).
+          build-args: |
+            VERSION=v${{ needs.validate.outputs.version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,9 @@ pkg/ebpf/bpf/vmlinux.h
 # ARE committed; the binaries themselves are regenerable and too large.
 pkg/ebpf/testdata/go-tls-fixtures/*.elf
 .claude/worktrees/
-kloak
+# Anchor to repo root: bare `kloak` would match `cmd/kloak/` too and
+# block new files there from being added to git.
+/kloak
 lima-k3d.yaml
 sec.yml
 test.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,21 @@ RUN if [ "$TARGETARCH" = "amd64" ]; then \
 # coverage_flush.go is used and the binary contains no runtime/coverage
 # import.
 ARG COVER=0
+# VERSION is the release tag baked into the binary so `kloak version`
+# can report it. release.yml sets this from the git tag; local builds
+# leave it as the default and the binary advertises itself as "dev".
+# The commit hash is auto-discovered via runtime/debug.ReadBuildInfo,
+# so no extra build-arg is needed for that.
+ARG VERSION=dev
 RUN if [ "$COVER" = "1" ]; then \
       CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-        go build -cover -covermode=atomic -tags cover -o /kloak ./cmd/kloak; \
+        go build -cover -covermode=atomic -tags cover \
+          -ldflags "-X main.version=${VERSION}" \
+          -o /kloak ./cmd/kloak; \
     else \
       CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} \
-        go build -o /kloak ./cmd/kloak; \
+        go build -ldflags "-X main.version=${VERSION}" \
+          -o /kloak ./cmd/kloak; \
     fi
 
 # Runtime stage — uses the target platform.

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,13 @@ GOGENERATE=$(GOCMD) generate
 BINARY_NAME=kloak
 WEBHOOK_BINARY=kloak-webhook
 
+# Release tag baked into the binary for `kloak version`. `git describe
+# --tags --always --dirty` gives `v0.1.0` exactly on tag, `v0.1.0-3-gabc1234-dirty`
+# between tags with uncommitted changes, and falls back to the short
+# commit when no tags exist. CI release builds override VERSION explicitly.
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS = -ldflags "-X main.version=$(VERSION)"
+
 # Build directories
 BUILD_DIR=bin
 CMD_DIR=cmd
@@ -48,14 +55,14 @@ build: deps $(BUILD_DIR)/$(BINARY_NAME)
 
 $(BUILD_DIR)/$(BINARY_NAME): $(GO_SOURCES)
 	@mkdir -p $(BUILD_DIR)
-	$(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME) ./$(CMD_DIR)/kloak
+	$(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME) ./$(CMD_DIR)/kloak
 
 # Build for Linux (cross-compile or via Lima)
 build-linux: lima-ensure
 	@if [ "$$(uname)" = "Linux" ]; then \
-		GOOS=linux GOARCH=amd64 $(GOBUILD) -o $(BUILD_DIR)/$(BINARY_NAME)-linux ./$(CMD_DIR)/kloak; \
+		GOOS=linux GOARCH=amd64 $(GOBUILD) $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux ./$(CMD_DIR)/kloak; \
 	else \
-		$(MAKE) lima-exec CMD="cd $(LIMA_WORKDIR) && go build -o $(BUILD_DIR)/$(BINARY_NAME)-linux ./$(CMD_DIR)/kloak"; \
+		$(MAKE) lima-exec CMD="cd $(LIMA_WORKDIR) && go build $(LDFLAGS) -o $(BUILD_DIR)/$(BINARY_NAME)-linux ./$(CMD_DIR)/kloak"; \
 	fi
 
 test: deps

--- a/cmd/kloak/main.go
+++ b/cmd/kloak/main.go
@@ -17,6 +17,12 @@ API key management without exposing secrets in plain text.`,
 func init() {
 	rootCmd.AddCommand(controllerCmd)
 	rootCmd.AddCommand(webhookCmd)
+	rootCmd.AddCommand(versionCmd)
+
+	// Wire `kloak --version` to the same multi-line output as `kloak version`
+	// instead of Cobra's default one-liner, so the two surfaces stay in sync.
+	rootCmd.Version = version
+	rootCmd.SetVersionTemplate(versionString())
 }
 
 func main() {

--- a/cmd/kloak/version.go
+++ b/cmd/kloak/version.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// version is the release tag for shipped builds, set at build time via:
+//
+//	-ldflags "-X main.version=v0.1.0"
+//
+// Dev builds without that flag fall back to "dev"; the commit hash that
+// versionString reports below comes from runtime/debug.ReadBuildInfo, so
+// the dev fallback still pins the source tree exactly.
+var version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print kloak version, commit hash, and Go runtime",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Print(versionString())
+	},
+}
+
+func versionString() string {
+	commit, dirty, goVer := buildInfo()
+	tree := "clean"
+	if dirty {
+		tree = "dirty"
+	}
+	return fmt.Sprintf("kloak version %s\ncommit:        %s (%s)\ngo:            %s\n",
+		version, commit, tree, goVer)
+}
+
+// buildInfo extracts the VCS revision, dirty flag, and Go toolchain
+// version from the binary's embedded build info. Go ≥1.18 records these
+// automatically when building from a checkout under VCS, so no
+// `--build-arg GIT_COMMIT=…` plumbing is needed in the Dockerfile.
+func buildInfo() (commit string, dirty bool, goVer string) {
+	commit = "unknown"
+	goVer = "unknown"
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	goVer = info.GoVersion
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if len(s.Value) >= 7 {
+				commit = s.Value[:7]
+			} else {
+				commit = s.Value
+			}
+		case "vcs.modified":
+			dirty = s.Value == "true"
+		}
+	}
+	return
+}


### PR DESCRIPTION
## Summary

Adds a `version` subcommand so a deployed kloak binary can report which release it is. Until now there was no way to ask — `release.yml` tags the docker image and bumps `Chart.yaml` at publish time, but nothing was injected into the binary itself.

```
$ kloak version
kloak version v0.1.0
commit:        abc1234 (clean)
go:            go1.26.2
```

`kloak --version` prints the same multi-line output (Cobra's `SetVersionTemplate`).

### How it's wired

Hybrid source, deliberate to minimize plumbing:

- **Release tag** comes from `-ldflags '-X main.version=…'` at build time. It's the only thing the binary can't discover from itself, so it's the only build-arg that needs to flow through.
- **Commit hash, dirty flag, Go version** come from `runtime/debug.ReadBuildInfo()`. Go ≥1.18 embeds these automatically when building from a VCS checkout — no `--build-arg GIT_COMMIT=…` plumbing in `Dockerfile`, no `git rev-parse` shell-out in `Makefile`, no env vars in `release.yml`.

### Build pipeline

| File | Change |
|---|---|
| `cmd/kloak/version.go` | new — `version` var, `versionCmd`, `versionString()`, `buildInfo()` |
| `cmd/kloak/main.go` | register `versionCmd`; set `rootCmd.Version` + `SetVersionTemplate` |
| `Dockerfile` | new `ARG VERSION=dev` threaded into both go-build invocations (COVER=1 + production) |
| `Makefile` | `VERSION ?= $(shell git describe --tags --always --dirty)` so local builds get accurate provenance like `v0.1.0-3-gabc1234-dirty` |
| `.github/workflows/release.yml` | pass `VERSION=v\${ver}` to docker build-args (re-prefix the `v` that the validate step strips) |
| `.gitignore` | anchor `kloak` → `/kloak` so it doesn't match `cmd/kloak/` and block new files there (caught while creating `version.go`) |

## Test plan

- [x] `GOOS=linux go build -ldflags '-X main.version=v0.1.2-test' ./cmd/kloak` → docker run reports `kloak version v0.1.2-test`, `commit 29dde26 (dirty)`, `go go1.26.1`.
- [x] Plain `GOOS=linux go build ./cmd/kloak` → `kloak version dev`, commit hash auto-discovered.
- [x] `kloak --version` flag matches `kloak version` subcommand output.
- [x] `kloak --help` lists `version` alongside `controller` / `webhook`; existing subcommands and their flags unchanged.
- [x] `gofmt` + `GOOS=linux go vet` clean.
- [ ] CI lint/build/test pass on this PR.
- [ ] Post-merge: push a `v0.1.x` tag, run `docker run --rm ghcr.io/spinningfactory/kloak:0.1.x version`, verify the output matches the tag.

## Out of scope

- Surfacing the version in controller/webhook startup logs (small follow-up if wanted).
- Embedding the build date — possible via another `-ldflags` var but adds noise when commit hash already pins the source tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)