### PR TITLE
feat(secrets): YAML source for `kloak run` + `kloak secrets validate` (Phase 2)

### DIFF
--- a/cmd/kloak/secrets.go
+++ b/cmd/kloak/secrets.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+	yamlsrc "github.com/spinningfactory/kloak/pkg/secrets/yaml"
+)
+
+// openSecretsSource is the format dispatcher every subcommand that
+// loads a secrets file should call. The plan keeps the seam clean by
+// putting format selection here (CLI-layer) rather than in pkg/secrets/
+// (which would force the base package to import every adapter).
+//
+// Today only YAML is supported; future formats add a case + an import:
+//
+//	case ".env":  return dotenvsrc.NewSource(path)
+//	case "":      return hostenvsrc.NewSource(path /* prefix */)
+//
+// Anything else returns an explicit error so a typo in the file
+// extension fails loudly rather than picking a wrong format silently.
+func openSecretsSource(path string) (secrets.Source, error) {
+	switch ext := strings.ToLower(filepath.Ext(path)); ext {
+	case ".yaml", ".yml":
+		return yamlsrc.NewSource(path)
+	default:
+		return nil, fmt.Errorf("unsupported secrets file extension %q (supported: .yaml, .yml)", ext)
+	}
+}

--- a/cmd/kloak/secrets_test.go
+++ b/cmd/kloak/secrets_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempYAML writes body to a temp file with the given extension and
+// returns its path. Cheap fixture for the dispatcher tests below.
+func writeTempYAML(t *testing.T, ext, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "secrets"+ext)
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return p
+}
+
+func TestOpenSecretsSource_YAMLValid(t *testing.T) {
+	path := writeTempYAML(t, ".yaml", `secrets:
+  - name: x
+    value: real-val
+    inject:
+      env: X
+`)
+	src, err := openSecretsSource(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if src == nil {
+		t.Fatal("expected non-nil Source")
+	}
+}
+
+func TestOpenSecretsSource_YMLExtensionAlsoWorks(t *testing.T) {
+	// .yml and .yaml should both dispatch to the YAML loader so users
+	// who prefer one or the other don't get a surprising error.
+	path := writeTempYAML(t, ".yml", `secrets:
+  - name: x
+    value: v
+    inject:
+      env: X
+`)
+	if _, err := openSecretsSource(path); err != nil {
+		t.Errorf(".yml dispatch failed: %v", err)
+	}
+}
+
+func TestOpenSecretsSource_UppercaseExtension(t *testing.T) {
+	// Extension matching is case-insensitive (filepath.Ext + strings.ToLower).
+	path := writeTempYAML(t, ".YAML", `secrets:
+  - name: x
+    value: v
+    inject:
+      env: X
+`)
+	if _, err := openSecretsSource(path); err != nil {
+		t.Errorf("uppercase .YAML should dispatch: %v", err)
+	}
+}
+
+func TestOpenSecretsSource_UnsupportedExtension(t *testing.T) {
+	path := writeTempYAML(t, ".txt", "irrelevant body")
+	_, err := openSecretsSource(path)
+	if err == nil {
+		t.Fatal("expected error for .txt")
+	}
+	if !strings.Contains(err.Error(), `unsupported secrets file extension ".txt"`) {
+		t.Errorf("error %q should mention the unsupported extension", err)
+	}
+	// The error must list supported extensions so the user knows what
+	// to fix without reading source code.
+	if !strings.Contains(err.Error(), ".yaml") || !strings.Contains(err.Error(), ".yml") {
+		t.Errorf("error %q should advertise supported extensions", err)
+	}
+}
+
+func TestOpenSecretsSource_PropagatesYAMLErrors(t *testing.T) {
+	// Validator failures from the YAML loader must reach the caller
+	// unwrapped (the dispatcher is a pass-through).
+	path := writeTempYAML(t, ".yaml", `secrets:
+  - name: bad
+    value: v
+    port: not-a-port
+    inject:
+      env: X
+`)
+	_, err := openSecretsSource(path)
+	if err == nil {
+		t.Fatal("expected validator error")
+	}
+	if !strings.Contains(err.Error(), "invalid port") {
+		t.Errorf("expected port error, got: %v", err)
+	}
+}

--- a/cmd/kloak/secrets_validate.go
+++ b/cmd/kloak/secrets_validate.go
@@ -40,10 +40,15 @@ same dispatcher.`,
 		if err != nil {
 			return fmt.Errorf("snapshot: %w", err)
 		}
-		fmt.Fprintf(os.Stdout, "%s: ok (%d secret%s)\n", path, len(snap), plural(len(snap)))
-		for _, s := range snap {
-			fmt.Fprintf(os.Stdout, "  - %s: host=%q port=%d inject=%s\n",
-				s.Key, hostOrIP(s), s.Port, formatInject(s.Inject))
+		if _, err := fmt.Fprintf(os.Stdout, "%s: ok (%d secret%s)\n", path, len(snap), plural(len(snap))); err != nil {
+			return fmt.Errorf("write output: %w", err)
+		}
+		for i := range snap {
+			s := &snap[i]
+			if _, err := fmt.Fprintf(os.Stdout, "  - %s: host=%q port=%d inject=%s\n",
+				s.Key, hostOrIP(s), s.Port, formatInject(s.Inject)); err != nil {
+				return fmt.Errorf("write output: %w", err)
+			}
 		}
 		return nil
 	},
@@ -63,8 +68,9 @@ func plural(n int) string {
 
 // hostOrIP returns the textual host/IP form for the validator output.
 // Host takes precedence; IP fills in for literal-IP secrets. Empty
-// string when both are unset (wildcard).
-func hostOrIP(s secrets.Secret) string {
+// string when both are unset (wildcard). Takes a pointer to avoid the
+// 144-byte hugeParam copy the linter flags.
+func hostOrIP(s *secrets.Secret) string {
 	if s.Host != "" {
 		return s.Host
 	}

--- a/cmd/kloak/secrets_validate.go
+++ b/cmd/kloak/secrets_validate.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"context"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,28 +28,36 @@ The file format is selected by extension: .yaml/.yml use the YAML loader.
 Future formats (.env, host-env, secret backends) will register through the
 same dispatcher.`,
 	Args: cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
-		path := args[0]
-		src, err := openSecretsSource(path)
-		if err != nil {
-			return err
-		}
-		snap, err := src.Snapshot(context.Background())
-		if err != nil {
-			return fmt.Errorf("snapshot: %w", err)
-		}
-		if _, err := fmt.Fprintf(os.Stdout, "%s: ok (%d secret%s)\n", path, len(snap), plural(len(snap))); err != nil {
+	RunE: runSecretsValidate,
+}
+
+// runSecretsValidate is the cobra RunE for `kloak secrets validate`,
+// extracted so unit tests can call it without going through
+// cobra.Execute. Output goes through cmd.OutOrStdout() (test-redirectable)
+// and the context comes from cmd.Context() so Ctrl-C / parent
+// cancellation are respected.
+func runSecretsValidate(cmd *cobra.Command, args []string) error {
+	path := args[0]
+	src, err := openSecretsSource(path)
+	if err != nil {
+		return err
+	}
+	snap, err := src.Snapshot(cmd.Context())
+	if err != nil {
+		return fmt.Errorf("snapshot: %w", err)
+	}
+	out := cmd.OutOrStdout()
+	if _, err := fmt.Fprintf(out, "%s: ok (%d secret%s)\n", path, len(snap), plural(len(snap))); err != nil {
+		return fmt.Errorf("write output: %w", err)
+	}
+	for i := range snap {
+		s := &snap[i]
+		if _, err := fmt.Fprintf(out, "  - %s: host=%q port=%d inject=%s\n",
+			s.Key, hostOrIP(s), s.Port, formatInject(s.Inject)); err != nil {
 			return fmt.Errorf("write output: %w", err)
 		}
-		for i := range snap {
-			s := &snap[i]
-			if _, err := fmt.Fprintf(os.Stdout, "  - %s: host=%q port=%d inject=%s\n",
-				s.Key, hostOrIP(s), s.Port, formatInject(s.Inject)); err != nil {
-				return fmt.Errorf("write output: %w", err)
-			}
-		}
-		return nil
-	},
+	}
+	return nil
 }
 
 func init() {

--- a/cmd/kloak/secrets_validate.go
+++ b/cmd/kloak/secrets_validate.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+)
+
+var secretsCmd = &cobra.Command{
+	Use:   "secrets",
+	Short: "Inspect and validate kloak secrets configuration",
+	Long: `Subcommands for working with kloak secrets files. Today only
+` + "`kloak secrets validate`" + ` is exposed; future subcommands will cover
+templating and live inspection.`,
+}
+
+var secretsValidateCmd = &cobra.Command{
+	Use:   "validate <path>",
+	Short: "Validate a kloak secrets file",
+	Long: `Loads a kloak secrets file, parses it, runs every validator that
+the runtime would run, and prints a short summary on success. Exits non-zero
+on any error so it can drop into CI.
+
+The file format is selected by extension: .yaml/.yml use the YAML loader.
+Future formats (.env, host-env, secret backends) will register through the
+same dispatcher.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(_ *cobra.Command, args []string) error {
+		path := args[0]
+		src, err := openSecretsSource(path)
+		if err != nil {
+			return err
+		}
+		snap, err := src.Snapshot(context.Background())
+		if err != nil {
+			return fmt.Errorf("snapshot: %w", err)
+		}
+		fmt.Fprintf(os.Stdout, "%s: ok (%d secret%s)\n", path, len(snap), plural(len(snap)))
+		for _, s := range snap {
+			fmt.Fprintf(os.Stdout, "  - %s: host=%q port=%d inject=%s\n",
+				s.Key, hostOrIP(s), s.Port, formatInject(s.Inject))
+		}
+		return nil
+	},
+}
+
+func init() {
+	secretsCmd.AddCommand(secretsValidateCmd)
+	rootCmd.AddCommand(secretsCmd)
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return ""
+	}
+	return "s"
+}
+
+// hostOrIP returns the textual host/IP form for the validator output.
+// Host takes precedence; IP fills in for literal-IP secrets. Empty
+// string when both are unset (wildcard).
+func hostOrIP(s secrets.Secret) string {
+	if s.Host != "" {
+		return s.Host
+	}
+	if s.IP != nil {
+		return s.IP.String()
+	}
+	return ""
+}
+
+// formatInject renders the Inject targets compactly for `secrets validate`
+// output. "env=NAME", "file=PATH", or "env=NAME,file=PATH"; "none" when
+// both are empty (which the translator already rejects — printing "none"
+// is just a defensive fallback).
+func formatInject(in secrets.Inject) string {
+	var parts []string
+	if in.Env != "" {
+		parts = append(parts, "env="+in.Env)
+	}
+	if in.File != "" {
+		parts = append(parts, "file="+in.File)
+	}
+	if len(parts) == 0 {
+		return "none"
+	}
+	return strings.Join(parts, ",")
+}

--- a/cmd/kloak/secrets_validate_test.go
+++ b/cmd/kloak/secrets_validate_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+)
+
+// newValidateCmd builds an isolated copy of the validate command for a
+// test. Using the package-level secretsValidateCmd directly would let
+// state leak between tests (output buffers, args) — and Cobra's docs
+// warn against reusing commands across runs in tests. Cloning ensures
+// each test gets a fresh RunE binding to runSecretsValidate.
+func newValidateCmd(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{
+		Use:  "validate <path>",
+		Args: cobra.ExactArgs(1),
+		RunE: runSecretsValidate,
+	}
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	// SilenceUsage so cobra's auto-printed usage block doesn't
+	// contaminate the output buffer when we're asserting on it.
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetContext(context.Background())
+	return cmd, buf
+}
+
+func TestRunSecretsValidate_HappyPath(t *testing.T) {
+	t.Setenv("KLOAK_TEST_REAL", "from-env-real")
+	path := writeTempYAML(t, ".yaml", `secrets:
+  - name: stripe-key
+    value: sk-live-abcdef
+    host: api.stripe.com
+    port: 443
+    inject:
+      env: STRIPE_KEY
+  - name: openai
+    valueFrom:
+      env: KLOAK_TEST_REAL
+    inject:
+      env: OPENAI_KEY
+      file: /run/kloak/openai
+`)
+	cmd, buf := newValidateCmd(t)
+	cmd.SetArgs([]string{path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	out := buf.String()
+	// Summary line counts both entries.
+	if !strings.Contains(out, "ok (2 secrets)") {
+		t.Errorf("missing 2-secret summary in output:\n%s", out)
+	}
+	// Per-entry lines surface host + inject metadata.
+	if !strings.Contains(out, `stripe-key: host="api.stripe.com" port=443 inject=env=STRIPE_KEY`) {
+		t.Errorf("stripe-key line missing or wrong:\n%s", out)
+	}
+	if !strings.Contains(out, `openai: host="" port=0 inject=env=OPENAI_KEY,file=/run/kloak/openai`) {
+		t.Errorf("openai line missing or wrong:\n%s", out)
+	}
+}
+
+func TestRunSecretsValidate_SingleSecretPluralForm(t *testing.T) {
+	// One secret → "(1 secret)" not "(1 secrets)". Guards the plural helper.
+	path := writeTempYAML(t, ".yaml", `secrets:
+  - name: only
+    value: v
+    inject:
+      env: ONLY
+`)
+	cmd, buf := newValidateCmd(t)
+	cmd.SetArgs([]string{path})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if !strings.Contains(buf.String(), "ok (1 secret)") {
+		t.Errorf("expected singular `1 secret`, got:\n%s", buf.String())
+	}
+}
+
+func TestRunSecretsValidate_ValidatorErrorPropagates(t *testing.T) {
+	path := writeTempYAML(t, ".yaml", `secrets:
+  - name: bad
+    value: v
+    port: not-a-port
+    inject:
+      env: X
+`)
+	cmd, _ := newValidateCmd(t)
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected validator error")
+	}
+	if !strings.Contains(err.Error(), "invalid port") {
+		t.Errorf("expected port error, got: %v", err)
+	}
+}
+
+func TestRunSecretsValidate_UnsupportedExtension(t *testing.T) {
+	path := writeTempYAML(t, ".txt", "irrelevant")
+	cmd, _ := newValidateCmd(t)
+	cmd.SetArgs([]string{path})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected dispatcher error")
+	}
+	if !strings.Contains(err.Error(), "unsupported secrets file extension") {
+		t.Errorf("expected extension error, got: %v", err)
+	}
+}
+
+func TestRunSecretsValidate_MissingArgsRejected(t *testing.T) {
+	// cobra.ExactArgs(1) rejects zero or multiple args. Belt-and-suspenders
+	// on the args contract.
+	cmd, _ := newValidateCmd(t)
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err == nil {
+		t.Error("expected error for missing args")
+	}
+}
+
+func TestHostOrIP(t *testing.T) {
+	cases := []struct {
+		name string
+		s    secrets.Secret
+		want string
+	}{
+		{"host wins", secrets.Secret{Host: "api.stripe.com"}, "api.stripe.com"},
+		{"host takes precedence over IP", secrets.Secret{Host: "api.stripe.com", IP: net.ParseIP("192.0.2.1")}, "api.stripe.com"},
+		{"IP fallback", secrets.Secret{IP: net.ParseIP("192.0.2.1")}, "192.0.2.1"},
+		{"empty wildcard", secrets.Secret{}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := tc.s
+			if got := hostOrIP(&s); got != tc.want {
+				t.Errorf("hostOrIP(%+v) = %q, want %q", tc.s, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatInject(t *testing.T) {
+	cases := []struct {
+		name string
+		in   secrets.Inject
+		want string
+	}{
+		{"env only", secrets.Inject{Env: "STRIPE_KEY"}, "env=STRIPE_KEY"},
+		{"file only", secrets.Inject{File: "/run/kloak/x"}, "file=/run/kloak/x"},
+		{"both", secrets.Inject{Env: "E", File: "/f"}, "env=E,file=/f"},
+		{"none (defensive)", secrets.Inject{}, "none"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := formatInject(tc.in); got != tc.want {
+				t.Errorf("formatInject(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlural(t *testing.T) {
+	for _, tc := range []struct {
+		n    int
+		want string
+	}{
+		{0, "s"}, {1, ""}, {2, "s"}, {100, "s"},
+	} {
+		if got := plural(tc.n); got != tc.want {
+			t.Errorf("plural(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.0
 	sigs.k8s.io/controller-runtime v0.24.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -64,5 +65,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.2 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/pkg/secrets/secrets.go
+++ b/pkg/secrets/secrets.go
@@ -55,6 +55,36 @@ type Secret struct {
 
 	// Protocol is unix.IPPROTO_TCP / IPPROTO_UDP, or 0 for any.
 	Protocol uint8
+
+	// Inject describes how the standalone `kloak run` runtime should
+	// surface this secret's *shadow* value to a child process. The k8s
+	// adapter leaves this zero — Kubernetes Pods already get their
+	// secret values through the cluster's own injection mechanisms
+	// (volume mounts, env vars rewritten by the webhook), so the
+	// data-plane sync code never reads this field. The YAML / dotenv /
+	// host-env Sources for `kloak run` set it from the user's config.
+	Inject Inject
+}
+
+// Inject describes how a Source wants the shadow value materialized
+// for a child process. A non-runtime consumer (e.g. the k8s adapter)
+// returns the zero value and the field is ignored.
+//
+// Both Env and File may be set on the same Secret — the child will see
+// the shadow placeholder in both the named env var AND the file at the
+// given path. Empty in both fields means "no injection requested";
+// runtimes should treat that as a validation error before they get
+// here.
+type Inject struct {
+	// Env is the name of an environment variable to set on the child
+	// process. The value will be the secret's Shadow placeholder.
+	Env string
+
+	// File is an absolute path inside the child's filesystem where the
+	// Shadow placeholder will be written. Parent directories are
+	// created with 0700; the file itself is mode 0400 owned by the
+	// child's uid (the runtime owns those decisions).
+	File string
 }
 
 // Source produces snapshots of the secrets the data plane should program

--- a/pkg/secrets/yaml/equivalence_test.go
+++ b/pkg/secrets/yaml/equivalence_test.go
@@ -1,0 +1,120 @@
+package yaml
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+	k8ssrc "github.com/spinningfactory/kloak/pkg/secrets/k8s"
+)
+
+// TestEquivalence_YAMLvsK8s proves that the YAML adapter and the k8s
+// adapter produce semantically identical secrets — same Real, Host,
+// Port, Protocol — when fed equivalent inputs. This is the contract
+// that lets `kloak run` reuse every byte of the data plane.
+//
+// Fields excluded from the comparison:
+//   - Shadow:  random per generator
+//   - OwnerID: format-specific identifier (namespace/name vs name);
+//     internal to collision tracking, not visible to BPF.
+//   - Inject:  YAML-only; k8s adapter leaves it zero. Verified by
+//     other tests in this package.
+//   - IP:      not exercised here; covered by TestTranslate_HostParsedAsLiteralIP.
+func TestEquivalence_YAMLvsK8s(t *testing.T) {
+	const (
+		realValue = "sk-live-equivalence-test"
+		host      = "api.stripe.com"
+		port      = "443"
+	)
+
+	// --- k8s side: build a fake client with an enabled + shadow Secret.
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1: %v", err)
+	}
+	enabled := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stripe-key",
+			Namespace: "default",
+			Labels:    map[string]string{k8ssrc.LabelEnabled: "true"},
+			Annotations: map[string]string{
+				k8ssrc.AnnotationHosts: host,
+				k8ssrc.AnnotationPort:  port,
+			},
+		},
+		Data: map[string][]byte{"api-key": []byte(realValue)},
+	}
+	// Mint a shadow up-front so the k8s join sees one.
+	gen := secrets.NewShadowGenerator(nil, nil)
+	shadowVal, err := gen.Generate(len(realValue), realValue, "default/stripe-key", 20)
+	if err != nil {
+		t.Fatalf("shadow gen: %v", err)
+	}
+	shadow := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "stripe-key-kloak",
+			Namespace: "default",
+			Labels: map[string]string{
+				k8ssrc.LabelManaged: "true",
+				k8ssrc.LabelOwner:   "stripe-key",
+			},
+		},
+		Data: map[string][]byte{"api-key": []byte(shadowVal)},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(enabled, shadow).Build()
+	k8sSrc := k8ssrc.NewSource(cl)
+	k8sSnap, err := k8sSrc.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("k8s Snapshot: %v", err)
+	}
+	if len(k8sSnap) != 1 {
+		t.Fatalf("k8s snapshot len=%d, want 1", len(k8sSnap))
+	}
+
+	// --- yaml side: equivalent entry through the YAML translator.
+	path := writeTempYAML(t, `secrets:
+  - name: stripe-key
+    value: sk-live-equivalence-test
+    host: api.stripe.com
+    port: 443
+    inject:
+      env: STRIPE_KEY
+`)
+	ySrc, err := NewSource(path)
+	if err != nil {
+		t.Fatalf("yaml NewSource: %v", err)
+	}
+	ySnap, err := ySrc.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("yaml Snapshot: %v", err)
+	}
+	if len(ySnap) != 1 {
+		t.Fatalf("yaml snapshot len=%d, want 1", len(ySnap))
+	}
+
+	k, y := k8sSnap[0], ySnap[0]
+	if k.Real != y.Real {
+		t.Errorf("Real mismatch: k8s=%q yaml=%q", k.Real, y.Real)
+	}
+	if k.Host != y.Host {
+		t.Errorf("Host mismatch: k8s=%q yaml=%q", k.Host, y.Host)
+	}
+	if k.Port != y.Port {
+		t.Errorf("Port mismatch: k8s=%d yaml=%d", k.Port, y.Port)
+	}
+	if k.Protocol != y.Protocol {
+		t.Errorf("Protocol mismatch: k8s=%d yaml=%d", k.Protocol, y.Protocol)
+	}
+	// Sanity: YAML side populates Inject; k8s side doesn't.
+	if y.Inject.Env != "STRIPE_KEY" {
+		t.Errorf("yaml Inject.Env=%q, want STRIPE_KEY", y.Inject.Env)
+	}
+	if k.Inject != (secrets.Inject{}) {
+		t.Errorf("k8s Inject should be zero, got %+v", k.Inject)
+	}
+}

--- a/pkg/secrets/yaml/schema.go
+++ b/pkg/secrets/yaml/schema.go
@@ -1,0 +1,58 @@
+// Package yaml is one concrete `secrets.Source` implementation: it
+// reads a kloak-native YAML file and emits the canonical
+// `[]secrets.Secret` slice the data plane consumes.
+//
+// The package owns three layers in strict separation, so adding another
+// on-disk format (`.env`, host env vars, …) is a copy of this package
+// with the schema struct swapped — no other code path moves:
+//
+//	schema.go    private types tagged for yaml.v3; the only thing that
+//	             knows about the on-disk shape.
+//	translate.go pure schema → []secrets.Secret + validation; no I/O.
+//	source.go    secrets.Source adapter; loads + translates at New, caches
+//	             the snapshot.
+//
+// Future format packages mirror the layout. The public seam is
+// pkg/secrets.{Secret, Source, ShadowGenerator, ParseHost, ParsePort} —
+// not the schema struct.
+package yaml
+
+// fileSpec is the top-level on-disk shape. yaml.v3 unmarshals into this
+// struct; nothing outside this package depends on it. Field names match
+// the user-facing YAML keys, not the internal model.
+type fileSpec struct {
+	Secrets []secretSpec `yaml:"secrets"`
+}
+
+// secretSpec is one entry under the `secrets:` list. All fields except
+// Name and Inject are optional at the schema level; the translator
+// enforces the semantic rules (exactly one of Value / ValueFrom, at
+// least one Inject target, etc.).
+type secretSpec struct {
+	Name      string         `yaml:"name"`
+	Value     string         `yaml:"value,omitempty"`
+	ValueFrom *valueFromSpec `yaml:"valueFrom,omitempty"`
+	Host      string         `yaml:"host,omitempty"`
+	// Port is a string at the schema layer so we can accept both bare
+	// numbers ("443") and the "<port>/<proto>" form ("443/tcp"). The
+	// translator splits it via pkg/secrets.ParsePort.
+	Port   string     `yaml:"port,omitempty"`
+	Inject injectSpec `yaml:"inject"`
+}
+
+// valueFromSpec lets `secrets.yaml` reference a real value indirectly so
+// the file itself stays safe to commit. Env is the only source for now;
+// future backends (op://, aws-sm://, …) get sibling fields here.
+type valueFromSpec struct {
+	Env string `yaml:"env,omitempty"`
+}
+
+// injectSpec is the per-secret request for how the shadow value should
+// be exposed to the child process the `kloak run` runtime spawns. Both
+// fields may be set on the same secret (env AND file), but at least one
+// must be — a secret with no injection target has no way to reach the
+// child and is rejected at translate time.
+type injectSpec struct {
+	Env  string `yaml:"env,omitempty"`
+	File string `yaml:"file,omitempty"`
+}

--- a/pkg/secrets/yaml/source.go
+++ b/pkg/secrets/yaml/source.go
@@ -1,0 +1,56 @@
+package yaml
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/yaml"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+)
+
+// Source implements secrets.Source over a kloak-native YAML file.
+//
+// The file is loaded, validated, and translated at construction; the
+// resulting []secrets.Secret is cached and returned by every Snapshot
+// call. Hot reload is not implemented in this Source — wrap it in a
+// reloading shim when Phase 6's Subscribe() variant lands.
+//
+// Source is safe for concurrent Snapshot callers because the snapshot
+// slice is immutable after New returns.
+type Source struct {
+	snapshot []secrets.Secret
+}
+
+// NewSource reads, parses, validates, and translates the YAML at path.
+// All errors — file not found, invalid YAML, schema violations, port
+// parse errors, Huffman-unsatisfiable shadow generation — surface here,
+// not at Snapshot time. The runtime can therefore decide to fail fast
+// before launching a child process.
+func NewSource(path string) (*Source, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read secrets file: %w", err)
+	}
+	var spec fileSpec
+	// sigs.k8s.io/yaml routes through encoding/json for stricter type
+	// handling than gopkg.in/yaml.v3 — it rejects an int where a string
+	// is expected, which matches user expectations for a config file.
+	if err := yaml.Unmarshal(raw, &spec); err != nil {
+		return nil, fmt.Errorf("parse secrets file: %w", err)
+	}
+
+	gen := secrets.NewShadowGenerator(nil, nil)
+	out, err := translate(spec, gen)
+	if err != nil {
+		return nil, err
+	}
+	return &Source{snapshot: out}, nil
+}
+
+// Snapshot returns the cached snapshot. The slice MUST NOT be mutated
+// by the caller (same contract as every secrets.Source).
+func (s *Source) Snapshot(_ context.Context) ([]secrets.Secret, error) {
+	return s.snapshot, nil
+}

--- a/pkg/secrets/yaml/source_test.go
+++ b/pkg/secrets/yaml/source_test.go
@@ -1,0 +1,130 @@
+package yaml
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeTempYAML drops a YAML blob into a temp file scoped to t and
+// returns its path. Cheap fixture pattern that keeps the YAML literal
+// next to the test that uses it.
+func writeTempYAML(t *testing.T, body string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "secrets.yaml")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	return p
+}
+
+func TestSource_GoldenValid(t *testing.T) {
+	// Realistic mixed config: literal value, valueFrom env, env+file
+	// injection, host + port filter, port-with-protocol.
+	t.Setenv("KLOAK_TEST_REAL", "from-env-real")
+	path := writeTempYAML(t, `secrets:
+  - name: stripe-key
+    value: sk-live-abcdef123
+    host: api.stripe.com
+    port: 443
+    inject:
+      env: STRIPE_KEY
+  - name: openai-key
+    valueFrom:
+      env: KLOAK_TEST_REAL
+    host: api.openai.com
+    inject:
+      env: OPENAI_KEY
+      file: /run/kloak/openai-key
+  - name: dns-secret
+    value: dns-real-value
+    port: 53/udp
+    inject:
+      env: DNS_KEY
+`)
+
+	src, err := NewSource(path)
+	if err != nil {
+		t.Fatalf("NewSource: %v", err)
+	}
+	snap, err := src.Snapshot(context.Background())
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if len(snap) != 3 {
+		t.Fatalf("len(snap)=%d, want 3", len(snap))
+	}
+	// Confirm valueFrom resolution flowed through.
+	if snap[1].Real != "from-env-real" {
+		t.Errorf("snap[1].Real=%q, want from-env-real", snap[1].Real)
+	}
+	// Confirm both inject targets set on the second entry.
+	if snap[1].Inject.Env != "OPENAI_KEY" || snap[1].Inject.File != "/run/kloak/openai-key" {
+		t.Errorf("snap[1].Inject=%+v, want env+file both set", snap[1].Inject)
+	}
+}
+
+func TestSource_FileNotFound(t *testing.T) {
+	_, err := NewSource("/no/such/path/secrets.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "read secrets file") {
+		t.Errorf("expected `read secrets file` in error, got: %v", err)
+	}
+}
+
+func TestSource_InvalidYAML(t *testing.T) {
+	path := writeTempYAML(t, ": not yaml :::\n")
+	_, err := NewSource(path)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse secrets file") {
+		t.Errorf("expected `parse secrets file` in error, got: %v", err)
+	}
+}
+
+func TestSource_ValidatorErrorsBubbleUp(t *testing.T) {
+	// Confirms that translator errors propagate through NewSource with
+	// the entry context preserved.
+	path := writeTempYAML(t, `secrets:
+  - name: bad
+    value: v
+    port: not-a-port
+    inject:
+      env: X
+`)
+	_, err := NewSource(path)
+	if err == nil {
+		t.Fatal("expected validator error")
+	}
+	if !strings.Contains(err.Error(), `entry 0 ("bad")`) {
+		t.Errorf("error should include entry context, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid port") {
+		t.Errorf("error should describe the failure, got: %v", err)
+	}
+}
+
+func TestSource_SnapshotIsStable(t *testing.T) {
+	// Snapshot must return the same slice on every call (per the
+	// secrets.Source contract — no I/O on the hot path).
+	path := writeTempYAML(t, `secrets:
+  - name: a
+    value: aaa
+    inject:
+      env: A
+`)
+	src, err := NewSource(path)
+	if err != nil {
+		t.Fatalf("NewSource: %v", err)
+	}
+	a, _ := src.Snapshot(context.Background())
+	b, _ := src.Snapshot(context.Background())
+	if len(a) != len(b) || a[0].Shadow != b[0].Shadow {
+		t.Error("Snapshot should be cached + stable across calls")
+	}
+}

--- a/pkg/secrets/yaml/translate.go
+++ b/pkg/secrets/yaml/translate.go
@@ -43,13 +43,14 @@ func translate(spec fileSpec, gen *secrets.ShadowGenerator) ([]secrets.Secret, e
 	}
 
 	out := make([]secrets.Secret, 0, len(spec.Secrets))
-	for i, s := range spec.Secrets {
-		real, err := resolveRealValue(s)
+	for i := range spec.Secrets {
+		s := &spec.Secrets[i]
+		realVal, err := resolveRealValue(s)
 		if err != nil {
 			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): %w", i, s.Name, err)
 		}
-		if len(real) > maxRealLen {
-			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): real value is %d bytes, max is %d", i, s.Name, len(real), maxRealLen)
+		if len(realVal) > maxRealLen {
+			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): real value is %d bytes, max is %d", i, s.Name, len(realVal), maxRealLen)
 		}
 
 		host, ip := secrets.ParseHost(s.Host)
@@ -74,7 +75,7 @@ func translate(spec fileSpec, gen *secrets.ShadowGenerator) ([]secrets.Secret, e
 		// future hot-reload of the same secret reuses its own prefix
 		// instead of treating itself as a collision. maxRetries=20
 		// mirrors the controller's value at pkg/controller/secret_reconciler.go.
-		shadow, err := gen.Generate(len(real), real, s.Name, 20)
+		shadow, err := gen.Generate(len(realVal), realVal, s.Name, 20)
 		if err != nil {
 			if errors.Is(err, secrets.ErrHuffmanInvariantUnsatisfiable) {
 				return nil, fmt.Errorf("secrets.yaml: entry %d (%q): cannot mint a shadow with sufficient HPACK Huffman length — the real value's encoding is too dense for the requested length (consider a longer secret value): %w", i, s.Name, err)
@@ -85,7 +86,7 @@ func translate(spec fileSpec, gen *secrets.ShadowGenerator) ([]secrets.Secret, e
 		out = append(out, secrets.Secret{
 			OwnerID:  s.Name,
 			Key:      s.Name,
-			Real:     real,
+			Real:     realVal,
 			Shadow:   shadow,
 			Host:     host,
 			IP:       ip,
@@ -101,8 +102,9 @@ func translate(spec fileSpec, gen *secrets.ShadowGenerator) ([]secrets.Secret, e
 // reading from `valueFrom.env` if Value is empty. Exactly one of the
 // two must be set, and `valueFrom.env` must resolve to a non-empty
 // string — a missing env var is a configuration error, not a silent
-// empty secret.
-func resolveRealValue(s secretSpec) (string, error) {
+// empty secret. Takes a pointer to avoid the hugeParam copy the linter
+// flags (secretSpec is 104 bytes).
+func resolveRealValue(s *secretSpec) (string, error) {
 	switch {
 	case s.Value != "" && s.ValueFrom != nil:
 		return "", fmt.Errorf("`value` and `valueFrom` are mutually exclusive")

--- a/pkg/secrets/yaml/translate.go
+++ b/pkg/secrets/yaml/translate.go
@@ -1,0 +1,136 @@
+package yaml
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+)
+
+// maxRealLen mirrors the BPF wire-format secretValue.RealSecret cap in
+// pkg/ebpf/uprobe.go. Keeping this constant local (rather than reaching
+// across packages) avoids dragging the Linux-only ebpf package into the
+// portable secrets/yaml build; the value is part of kloak's on-disk
+// contract, not a Linux-runtime detail.
+const maxRealLen = 128
+
+// translate converts a parsed fileSpec into the canonical
+// []secrets.Secret slice. Pure function (apart from os.Getenv used to
+// resolve `valueFrom.env`): no I/O against the source file, no clock,
+// no network. The ShadowGenerator is supplied by the caller so tests
+// can pass a deterministic seed.
+//
+// All validation lives here so the translator itself is the single
+// source of truth for what a valid YAML entry looks like. The Source
+// adapter (source.go) is just YAML load + Snapshot caching.
+func translate(spec fileSpec, gen *secrets.ShadowGenerator) ([]secrets.Secret, error) {
+	if len(spec.Secrets) == 0 {
+		return nil, fmt.Errorf("secrets.yaml: no secrets defined under `secrets:`")
+	}
+
+	// Detect duplicate names early so the per-entry error messages don't
+	// mention rules that pass for both copies of the same name.
+	seenNames := make(map[string]int, len(spec.Secrets))
+	for i, s := range spec.Secrets {
+		if s.Name == "" {
+			return nil, fmt.Errorf("secrets.yaml: entry %d: `name` is required", i)
+		}
+		if prev, dup := seenNames[s.Name]; dup {
+			return nil, fmt.Errorf("secrets.yaml: duplicate secret name %q (entries %d and %d)", s.Name, prev, i)
+		}
+		seenNames[s.Name] = i
+	}
+
+	out := make([]secrets.Secret, 0, len(spec.Secrets))
+	for i, s := range spec.Secrets {
+		real, err := resolveRealValue(s)
+		if err != nil {
+			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): %w", i, s.Name, err)
+		}
+		if len(real) > maxRealLen {
+			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): real value is %d bytes, max is %d", i, s.Name, len(real), maxRealLen)
+		}
+
+		host, ip := secrets.ParseHost(s.Host)
+
+		var port uint16
+		var proto uint8
+		if s.Port != "" {
+			ps, err := secrets.ParsePort(s.Port)
+			if err != nil {
+				return nil, fmt.Errorf("secrets.yaml: entry %d (%q): invalid port %q: %w", i, s.Name, s.Port, err)
+			}
+			port = ps.Port
+			proto = ps.Protocol
+		}
+
+		inject, err := resolveInject(s.Inject)
+		if err != nil {
+			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): %w", i, s.Name, err)
+		}
+
+		// The shadow is minted with the secret name as the ownerID so a
+		// future hot-reload of the same secret reuses its own prefix
+		// instead of treating itself as a collision. maxRetries=20
+		// mirrors the controller's value at pkg/controller/secret_reconciler.go.
+		shadow, err := gen.Generate(len(real), real, s.Name, 20)
+		if err != nil {
+			if errors.Is(err, secrets.ErrHuffmanInvariantUnsatisfiable) {
+				return nil, fmt.Errorf("secrets.yaml: entry %d (%q): cannot mint a shadow with sufficient HPACK Huffman length — the real value's encoding is too dense for the requested length (consider a longer secret value): %w", i, s.Name, err)
+			}
+			return nil, fmt.Errorf("secrets.yaml: entry %d (%q): shadow generation failed: %w", i, s.Name, err)
+		}
+
+		out = append(out, secrets.Secret{
+			OwnerID:  s.Name,
+			Key:      s.Name,
+			Real:     real,
+			Shadow:   shadow,
+			Host:     host,
+			IP:       ip,
+			Port:     port,
+			Protocol: proto,
+			Inject:   inject,
+		})
+	}
+	return out, nil
+}
+
+// resolveRealValue returns the literal value the secret rewrites to,
+// reading from `valueFrom.env` if Value is empty. Exactly one of the
+// two must be set, and `valueFrom.env` must resolve to a non-empty
+// string — a missing env var is a configuration error, not a silent
+// empty secret.
+func resolveRealValue(s secretSpec) (string, error) {
+	switch {
+	case s.Value != "" && s.ValueFrom != nil:
+		return "", fmt.Errorf("`value` and `valueFrom` are mutually exclusive")
+	case s.Value != "":
+		return s.Value, nil
+	case s.ValueFrom != nil:
+		if s.ValueFrom.Env == "" {
+			return "", fmt.Errorf("`valueFrom` requires `env` (additional backends not yet supported)")
+		}
+		v, ok := os.LookupEnv(s.ValueFrom.Env)
+		if !ok || v == "" {
+			return "", fmt.Errorf("`valueFrom.env: %s` resolves to empty / unset; refusing to ship an empty real value", s.ValueFrom.Env)
+		}
+		return v, nil
+	default:
+		return "", fmt.Errorf("must set exactly one of `value` or `valueFrom`")
+	}
+}
+
+// resolveInject normalizes the injection target. At least one of
+// Env / File must be set; everything else (e.g. validating that File is
+// an absolute path) is enforced by the runtime that actually
+// materializes the injection — keeping it out of the translator lets
+// the YAML source stay loadable on macOS for tooling like
+// `kloak secrets validate`.
+func resolveInject(spec injectSpec) (secrets.Inject, error) {
+	if spec.Env == "" && spec.File == "" {
+		return secrets.Inject{}, fmt.Errorf("`inject` must set at least one of `env` or `file`")
+	}
+	return secrets.Inject{Env: spec.Env, File: spec.File}, nil
+}

--- a/pkg/secrets/yaml/translate_test.go
+++ b/pkg/secrets/yaml/translate_test.go
@@ -1,0 +1,242 @@
+package yaml
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/spinningfactory/kloak/pkg/secrets"
+)
+
+// newGen returns a fresh ShadowGenerator with an empty seed. Used by
+// every translator test so name-derived OwnerIDs are the only thing
+// the collision tracker sees.
+func newGen() *secrets.ShadowGenerator { return secrets.NewShadowGenerator(nil, nil) }
+
+func TestTranslate_SingleSecretLiteralValue(t *testing.T) {
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name:   "stripe-key",
+		Value:  "sk-live-xyz",
+		Host:   "api.stripe.com",
+		Port:   "443",
+		Inject: injectSpec{Env: "STRIPE_KEY"},
+	}}}
+
+	out, err := translate(spec, newGen())
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if len(out) != 1 {
+		t.Fatalf("len(out)=%d, want 1", len(out))
+	}
+	got := out[0]
+	if got.OwnerID != "stripe-key" || got.Key != "stripe-key" {
+		t.Errorf("OwnerID=%q Key=%q, want both =stripe-key", got.OwnerID, got.Key)
+	}
+	if got.Real != "sk-live-xyz" {
+		t.Errorf("Real=%q, want sk-live-xyz", got.Real)
+	}
+	if !strings.HasPrefix(got.Shadow, secrets.ValuePrefix) {
+		t.Errorf("Shadow=%q does not start with %q", got.Shadow, secrets.ValuePrefix)
+	}
+	if len(got.Shadow) != len(got.Real) {
+		t.Errorf("len(Shadow)=%d, want %d (= len(Real))", len(got.Shadow), len(got.Real))
+	}
+	if got.Host != "api.stripe.com" || got.IP != nil {
+		t.Errorf("Host=%q IP=%v, want api.stripe.com + nil", got.Host, got.IP)
+	}
+	if got.Port != 443 || got.Protocol != uint8(unix.IPPROTO_TCP) {
+		t.Errorf("Port=%d Protocol=%d, want 443/tcp", got.Port, got.Protocol)
+	}
+	if got.Inject.Env != "STRIPE_KEY" || got.Inject.File != "" {
+		t.Errorf("Inject=%+v, want {Env:STRIPE_KEY}", got.Inject)
+	}
+}
+
+func TestTranslate_HostParsedAsLiteralIP(t *testing.T) {
+	// ParseHost routes a literal IP into the IP field, leaving Host empty.
+	// The translator should propagate that unchanged.
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name:   "lan-key",
+		Value:  "abc",
+		Host:   "192.0.2.7",
+		Inject: injectSpec{File: "/run/kloak/lan"},
+	}}}
+	out, err := translate(spec, newGen())
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if out[0].Host != "" {
+		t.Errorf("Host=%q, want empty when input is a literal IP", out[0].Host)
+	}
+	if !out[0].IP.Equal(net.ParseIP("192.0.2.7")) {
+		t.Errorf("IP=%v, want 192.0.2.7", out[0].IP)
+	}
+}
+
+func TestTranslate_ValueFromEnv(t *testing.T) {
+	t.Setenv("KLOAK_TEST_REAL", "from-env-real-val")
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name:      "vf",
+		ValueFrom: &valueFromSpec{Env: "KLOAK_TEST_REAL"},
+		Inject:    injectSpec{Env: "VF"},
+	}}}
+	out, err := translate(spec, newGen())
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if out[0].Real != "from-env-real-val" {
+		t.Errorf("Real=%q, want from-env-real-val", out[0].Real)
+	}
+}
+
+func TestTranslate_ValueFromEnvMissingErrors(t *testing.T) {
+	// `valueFrom.env: …` referencing an unset env var must error rather
+	// than silently producing an empty real value.
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name:      "vf",
+		ValueFrom: &valueFromSpec{Env: "KLOAK_TEST_UNSET_VAR_DO_NOT_DEFINE"},
+		Inject:    injectSpec{Env: "VF"},
+	}}}
+	_, err := translate(spec, newGen())
+	if err == nil {
+		t.Fatal("expected error for missing valueFrom.env, got nil")
+	}
+	if !strings.Contains(err.Error(), "valueFrom.env") {
+		t.Errorf("error %q should mention valueFrom.env", err)
+	}
+}
+
+func TestTranslate_ValidationRules(t *testing.T) {
+	cases := []struct {
+		name    string
+		spec    fileSpec
+		wantSub string // substring expected in error
+	}{
+		{
+			name:    "empty list",
+			spec:    fileSpec{},
+			wantSub: "no secrets defined",
+		},
+		{
+			name:    "missing name",
+			spec:    fileSpec{Secrets: []secretSpec{{Value: "v", Inject: injectSpec{Env: "E"}}}},
+			wantSub: "`name` is required",
+		},
+		{
+			name: "duplicate name",
+			spec: fileSpec{Secrets: []secretSpec{
+				{Name: "dup", Value: "a", Inject: injectSpec{Env: "A"}},
+				{Name: "dup", Value: "b", Inject: injectSpec{Env: "B"}},
+			}},
+			wantSub: "duplicate secret name",
+		},
+		{
+			name:    "neither value nor valueFrom",
+			spec:    fileSpec{Secrets: []secretSpec{{Name: "x", Inject: injectSpec{Env: "X"}}}},
+			wantSub: "must set exactly one of",
+		},
+		{
+			name: "both value and valueFrom",
+			spec: fileSpec{Secrets: []secretSpec{{
+				Name: "x", Value: "v",
+				ValueFrom: &valueFromSpec{Env: "Y"},
+				Inject:    injectSpec{Env: "X"},
+			}}},
+			wantSub: "mutually exclusive",
+		},
+		{
+			name: "valueFrom without env field",
+			spec: fileSpec{Secrets: []secretSpec{{
+				Name:      "x",
+				ValueFrom: &valueFromSpec{},
+				Inject:    injectSpec{Env: "X"},
+			}}},
+			wantSub: "valueFrom",
+		},
+		{
+			name: "invalid port string",
+			spec: fileSpec{Secrets: []secretSpec{{
+				Name: "x", Value: "v",
+				Port: "not-a-port", Inject: injectSpec{Env: "X"},
+			}}},
+			wantSub: "invalid port",
+		},
+		{
+			name: "missing inject targets",
+			spec: fileSpec{Secrets: []secretSpec{{
+				Name: "x", Value: "v",
+			}}},
+			wantSub: "at least one of `env` or `file`",
+		},
+		{
+			name: "real value too long",
+			spec: fileSpec{Secrets: []secretSpec{{
+				Name: "x", Value: strings.Repeat("x", maxRealLen+1),
+				Inject: injectSpec{Env: "X"},
+			}}},
+			wantSub: "max is 128",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := translate(tc.spec, newGen())
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestTranslate_HuffmanUnsatisfiableRejectsAtTranslateTime(t *testing.T) {
+	// 'X' is one of HPACK's 8-bit codes; a 10-byte real of all-'X' has
+	// no satisfiable shadow (the BPF wire-buffer invariant from PR #216).
+	// The translator must surface this rather than ship a broken Source.
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name:   "x10",
+		Value:  strings.Repeat("X", 10),
+		Inject: injectSpec{Env: "X10"},
+	}}}
+	_, err := translate(spec, newGen())
+	if err == nil {
+		t.Fatal("expected ErrHuffmanInvariantUnsatisfiable, got nil")
+	}
+	if !errors.Is(err, secrets.ErrHuffmanInvariantUnsatisfiable) {
+		t.Errorf("expected errors.Is(_, ErrHuffmanInvariantUnsatisfiable); got: %v", err)
+	}
+}
+
+func TestTranslate_BothInjectTargets(t *testing.T) {
+	// env + file in the same entry is allowed; runtime exposes both.
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name: "dual", Value: "real-dual",
+		Inject: injectSpec{Env: "DUAL", File: "/run/kloak/dual"},
+	}}}
+	out, err := translate(spec, newGen())
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if out[0].Inject.Env != "DUAL" || out[0].Inject.File != "/run/kloak/dual" {
+		t.Errorf("Inject=%+v, want both Env and File set", out[0].Inject)
+	}
+}
+
+func TestTranslate_PortWithProtocol(t *testing.T) {
+	spec := fileSpec{Secrets: []secretSpec{{
+		Name: "dns", Value: "abcd",
+		Port: "53/udp", Inject: injectSpec{Env: "DNS"},
+	}}}
+	out, err := translate(spec, newGen())
+	if err != nil {
+		t.Fatalf("translate: %v", err)
+	}
+	if out[0].Port != 53 || out[0].Protocol != uint8(unix.IPPROTO_UDP) {
+		t.Errorf("Port=%d Protocol=%d, want 53/udp", out[0].Port, out[0].Protocol)
+	}
+}


### PR DESCRIPTION
## Summary

Phase 2 of the [\`kloak run\` roadmap](../tree/main). Adds the first concrete non-k8s \`secrets.Source\` plus the CLI seam for future formats. Phase 1 (the \`secrets.Source\` interface + ShadowGenerator lift) shipped in #211; Phase 3 (host-cgroup runtime) is the next milestone.

### Why this shape

The on-disk format and the internal model are decoupled by design. Each format gets its own package with three files:

\`\`\`
pkg/secrets/yaml/
  schema.go     private yaml.v3-tagged structs; on-disk shape only
  translate.go  pure schema → []secrets.Secret + validation
  source.go     secrets.Source adapter; cached snapshot
\`\`\`

Adding a future format (\`.env\`, host env vars, Doppler / 1Password / AWS SM) is a copy of this package with the schema struct swapped — no other code path moves. The CLI dispatcher (\`cmd/kloak/secrets.go::openSecretsSource\`) switches on file extension; future formats add a \`case\` + an import.

### YAML schema (kloak-native flat)

\`\`\`yaml
secrets:
  - name: stripe-key
    value: sk-live-xyz123          # or valueFrom: { env: STRIPE_REAL }
    host: api.stripe.com
    port: 443                      # or "443/tcp"
    inject:
      env: STRIPE_KEY              # and/or file: /path/to/secret
\`\`\`

### Validation rules (translator is the single source of truth)

- \`name\` required + unique
- exactly one of \`value\` / \`valueFrom\`
- \`valueFrom.env\` must resolve to a non-empty env var (no silent empty secrets)
- \`port\` parses via the shared \`secrets.ParsePort\`
- \`inject\` requires at least one of \`{env, file}\`
- real value ≤ 128 B (BPF wire-format cap)
- shadow Huffman-invariant satisfiable at translate time (#216)

### Internal model extension

New \`secrets.Inject\` carrier on \`secrets.Secret\` (\`Env\` / \`File\`). The k8s adapter leaves it zero — cluster-injection mechanisms cover that side. YAML populates it; the Phase-3 host-cgroup runtime will read it to materialize the child's env/file. The data-plane sync code in \`pkg/ebpf/sync.go\` never touches the field.

### CLI surface

\`kloak secrets validate <path>\` — loads, validates, prints summary, exits non-zero on any error. Drops into CI cleanly.

### Smoke-tested locally

\`\`\`
$ kloak secrets validate /tmp/secrets-good.yaml
/tmp/secrets-good.yaml: ok (2 secrets)
  - stripe-key: host="api.stripe.com" port=443 inject=env=STRIPE_KEY
  - openai: host="" port=0 inject=env=OPENAI_KEY,file=/run/kloak/openai

$ kloak secrets validate /tmp/secrets-bad.yaml
Error: secrets.yaml: entry 0 ("bad"): invalid port "not-a-port": ...
(exit 1)

$ kloak secrets validate /tmp/secrets.txt
Error: unsupported secrets file extension ".txt" (supported: .yaml, .yml)
(exit 1)
\`\`\`

## Test plan

- [x] 17 translator unit tests (zero I/O) covering every validation rule, both inject targets, port-with-protocol, literal-IP host, valueFrom resolution, Huffman-unsatisfiable rejection.
- [x] Source-level tests: file-not-found, invalid YAML, validator error propagation, snapshot stability.
- [x] **Equivalence test**: a k8s Secret manifest and an equivalent YAML entry produce identical Real/Host/Port/Protocol through their respective adapters — proves the seam holds at the format boundary.
- [x] \`go test -count=1 ./pkg/secrets/... ./pkg/webhook/... ./pkg/controller/... ./cmd/kloak/...\` all green; no existing test regresses on the new \`Inject\` field.
- [x] \`gofmt -l\` clean (only pre-existing main-branch dirty files remain).
- [x] \`go vet ./...\` clean.
- [x] \`go build ./...\` and \`GOOS=linux go build ./...\` both clean.

## Out of scope (Phase 3+)

- The host-cgroup runtime that consumes \`secrets.Inject\` to actually materialize env vars / files for a child process — that's Phase 3, separate PR.
- Hot reload (\`Source.Subscribe()\`), \`valueFrom: { op://, aws-sm:// }\` — deferred to Phase 6.
- \`.env\` and host-env Sources — the seam is in place; each is a copy of \`pkg/secrets/yaml/\` with the schema swapped.

## Binary size impact

Negligible. \`sigs.k8s.io/yaml\` was already an indirect dep (now direct via \`go mod tidy\`). New code is ~430 LOC of pure Go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)