### PR TITLE
fix(ebpf): per-binary wbio offset — OpenSSL 3.0/3.1 silently broke on hardcoded 88

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -560,6 +560,13 @@ struct tls_offsets {
   __u32 enc_ctx_to_algctx;  // enc_ctx* + off → algctx/PROV_GCM_CTX* (pointer deref)
   __u32 algctx_to_h;        // algctx* + off → H (16 bytes, direct read)
   __u32 ssl_to_version;     // SSL_CONNECTION* + off → int version (0xFFFFFFFF=unknown)
+  // ssl_to_wbio is the offset from the SSL/SSL_CONNECTION pointer to its
+  // `wbio` BIO* field. Used by ssl_read_fd() to walk SSL → wbio → BIO.num
+  // (the socket fd). 3.0/3.1 use struct ssl_st where wbio lives at 24;
+  // 3.2+ wrapped SSL in ssl_connection_st and moved wbio to 88. Pushed by
+  // pushTLSOffsets per detected OpenSSL major.minor — 0 here means
+  // "unknown; ssl_read_fd should fall back to the legacy hardcoded 88".
+  __u32 ssl_to_wbio;
 };
 
 // Shared key for per-binary TLS config maps (see tls_offset_config and
@@ -1335,18 +1342,44 @@ int tp_enter_close(struct trace_event_raw_sys_enter *ctx) {
   return 0;
 }
 
-// Offsets for reading fd from SSL struct's BIO (stable across OpenSSL 3.x).
-// SSL_CONNECTION.wbio → BIO*, BIO.num → int fd
-// Verified via pahole: identical on aarch64 and x86_64, OpenSSL 3.0-3.5.
-#define SSL_WBIO_OFFSET 88  // offsetof(ssl_connection_st, wbio) for 3.2+
-#define BIO_NUM_OFFSET  56  // offsetof(bio_st, num)
+// Fallback wbio offset used only when tls_offset_config has no entry for
+// the current binary yet (cold path very early in a process's lifetime,
+// before pushTLSOffsets has run). Matches OpenSSL 3.2+ ssl_connection_st.
+// 3.0/3.1 resolve their own (smaller) wbio offset at runtime — keeping
+// the fallback at 88 preserves the pre-fix behavior for callers that
+// happen to be on 3.2+ but raced the userspace push.
+#define SSL_WBIO_OFFSET_FALLBACK 88
+// offsetof(bio_st, num). Confirmed identical on OpenSSL 3.0.13 and 3.5
+// via pahole + empirical SSL_set_bio + pointer-scan; the bio_st layout
+// hasn't been reshuffled across 3.x. If a future release does move
+// `num`, lift this into tls_offsets the same way ssl_to_wbio is now.
+#define BIO_NUM_OFFSET  56
+
+// resolve_wbio_offset returns the SSL → wbio field offset for the
+// calling process's libssl, derived from the per-binary tls_offset_config
+// pushed by pushTLSOffsets. Falls back to the hardcoded 3.2+ value if
+// the map has no entry yet (race with userspace push) so existing 3.2+
+// workloads keep working even on the cold path.
+static __always_inline __u32 resolve_wbio_offset(void) {
+  struct tls_binary_key bk = {};
+  bk.cgroup_id = bpf_get_current_cgroup_id();
+  struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+  bk.exe_inode = BPF_CORE_READ(task, mm, exe_file, f_inode, i_ino);
+  struct tls_offsets *off = bpf_map_lookup_elem(&tls_offset_config, &bk);
+  if (off && off->ssl_to_wbio != 0) return off->ssl_to_wbio;
+  bk.exe_inode = 0;
+  off = bpf_map_lookup_elem(&tls_offset_config, &bk);
+  if (off && off->ssl_to_wbio != 0) return off->ssl_to_wbio;
+  return SSL_WBIO_OFFSET_FALLBACK;
+}
 
 // Read the socket fd directly from the SSL struct's write BIO.
 // Returns the fd, or 0 if the read fails.
 static __always_inline __u32 ssl_read_fd(__u64 ssl_ptr) {
   if (!ssl_ptr) return 0;
+  __u32 wbio_off = resolve_wbio_offset();
   __u64 wbio = 0;
-  if (bpf_probe_read_user(&wbio, 8, (void *)(ssl_ptr + SSL_WBIO_OFFSET)) < 0 || !wbio)
+  if (bpf_probe_read_user(&wbio, 8, (void *)(ssl_ptr + wbio_off)) < 0 || !wbio)
     return 0;
   __u32 fd = 0;
   if (bpf_probe_read_user(&fd, 4, (void *)(wbio + BIO_NUM_OFFSET)) < 0)

--- a/pkg/ebpf/openssl_offsets.go
+++ b/pkg/ebpf/openssl_offsets.go
@@ -29,6 +29,15 @@ type TLSOffsets struct {
 	EncCtxToAlgctx uint32 // enc_ctx* + off → algctx/PROV_GCM_CTX* (pointer deref)
 	AlgctxToH      uint32 // algctx* + off → H (16 bytes, direct read)
 	SSLToVersion   uint32 // SSL_CONNECTION* + off → int version (0xFFFFFFFF=unknown, use heuristic)
+	// SSLToWBIO is the offset from the SSL/SSL_CONNECTION pointer to its
+	// `wbio` BIO* field. The BPF data plane reads SSL → wbio → BIO.num to
+	// recover the socket fd, then looks it up in conn_ip_map to confirm
+	// client-mode (set by connect()). 3.0/3.1 use struct ssl_st where
+	// wbio sits at 24; 3.2+ wrapped SSL in ssl_connection_st and moved it
+	// to 88. Before this field existed, the BPF program hardcoded 88 —
+	// which silently broke every 3.0/3.1 workload by reading garbage and
+	// tripping the server-mode guard in bpf_uprobe_ssl_write.
+	SSLToWBIO uint32
 }
 
 // opensslOffsetTable maps OpenSSL major.minor version strings to their TLS
@@ -53,21 +62,29 @@ var opensslOffsetTable = map[string]TLSOffsets{
 	// 3-hop chain (3.0-3.1): SSL.enc_write_ctx → algctx → gcm.H
 	//   SSLToWRL stores enc_write_ctx offset; WRLToEncCtx=0 signals 3-hop to BPF.
 
+	// SSLToWBIO is the SSL → wbio field offset (used by ssl_read_fd in the
+	// BPF data plane). 3.0/3.1 use struct ssl_st where wbio = 24 (verified
+	// empirically on OpenSSL 3.0.13 via SSL_set_bio + pointer scan: rbio
+	// at 16, wbio at 24). 3.2+ wrapped SSL inside ssl_connection_st and
+	// moved wbio to 88. Before this field was added, the BPF program
+	// hardcoded 88 — which silently broke every 3.0/3.1 caller.
+
 	// OpenSSL 3.5.x — SSLToWRL grew due to new fields in SSL_CONNECTION.
 	// SSLToVersion=72: ssl_connection_st.version (after 64-byte embedded ssl_st).
-	"3.5": {SSLToWRL: 3208, WRLToEncCtx: 4128, EncCtxToAlgctx: 176, AlgctxToH: 328, SSLToVersion: 72},
+	"3.5": {SSLToWRL: 3208, WRLToEncCtx: 4128, EncCtxToAlgctx: 176, AlgctxToH: 328, SSLToVersion: 72, SSLToWBIO: 88},
 
 	// OpenSSL 3.2.x–3.4.x — identical offsets across these versions.
 	// TODO: verify SSLToVersion for 3.2-3.4 via pahole (likely 72, same as 3.5).
-	"3.4": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF},
-	"3.3": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF},
-	"3.2": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF},
+	"3.4": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF, SSLToWBIO: 88},
+	"3.3": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF, SSLToWBIO: 88},
+	"3.2": {SSLToWRL: 3056, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0xFFFFFFFF, SSLToWBIO: 88},
 
 	// OpenSSL 3.0.x–3.1.x — 3-hop chain (no record layer indirection).
 	// SSLToWRL stores enc_write_ctx=2168; WRLToEncCtx=0 signals 3-hop to BPF.
 	// SSLToVersion=0: ssl_st.version is at offset 0 (verified via pahole on Debian bookworm).
