### PR TITLE
fix(tooling): add go.mod for offset discoverer so its Dockerfile builds

### DIFF
--- a/tools/go-tls-offsets/Dockerfile
+++ b/tools/go-tls-offsets/Dockerfile
@@ -9,8 +9,9 @@
 
 # GO_VERSION is the version the fixture is COMPILED WITH (drives the struct
 # layout the tool will discover). DISCOVERY_GO_VERSION is the toolchain that
-# builds the discovery binary itself — it must satisfy the parent kloak
-# module's `go 1.26.0` directive, so it's pinned independently.
+# builds the discovery binary itself — pinned independently so it doesn't
+# move when GO_VERSION does. The discoverer has its own go.mod (`go 1.21`)
+# so any toolchain ≥ 1.21 works; the default tracks the parent module.
 ARG GO_VERSION=1.26
 ARG DISCOVERY_GO_VERSION=1.26
 
@@ -22,10 +23,10 @@ COPY fixture/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -o /fixture .
 
 # ─── Stage 2: build the discovery tool with a modern Go toolchain
-# (independent of GO_VERSION — older images would fail on `go 1.26.0`).
+# (independent of GO_VERSION — older images would fail on `go 1.21+`).
 FROM golang:${DISCOVERY_GO_VERSION} AS discoverer
 WORKDIR /src
-COPY main.go ./
+COPY go.mod main.go ./
 RUN go build -o /go-tls-offsets .
 
 # ─── Stage 3: minimal runtime image

--- a/tools/go-tls-offsets/go.mod
+++ b/tools/go-tls-offsets/go.mod
@@ -1,0 +1,7 @@
+// Standalone module for the offset-discovery tool. Decouples the tool's
+// build from the parent kloak module so the Dockerfile's `discoverer`
+// stage can `go build .` inside `golang:<DISCOVERY_GO_VERSION>` without
+// the parent module's go.mod being part of the build context.
+module go-tls-offsets
+
+go 1.21


### PR DESCRIPTION
## Summary

The first run of the new \`Go Versions Nightly\` workflow (run [25514883641](https://github.com/spinningfactory/kloak/actions/runs/25514883641)) failed all 14 \`discover\` cells with the same error:

\`\`\`
#13 [discoverer 4/4] RUN go build -o /go-tls-offsets .
#13 0.055 go: go.mod file not found in current directory or any parent directory
\`\`\`

The \`discoverer\` stage in \`tools/go-tls-offsets/Dockerfile\` copies only \`main.go\` and runs \`go build .\`, with no \`go.mod\` in the build context. The bug was latent — the on-demand \`go-tls-offsets.yml\` workflow that ships the same Dockerfile has never been triggered, so this only surfaced when the nightly fired for the first time.

## Fix

Give the discoverer its own \`go.mod\`, mirroring the pattern already used by \`tools/go-tls-offsets/fixture/go.mod\`. Update the Dockerfile to copy it alongside \`main.go\`. The discoverer only depends on stdlib (\`debug/buildinfo\`, \`debug/dwarf\`, \`debug/elf\`, \`encoding/json\`), all stable since Go 1.18 — \`go 1.21\` floor is more than enough.

## Test plan

- [x] Reproduced locally: \`cp main.go go.mod /tmp/t && cd /tmp/t && go build .\` now succeeds.
- [x] Full \`docker buildx build --platform linux/amd64 --build-arg GO_VERSION=1.26 ./tools/go-tls-offsets/\` succeeds; running the image discovers offsets cleanly (Go 1.26.2 fixture, GCM struct found).
- [ ] After merge: re-trigger the nightly via \`workflow_dispatch\` and confirm all 14 discover cells succeed → e2e cells run → detect-new-version reports no new versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)