### PR TITLE
fix(ebpf): apply crypto/aes.gcmAsm fix to runtime DWARF detector too

### DIFF
--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -247,12 +247,22 @@ func detectGoTLSFromDWARF(exePath string) (string, GoTLSOffsets, error) {
 		foundPD = true
 	}
 
-	// Go <1.24: GCM struct in crypto/cipher. Name varies across versions.
+	// Go <1.24: prefer crypto/aes.gcmAsm — the AES-NI/PCLMULQDQ runtime
+	// type that crypto/cipher.NewGCM(aesBlock) actually returns. Layout:
+	// ks []uint32 (24-byte slice header) + productTable [256]byte at
+	// offset 24, so PDBase = 24 + 224 = 248. The crypto/cipher.gcm path
+	// is the SOFTWARE FALLBACK used only when the cipher.Block lacks
+	// gcmAble; its productTable lives 8 bytes later (offset 32) and
+	// reading from it produces an off-by-8 garbage value that breaks
+	// GMAC for normal AES-NI builds. Mirrors the search order in
+	// tools/go-tls-offsets/main.go.
 	if !foundPD {
 		for _, sn := range []string{
-			"crypto/cipher.gcm",
+			"crypto/aes.gcmAsm",
+			"crypto/aes.gcmAES",
 			"crypto/cipher.gcmAES",
 			"crypto/cipher.gcmAsm",
+			"crypto/cipher.gcm", // software-fallback (no AES-NI)
 		} {
 			if pt, ok := getField(structFields, sn, "productTable"); ok {
 				pdBase = pt + 224
@@ -312,7 +322,10 @@ func isGoTLSTargetStruct(name string) bool {
 		"crypto/tls.halfConn",
 		"crypto/tls.prefixNonceAEAD",
 		"crypto/tls.xorNonceAEAD",
-		// Go 1.20–1.23: GCM struct in crypto/cipher (name varies).
+		// Go 1.20–1.23: AES-NI runtime type lives in crypto/aes; crypto/cipher
+		// types are the software fallback used when AES-NI is unavailable.
+		"crypto/aes.gcmAsm",
+		"crypto/aes.gcmAES",
 		"crypto/cipher.gcm",
 		"crypto/cipher.gcmAES",
 		"crypto/cipher.gcmAsm",


### PR DESCRIPTION
## Summary

Follow-up to #208. The controller has two paths to Go TLS offsets:

1. \`detectGoTLSFromDWARF\` (\`pkg/ebpf/go_tls_offsets.go\`) — walks DWARF in the demo binary at attach time. Preferred when DWARF is present (always, for demo-go).
2. \`goTLSOffsetTableBase\` — static fallback by major.minor.

PR #208 only fixed path (2). The runtime DWARF detector still walks the same wrong struct list (\`crypto/cipher.{gcm,gcmAES,gcmAsm}\`) and gets PDBase=256, which **overrides** the corrected static table.

## Evidence from last night's retrigger

After PR #208 merged, ran Go Versions Nightly. Discover all green ✓. E2E for Go 1.24-1.26 ✓ but **1.20-1.23 still failed**. Controller log on the failing demo:

\`\`\`
Detected Go TLS offsets {pid:17198, goVersion:"go1.20.14",
  connToCipher:552, aeadIfaceOff:24, h2HiOff:264, h2LoOff:256}
\`\`\`

\`h2HiOff: 264, h2LoOff: 256\` ← old (broken) PDBase=256 path.
With the fix applied this would be \`h2HiOff: 256, h2LoOff: 248\` (PDBase=248).

Note "Detected" (not "table lookup") — confirming the runtime DWARF path is the active one.

## Fix

Mirror the discovery tool's struct-name search in the runtime detector — prefer \`crypto/aes.gcmAsm\` (AES-NI runtime type) over \`crypto/cipher.gcm\` (software fallback). Also extend \`isGoTLSTargetStruct\` so the DWARF walker retains the new struct names during reading.

## Test plan

- [x] \`gofmt\` + \`GOOS=linux go build ./...\` clean.
- [ ] CI pass on this PR (no behavior change for Go 1.24+; new behavior for 1.20-1.23).
- [ ] Re-trigger Go Versions Nightly after merge: all 7 e2e cells should pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)