-	"3.1": {SSLToWRL: 2168, WRLToEncCtx: 0, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0},
-	"3.0": {SSLToWRL: 2168, WRLToEncCtx: 0, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0},
+	// SSLToWBIO=24: empirically confirmed on Ubuntu 24.04's libssl3 (3.0.13).
+	"3.1": {SSLToWRL: 2168, WRLToEncCtx: 0, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0, SSLToWBIO: 24},
+	"3.0": {SSLToWRL: 2168, WRLToEncCtx: 0, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 0, SSLToWBIO: 24},
 }
 
 // DetectOpenSSLVersion reads an OpenSSL/libssl shared library from a

--- a/pkg/ebpf/openssl_offsets_test.go
+++ b/pkg/ebpf/openssl_offsets_test.go
@@ -20,6 +20,49 @@ func TestExtractMajorMinor(t *testing.T) {
 	}
 }
 
+func TestOpensslOffsetTable_SSLToWBIO(t *testing.T) {
+	// Every entry in the table must carry a non-zero SSLToWBIO — a zero
+	// is the BPF data plane's sentinel for "fall back to the hardcoded
+	// 88", which silently regresses 3.0/3.1 callers. The specific values
+	// here were verified empirically (3.0.13: SSL_set_bio + pointer scan
+	// returned wbio at offset 24; 3.2+: ssl_connection_st.wbio = 88) and
+	// must not drift without re-verification.
+	cases := []struct {
+		majMin string
+		want   uint32
+	}{
+		// 3-hop chain — bare ssl_st, wbio is the second BIO field after rbio.
+		{"3.0", 24},
+		{"3.1", 24},
+		// 4-hop chain — ssl_connection_st wrapper relocated wbio to 88.
+		{"3.2", 88},
+		{"3.3", 88},
+		{"3.4", 88},
+		{"3.5", 88},
+	}
+	for _, c := range cases {
+		got, ok := opensslOffsetTable[c.majMin]
+		if !ok {
+			t.Fatalf("opensslOffsetTable missing %q", c.majMin)
+		}
+		if got.SSLToWBIO != c.want {
+			t.Errorf("opensslOffsetTable[%q].SSLToWBIO = %d, want %d "+
+				"(if this is intentional, update the test and confirm via pahole or "+
+				"SSL_set_bio + pointer scan against a real libssl of this version)",
+				c.majMin, got.SSLToWBIO, c.want)
+		}
+	}
+
+	// Defensive: any future entry added to the table must also include a
+	// non-zero SSLToWBIO. A zero would trip the BPF fallback to 88 and
+	// silently break workloads on that version.
+	for k, v := range opensslOffsetTable {
+		if v.SSLToWBIO == 0 {
+			t.Errorf("opensslOffsetTable[%q] has SSLToWBIO=0 — verify and set explicitly", k)
+		}
+	}
+}
+
 func TestFindVersionInData(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -850,13 +850,15 @@ func (m *TLSUprobeManager) pushTLSOffsets(pid int, cgroupID uint64, containerLib
 			continue
 		}
 
-		// Must match struct tls_offsets in tls_uprobe.c.
+		// Must match struct tls_offsets in tls_uprobe.c. Field order is
+		// load-bearing — the BPF program reads this struct by offset.
 		type bpfTLSOffsets struct {
 			SSLToWRL       uint32
 			WRLToEncCtx    uint32
 			EncCtxToAlgctx uint32
 			AlgctxToH      uint32
 			SSLToVersion   uint32
+			SSLToWBIO      uint32
 		}
 		val := bpfTLSOffsets(offsets)
 		key := tlsuprobeTlsBinaryKey{CgroupId: cgroupID, ExeInode: exeInode}


### PR DESCRIPTION
## Summary

`ssl_read_fd` in the BPF data plane reads `SSL → wbio → BIO.num` to recover the socket fd, then looks it up in `conn_ip_map` to confirm a client-mode connection set by `connect()`. The wbio offset was hardcoded to **88**, which matches `ssl_connection_st.wbio` on OpenSSL **3.2+** but is wrong on **3.0/3.1** where bare `struct ssl_st` puts wbio at **24**.

This silently broke every 3.0/3.1 caller (Ubuntu 22.04 / 24.04 stock libssl3, Debian bookworm, RHEL 9.x) — `bpf_uprobe_ssl_write` reads garbage, the conn_ip_map miss trips the server-mode skip, the uprobe returns `0` before writing to `xor_pending`, `tcp_sendmsg` finds nothing to bridge, and the rewrite never fires. No error log; only the `kprobe_bridge_no_entry` counter ticks up.

## How it was diagnosed

Found while exercising `klor` on Ubuntu 24.04 (curl + OpenSSL 3.0.13). Counter dump from a real run:

```
kprobe_entry       10    (DNS observed)
tc_entry           226   (curl's packets reach tc egress)
kprobe_bridge_no_entry 253   (xor_pending always empty)
xor_path_entered   0     (SSL_write uprobe bailed every time)
```

Empirically confirmed wbio offset on 3.0.13 via `SSL_set_bio` + pointer scan: `rbio` at **16**, `wbio` at **24**.

## Fix

Lift the wbio offset out of the C `#define` and into the per-binary `tls_offset_config` map, pushed at `AttachTLS` time alongside the existing SSL→WRL/EncCtx/Algctx/H chain. `ssl_read_fd` reads it via a new `resolve_wbio_offset()` helper that walks `current task → mm → exe_file → i_ino` (matching the existing pattern in `bpf_uretprobe_evp_cipher_init`) and **falls back to the historical 88** when the map has no entry yet — so the cold path on 3.2+ keeps behaving exactly like before this PR.

Per-version table:
- 3.0, 3.1: `SSLToWBIO=24` (verified)
- 3.2, 3.3, 3.4, 3.5: `SSLToWBIO=88` (preserved)

## Test plan

- [x] `TestOpensslOffsetTable_SSLToWBIO` covers the table values and rejects any future entry with `SSLToWBIO=0` (which would silently regress to the fallback).
- [x] `go test ./...` green on Linux (Lima VM).
- [x] `golangci-lint` clean.
- [ ] Manual end-to-end: rebuild + curl-against-httpbin from a klor invocation on Ubuntu 24.04 (libssl 3.0.13) — should now show the real value in the echoed POST body instead of the shadow placeholder. Will verify after this lands and `feat/runtime-host-ebpf` rebases.
- [ ] Existing e2e suite (`make e2e-run`) — covers 3.2+ workloads via the demo containers; should remain green since the fallback preserves their behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)