### PR TITLE
feat(cgroups): CreateTransient — kloak.slice/<name> mkdir + idempotent cleanup (Phase 3a)

### DIFF
--- a/pkg/cgroups/cgroup_linux.go
+++ b/pkg/cgroups/cgroup_linux.go
@@ -3,8 +3,20 @@
 package cgroups
 
 import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
 	"syscall"
 )
+
+// KloakSliceName is the directory under the cgroup root where every
+// `kloak run` invocation creates its transient cgroup. The `.slice`
+// suffix is a courtesy to systemd-managed hosts (so a top-level
+// kloak.slice can be hand-delegated if needed); on a pure cgroup v2
+// system it's just a regular directory.
+const KloakSliceName = "kloak.slice"
 
 // GetCgroupInodeFromPath returns the inode number of a cgroup directory on Linux.
 func GetCgroupInodeFromPath(path string) (uint64, error) {
@@ -13,4 +25,96 @@ func GetCgroupInodeFromPath(path string) (uint64, error) {
 		return 0, err
 	}
 	return stat.Ino, nil
+}
+
+// CreateTransient mkdirs a fresh cgroup at <cgroupRoot>/<KloakSliceName>/<name>
+// and returns its path, inode ID, and a cleanup function.
+//
+// The KloakSliceName parent is created on demand and is intentionally
+// NOT removed by the cleanup function — multiple concurrent `kloak run`
+// invocations share that parent, and Phase 4 will handle a startup
+// sweep for orphans.
+//
+// `name` must be a non-empty single path component (no `/`, no `..`).
+// Callers typically pass a UUID. We validate explicitly rather than
+// leaning on filepath.Join's normalization so a malicious name fails
+// loudly instead of escaping the slice parent.
+//
+// The cleanup function is idempotent: calling it after the cgroup is
+// already gone returns nil. It only errors when the cgroup is
+// non-empty (e.g. a child process is still alive in `cgroup.procs`) —
+// at which point the runtime's signal handler is expected to have
+// killed the survivors first.
+//
+// Errors from the initial mkdir (read-only cgroupfs, permission
+// denied, …) are wrapped with the candidate path so the operator can
+// fix the host without spelunking through syscall errors.
+func CreateTransient(cgroupRoot, name string) (path string, id uint64, cleanup func() error, err error) {
+	if cgroupRoot == "" {
+		cgroupRoot = DefaultCgroupRoot
+	}
+	if err := validateTransientName(name); err != nil {
+		return "", 0, nil, err
+	}
+
+	parent := filepath.Join(cgroupRoot, KloakSliceName)
+	// MkdirAll is idempotent on an already-existing parent and a no-op
+	// when permissions allow but the dir is already there. Permission
+	// denied / read-only fs surfaces here for the operator.
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return "", 0, nil, fmt.Errorf("create kloak slice parent %s (cgroupfs writable?): %w", parent, err)
+	}
+
+	path = filepath.Join(parent, name)
+	if err := os.Mkdir(path, 0o755); err != nil {
+		if errors.Is(err, os.ErrExist) {
+			// Same-name collision means a previous run leaked or two
+			// concurrent callers picked the same name. Either way, this
+			// invocation can't safely take ownership.
+			return "", 0, nil, fmt.Errorf("transient cgroup %s already exists; pick a unique name", path)
+		}
+		return "", 0, nil, fmt.Errorf("create transient cgroup %s: %w", path, err)
+	}
+
+	id, statErr := GetCgroupInodeFromPath(path)
+	if statErr != nil {
+		// The mkdir succeeded but we can't stat — best effort: try to
+		// remove what we just created so we don't leak a half-built
+		// transient cgroup.
+		_ = os.Remove(path)
+		return "", 0, nil, fmt.Errorf("stat transient cgroup %s: %w", path, statErr)
+	}
+
+	cleanup = makeTransientCleanup(path)
+	return path, id, cleanup, nil
+}
+
+// makeTransientCleanup returns a closure that removes path exactly
+// once. Idempotent: subsequent calls return nil even if path is gone.
+func makeTransientCleanup(path string) func() error {
+	return func() error {
+		if err := os.Remove(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
+			return fmt.Errorf("rmdir transient cgroup %s: %w", path, err)
+		}
+		return nil
+	}
+}
+
+// validateTransientName rejects names that would let mkdir escape the
+// kloak slice parent. We allow most printable chars (cgroup directory
+// names are flexible) but disallow path-separator / parent-dir tricks.
+func validateTransientName(name string) error {
+	if name == "" {
+		return errors.New("transient cgroup name must not be empty")
+	}
+	if strings.ContainsRune(name, '/') {
+		return fmt.Errorf("transient cgroup name %q must not contain `/`", name)
+	}
+	if name == "." || name == ".." || strings.Contains(name, "..") {
+		return fmt.Errorf("transient cgroup name %q must not contain `..` or `.`", name)
+	}
+	return nil
 }

