### PR TITLE
fix(demo-js): wait 10s before first TLS request to win uprobe-attach race

### DIFF
--- a/examples/demo-js/app.js
+++ b/examples/demo-js/app.js
@@ -78,6 +78,17 @@ async function main() {
   );
   console.log("=".repeat(60));
 
+  // Brief delay for kloak controller to attach uprobes before the first
+  // TLS connection. Node's https.globalAgent defaults to keepAlive=true
+  // (and we send Connection: keep-alive explicitly below), so all
+  // subsequent requests reuse the very first connection's SSL_CTX. If
+  // we lose the attach race against that first connection, every later
+  // request misses the rewrite — observable in CI as the kprobe_walk
+  // counter staying frozen while the demo cycles 100+ requests.
+  // Mirrors examples/demo-go/main.go:55-57.
+  console.log("Waiting 10s for Kloak controller to sync...");
+  await new Promise((r) => setTimeout(r, 10000));
+
   let requestCount = 0;
   while (true) {
     requestCount++;

--- a/examples/demo-js/app.js
+++ b/examples/demo-js/app.js
@@ -85,7 +85,7 @@ async function main() {
   // we lose the attach race against that first connection, every later
   // request misses the rewrite — observable in CI as the kprobe_walk
   // counter staying frozen while the demo cycles 100+ requests.
-  // Mirrors examples/demo-go/main.go:55-57.
+  // Mirrors the startup delay in examples/demo-go/main.go.
   console.log("Waiting 10s for Kloak controller to sync...");
   await new Promise((r) => setTimeout(r, 10000));
 


### PR DESCRIPTION
## Summary

`TestEBPFSecretRewrite/js` has been intermittently flaky for ~2 weeks. Re-running CI usually fixes it — classic race symptom. This PR addresses the actual race.

### Root cause

Node 22's `https.globalAgent` defaults to `keepAlive=true`, the demo sends `Connection: keep-alive` explicitly (`examples/demo-js/app.js:95`), and **a single TCP+TLS connection serves all 100+ requests**. The kloak controller has exactly one shot to attach uprobes before that first connection's SSL_CTX init — if it loses the race (pod-create event → /proc/<pid>/maps walk → uprobe attach), every later SSL_write travels over a connection whose init was never observed and there is no recovery.

This explains why **only JS** flakes:
- **demo-go** (`main.go:55-57`) has a 10s startup `time.Sleep` already — wins the race deterministically.
- **demo-python** uses `requests.get()` per call, which opens a fresh TCP+TLS connection every iteration — even if the first request loses the race, request N+1 has another shot.
- **demo-js** had **no startup delay**, AND uses keepalive → one shot, no retries.

### Evidence from the most recent failing run (PR #205, run 25473905883)

After PR #203's two-phase wait merged, the diagnostic clearly identifies this as a uprobe correctness issue rather than timing:

```
[js] timed out waiting for allowed secret in app logs
(demo runtime is healthy — uprobe path failed to rewrite)
```

Controller debug counters during the JS phase:

```
kprobe_walk_legacy: 14   (frozen at 14 for the full 3 minutes
kretprobe_read_fail: 4    JS was the only active demo)
```

The counter never advances — no new TLS connections form despite the demo cycling **172 requests** at `REQUEST_INTERVAL=1s`. Same offsets are pushed for `/proc/<pid>/exe` (statically-linked Node OpenSSL 3.5.5, `SSLToWRL:3208 WRLToEncCtx:4128 ...`) but they're applied to a connection whose SSL_CTX init we already missed.

### The fix

3-line addition mirroring `examples/demo-go/main.go:55-57` — the comment in demo-go even says *"Brief delay for watched_hosts BPF map to be populated"*, suggesting this was the intended pattern across all demos and demo-js was just an oversight when it was written.

```javascript
console.log("Waiting 10s for Kloak controller to sync...");
await new Promise((r) => setTimeout(r, 10000));
```

## Test plan

- [ ] CI E2E `TestEBPFSecretRewrite/js` passes on this PR.
- [ ] Re-run E2E several times across this and other PRs over the next few days; verify the JS-at-92s and JS-at-185s patterns disappear.

## Why not a deeper fix

We could disable Node's keepalive in the demo, or have kloak proactively reset existing TLS sessions for tracked pods, or add per-tgid attach retry on subsequent SSL_writes. All bigger surgery for what is fundamentally a demo-runtime startup-ordering issue. The other demos already use this pattern; bringing demo-js into parity is the right size of change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)