--- a/pkg/cgroups/cgroup_linux.go
+++ b/pkg/cgroups/cgroup_linux.go
@@ -113,8 +113,11 @@ func validateTransientName(name string) error {
 	if strings.ContainsRune(name, '/') {
 		return fmt.Errorf("transient cgroup name %q must not contain `/`", name)
 	}
-	if name == "." || name == ".." || strings.Contains(name, "..") {
-		return fmt.Errorf("transient cgroup name %q must not contain `..` or `.`", name)
+	// `..` anywhere allows directory traversal; `.` as the whole name
+	// would land on the parent itself. `name == ".."` is already
+	// covered by the Contains check below, so we don't list it twice.
+	if name == "." || strings.Contains(name, "..") {
+		return fmt.Errorf("transient cgroup name %q must not be `.` and must not contain `..`", name)
 	}
 	return nil
 }

--- a/pkg/cgroups/cgroup_linux_test.go
+++ b/pkg/cgroups/cgroup_linux_test.go
@@ -1,0 +1,164 @@
+//go:build linux
+
+package cgroups
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCreateTransient_HappyPath exercises mkdir + inode read + cleanup
+// against a t.TempDir() acting as the cgroup root. Real cgroupfs isn't
+// required because the operation is plain mkdir/rmdir at the syscall
+// layer; the inode we get back is just a normal directory inode, which
+// is fine for verifying the contract.
+func TestCreateTransient_HappyPath(t *testing.T) {
+	root := t.TempDir()
+	path, id, cleanup, err := CreateTransient(root, "abc123")
+	if err != nil {
+		t.Fatalf("CreateTransient: %v", err)
+	}
+	if path == "" {
+		t.Error("path is empty")
+	}
+	if id == 0 {
+		t.Error("inode id is zero")
+	}
+	wantPath := filepath.Join(root, KloakSliceName, "abc123")
+	if path != wantPath {
+		t.Errorf("path=%q, want %q", path, wantPath)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected transient dir to exist: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatal("cleanup is nil")
+	}
+	if err := cleanup(); err != nil {
+		t.Errorf("cleanup: %v", err)
+	}
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("transient dir should be gone after cleanup, got: %v", err)
+	}
+	// kloak.slice parent should remain — concurrent invocations share it.
+	if _, err := os.Stat(filepath.Join(root, KloakSliceName)); err != nil {
+		t.Errorf("kloak.slice parent should outlive cleanup: %v", err)
+	}
+}
+
+func TestCreateTransient_CleanupIdempotent(t *testing.T) {
+	root := t.TempDir()
+	_, _, cleanup, err := CreateTransient(root, "idempotent")
+	if err != nil {
+		t.Fatalf("CreateTransient: %v", err)
+	}
+	if err := cleanup(); err != nil {
+		t.Fatalf("first cleanup: %v", err)
+	}
+	// Calling cleanup again must succeed silently — runtime defer
+	// chains often invoke cleanup more than once on the error path.
+	if err := cleanup(); err != nil {
+		t.Errorf("second cleanup should be a no-op, got: %v", err)
+	}
+}
+
+func TestCreateTransient_NonEmptyDirRejected(t *testing.T) {
+	// If the transient cgroup still has files inside (in real life, a
+	// child process whose pid is in cgroup.procs), cleanup must return
+	// an error rather than swallow the failure — the runtime then knows
+	// to kill survivors first.
+	root := t.TempDir()
+	path, _, cleanup, err := CreateTransient(root, "nonempty")
+	if err != nil {
+		t.Fatalf("CreateTransient: %v", err)
+	}
+	// Drop a file in the dir so rmdir fails with ENOTEMPTY.
+	if err := os.WriteFile(filepath.Join(path, "cgroup.procs"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("seed non-empty: %v", err)
+	}
+	if err := cleanup(); err == nil {
+		t.Error("expected error rmdir'ing non-empty cgroup, got nil")
+	}
+}
+
+func TestCreateTransient_DefaultCgroupRoot(t *testing.T) {
+	// Empty cgroupRoot should fall back to DefaultCgroupRoot. We can't
+	// actually mkdir under /sys/fs/cgroup as a non-root test, so just
+	// confirm the call attempts that root (the error message should
+	// quote it).
+	_, _, _, err := CreateTransient("", "x")
+	if err == nil {
+		// If we DO have permission (CI as root, say), at least we
+		// produced something — skip the rest.
+		return
+	}
+	if !strings.Contains(err.Error(), DefaultCgroupRoot) {
+		t.Errorf("error should reference default root %q, got: %v", DefaultCgroupRoot, err)
+	}
+}
+
+func TestCreateTransient_NameValidation(t *testing.T) {
+	cases := []struct {
+		name, wantSub string
+	}{
+		{"", "must not be empty"},
+		{"with/slash", "must not contain `/`"},
+		{"..", "must not contain"},
+		{".", "must not contain"},
+		{"trailing/..", "must not contain `/`"},
+		{"sneaky..name", "must not contain"},
+	}
+	root := t.TempDir()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := CreateTransient(root, tc.name)
+			if err == nil {
+				t.Fatalf("expected error containing %q for name %q, got nil", tc.wantSub, tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error %q does not contain %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestCreateTransient_DuplicateNameRejected(t *testing.T) {
+	root := t.TempDir()
+	if _, _, _, err := CreateTransient(root, "dup"); err != nil {
+		t.Fatalf("first CreateTransient: %v", err)
+	}
+	_, _, _, err := CreateTransient(root, "dup")
+	if err == nil {
+		t.Fatal("expected error on duplicate name, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("error should mention `already exists`, got: %v", err)
+	}
+}
+
+func TestCreateTransient_ReadOnlyParent(t *testing.T) {
+	// When the cgroupfs (or our test stand-in) is mounted read-only,
+	// MkdirAll on the kloak.slice parent must fail with an actionable
+	// error. We approximate this by chmod'ing the test root to 0500
+	// (read+execute, no write). Running as root would bypass that
+	// permission check, so skip when we are uid 0.
+	if os.Geteuid() == 0 {
+		t.Skip("running as root bypasses directory permission bits")
+	}
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o500); err != nil {
+		t.Fatalf("chmod root: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(root, 0o700) })
+
+	_, _, _, err := CreateTransient(root, "ro")
+	if err == nil {
+		t.Fatal("expected error against read-only parent, got nil")
+	}
+	if !strings.Contains(err.Error(), "cgroupfs writable?") {
+		t.Errorf("error should hint at cgroupfs writability, got: %v", err)
+	}
+}

--- a/pkg/cgroups/cgroup_linux_test.go
+++ b/pkg/cgroups/cgroup_linux_test.go
@@ -85,14 +85,19 @@ func TestCreateTransient_NonEmptyDirRejected(t *testing.T) {
 }
 
 func TestCreateTransient_DefaultCgroupRoot(t *testing.T) {
-	// Empty cgroupRoot should fall back to DefaultCgroupRoot. We can't
-	// actually mkdir under /sys/fs/cgroup as a non-root test, so just
-	// confirm the call attempts that root (the error message should
-	// quote it).
-	_, _, _, err := CreateTransient("", "x")
+	// Empty cgroupRoot should fall back to DefaultCgroupRoot. As a
+	// non-root test we usually can't mkdir under /sys/fs/cgroup, so we
+	// confirm the call attempts that root by checking the error
+	// message. When the test DOES have permission (CI as root), the
+	// call succeeds — we must call cleanup() before returning or we
+	// leak `/sys/fs/cgroup/kloak.slice/<name>` on the host.
+	_, _, cleanup, err := CreateTransient("", "kloak-test-default-root")
 	if err == nil {
-		// If we DO have permission (CI as root, say), at least we
-		// produced something — skip the rest.
+		if cleanup != nil {
+			if cerr := cleanup(); cerr != nil {
+				t.Errorf("cleanup of root-created dir failed: %v", cerr)
+			}
+		}
 		return
 	}
 	if !strings.Contains(err.Error(), DefaultCgroupRoot) {

--- a/pkg/cgroups/cgroup_other.go
+++ b/pkg/cgroups/cgroup_other.go
@@ -6,7 +6,20 @@ import (
 	"fmt"
 )
 
+// KloakSliceName is exported on every OS so callers can reference the
+// constant in shared code; only the Linux implementation actually
+// creates the directory.
+const KloakSliceName = "kloak.slice"
+
 // GetCgroupInodeFromPath returns a placeholder inode on non-Linux systems.
-func GetCgroupInodeFromPath(path string) (uint64, error) {
+func GetCgroupInodeFromPath(_ string) (uint64, error) {
 	return 0, fmt.Errorf("cgroups not supported on this OS")
+}
+
+// CreateTransient is a non-Linux stub. Mirrors uprobe_other.go's
+// pattern from PR #217: signature matches the real implementation so
+// the rest of the codebase compiles on macOS for unit testing, and
+// every method returns an actionable "not supported" error.
+func CreateTransient(_, _ string) (string, uint64, func() error, error) {
+	return "", 0, nil, fmt.Errorf("cgroups not supported on this OS")
 }


### PR DESCRIPTION
## Summary

First building block for the \`kloak run\` host-cgroup runtime. A generic cgroup mkdir/rmdir primitive that the upcoming \`pkg/runtime/host\` backend (PR-B, was Phase 4) will call to provision a transient cgroup per invocation. The same function runs unchanged inside the libkrun guest in Phase 5.

This is deliberately a **primitive**, not a runtime entry point — its signature has zero runtime concepts in it, so it doesn't lock anything in about the \`Runtime\` interface that's coming next.

## What it does

- mkdir \`<cgroupRoot>/kloak.slice/<name>\` as a fresh directory
- create the \`kloak.slice\` parent on demand (\`MkdirAll\`); concurrent invocations share it, Phase 4 will add the startup sweep for orphans
- return \`(path, inode_id, cleanup, err)\` so \`TLSUprobeManager.TrackCgroup\` (which needs both path and inode) gets everything without an extra \`Stat\`
- \`cleanup()\` is idempotent: a second call after the dir is gone returns nil. Errors only when \`cgroup.procs\` is non-empty (caller didn't reap children)
- reject malicious names (\`empty\`, \`/\`, \`..\`) before touching the filesystem
- wrap mkdir errors with the candidate path + a writable-fs hint so operators on read-only / permission-restricted hosts know what to fix

## Files

| File | Change |
|---|---|
| \`pkg/cgroups/cgroup_linux.go\` | new \`CreateTransient\`, \`KloakSliceName\` const, \`validateTransientName\`, \`makeTransientCleanup\` |
| \`pkg/cgroups/cgroup_other.go\` | non-Linux stub matching PR #217's \`uprobe_other.go\` pattern |
| \`pkg/cgroups/cgroup_linux_test.go\` | new — 8 test cases |

## Test plan

- [x] Happy path: create → verify path/inode/dir-exists → cleanup → verify gone, parent slice stays
- [x] Cleanup idempotent (second call returns nil)
- [x] Non-empty dir → cleanup returns error (the "child still alive" signal)
- [x] Empty / \`/\` / \`..\` / \`.\` names → reject with actionable message (6 sub-cases)
- [x] Duplicate name → reject with \"already exists\"
- [x] Read-only parent → reject with \"cgroupfs writable?\" hint (skipped when running as root)
- [x] Default cgroupRoot fallback when empty string passed
- [x] \`go build ./...\` and \`GOOS=linux go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`gofmt\` clean

Real cgroupfs isn't required for any of the tests; the operation is plain mkdir/rmdir under \`t.TempDir()\`.

## Next

**PR-B** (in flight): \`pkg/runtime/Runtime\` interface + \`pkg/runtime/host/\` implementation that calls \`CreateTransient\` from its \`Run(ctx, spec)\` method. \`cmd/kloak/run.go\` becomes ~20 LOC that constructs the runtime and dispatches.

This collapses old Phase 3b+3c+3d (separate sub-PRs) and Phase 4 (lift-and-shift) into one cohesive landing — the interface is shaped by an actual consumer, not designed in the abstract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)