### PR TITLE
fix(ebpf): //go:generate strips ${KLOAK_TARGET_ARCH:-arm64}, dead-stripping every uprobe's arch-specific code

### DIFF
--- a/pkg/ebpf/generate.sh
+++ b/pkg/ebpf/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Wrapper around `bpf2go` invoked from this package's //go:generate directive.
 #
 # Why a script instead of inlining the bpf2go command in //go:generate:

--- a/pkg/ebpf/generate.sh
+++ b/pkg/ebpf/generate.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Wrapper around `bpf2go` invoked from this package's //go:generate directive.
+#
+# Why a script instead of inlining the bpf2go command in //go:generate:
+# Go's variable substitution for //go:generate directives matches `${VAR...}`
+# greedily and does NOT understand the shell `${VAR:-default}` form — it
+# replaces the whole `${KLOAK_TARGET_ARCH:-arm64}` token with empty, then sh
+# only sees an empty `ARCH=` assignment. Result: clang gets `-D__TARGET_ARCH_`
+# (suffix missing), so neither `bpf_target_x86` nor `bpf_target_arm64` ends up
+# defined and the SSL_write / Go-TLS / EVP_CipherInit uprobes' arch-specific
+# register-read blocks silently dead-strip to a `return 0`. Empirically: kloak's
+# data plane on every aarch64 dev build (and any path that hit this directive
+# without the env var explicitly set) was bailing at uprobe entry, never
+# reaching the prescan / xor path. CI worked-by-accident because it set the
+# env var explicitly but Go still mangled the cflags string.
+#
+# A wrapper script bypasses Go's directive substitution entirely: sh runs the
+# command with full shell semantics, including `${KLOAK_TARGET_ARCH:-arm64}`.
+set -euo pipefail
+
+# Default to arm64 to match macOS / Apple Silicon dev environments. CI sets
+# this to x86 explicitly. Any new arch goes here.
+ARCH="${KLOAK_TARGET_ARCH:-arm64}"
+case "$ARCH" in
+    x86|arm64) ;;
+    *)
+        echo "generate.sh: unsupported KLOAK_TARGET_ARCH=$ARCH (expected x86 or arm64)" >&2
+        exit 1
+        ;;
+esac
+
+# -tags linux constrains the generated _bpfel.go / _bpfeb.go to linux builds
+# so macOS unit tests still compile (cilium/ebpf is Linux-only). See PR #217.
+exec go run github.com/cilium/ebpf/cmd/bpf2go \
+    -cc clang \
+    -cflags "-O2 -g -Wall -Werror -D__TARGET_ARCH_${ARCH}" \
+    -tags linux \
+    tlsuprobe \
+    bpf/tls_uprobe.c -- -I../ebpf

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -80,7 +80,12 @@ type watchedHostKey struct {
 // understand the shell `:-default` form, drops the whole token to empty),
 // which silently dead-strips the arch-specific register-read code in every
 // uprobe. See generate.sh for the full story.
-//go:generate ./generate.sh
+//
+// `bash ./generate.sh` (rather than just `./generate.sh`) avoids depending
+// on the file mode bit surviving every clone / tarball / CI checkout — some
+// fetch paths drop the executable bit and we'd get "permission denied" with
+// no obvious cause.
+//go:generate bash ./generate.sh
 
 // TLSUprobeManager manages the loading and attaching of eBPF uprobes for TLS interception.
 type TLSUprobeManager struct {

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -71,15 +71,16 @@ type watchedHostKey struct {
 	Host [64]byte
 }
 
-// Generate eBPF bindings. The KLOAK_TARGET_ARCH env var (set by Dockerfile or
-// Makefile) controls which __TARGET_ARCH_xxx define is passed to clang.
-// Defaults to arm64 for local development on macOS/Lima.
+// Generate eBPF bindings. KLOAK_TARGET_ARCH (set by the Makefile or by CI)
+// selects the `__TARGET_ARCH_xxx` define handed to clang. Defaults to arm64
+// for local development on macOS/Lima.
 //
-// `-tags linux` makes bpf2go emit `//go:build linux && (<arches>)` on the
-// generated `tlsuprobe_bpfel.go` / `tlsuprobe_bpfeb.go` files. Without it
-// the generated files build on every OS and break macOS compilation
-// because cilium/ebpf is Linux-only.
-//go:generate sh -c "ARCH=${KLOAK_TARGET_ARCH:-arm64}; go run github.com/cilium/ebpf/cmd/bpf2go -cc clang -cflags \"-O2 -g -Wall -Werror -D__TARGET_ARCH_${ARCH}\" -tags linux tlsuprobe bpf/tls_uprobe.c -- -I../ebpf"
+// The actual command runs out of `generate.sh` rather than inline here — Go's
+// directive substitution mangles `${VAR:-default}` (matches greedily, doesn't
+// understand the shell `:-default` form, drops the whole token to empty),
+// which silently dead-strips the arch-specific register-read code in every
+// uprobe. See generate.sh for the full story.
+//go:generate ./generate.sh
 
 // TLSUprobeManager manages the loading and attaching of eBPF uprobes for TLS interception.
 type TLSUprobeManager struct {


### PR DESCRIPTION
## Summary

Go's `//go:generate` directive substitution matches `${VAR...}` greedily and **doesn't understand the shell `${VAR:-default}` form** — it drops the entire `${KLOAK_TARGET_ARCH:-arm64}` token to empty. With `KLOAK_TARGET_ARCH` unset, the inner `sh -c` saw `ARCH=;` and clang was invoked with `-D__TARGET_ARCH_` (no suffix).

Neither `bpf_target_x86` nor `bpf_target_arm64` ever got defined, so every uprobe's arch-specific `bpf_probe_read_kernel` block fell into `#else return 0;` and clang dead-stripped everything downstream of the cgroup filter — register reads, `ssl_read_fd`, the server-mode bail, the prescan, the xor tail call, all gone.

## How it was diagnosed

Found while debugging `klor` end-to-end (`curl --data-binary @/tmp/kloak/gcp-credentials.json https://httpbin.org/anything` returning the shadow placeholder instead of the real value). Counter trace showed:

```
ssl_write_entry        8     ← uprobe IS firing
ssl_write_cgroup_pass  0/12  ← but bailing immediately (no reg-read, no bio_fd check, nothing)
```

`llvm-objdump` confirmed: `bpf_uprobe_ssl_write` compiled to **53 instructions** (cgroup check + early return). After this fix: **1718 instructions** — full pipeline restored.

## Why CI is masked

Every workflow already sets `KLOAK_TARGET_ARCH=x86` explicitly, but Go still substituted the directive's `${KLOAK_TARGET_ARCH:-arm64}` to empty regardless. CI gets the same broken `-D__TARGET_ARCH_` flag. e2e likely passes because:

- Go TLS path's own arch detection falls back to clang's built-in `__aarch64__` / `__x86_64__` macros for some sub-flows
- OR the e2e suite doesn't actually exercise the SSL_write rewrite end-to-end against an OpenSSL/libssl workload

A separate audit of what the e2e suite actually rewrites would be valuable — it likely uncovered other latent gaps along with this one.

## Fix

Move the `bpf2go` invocation into `pkg/ebpf/generate.sh`. A wrapper script bypasses Go's directive substitution entirely; the shell handles `${KLOAK_TARGET_ARCH:-arm64}` natively. The script also validates the arch (rejects anything other than `x86`/`arm64`) so a typo fails loudly instead of silently building a broken data plane.

## Test plan

- [x] Default (`KLOAK_TARGET_ARCH` unset) → arm64 build, `ssl_write` section 1718 instructions
- [x] `KLOAK_TARGET_ARCH=x86` → x86 build, full pipeline present
- [x] `KLOAK_TARGET_ARCH=mips` → `generate.sh: unsupported KLOAK_TARGET_ARCH=mips (expected x86 or arm64)`, exit 1
- [x] `pkg/ebpf` tests + lint clean
- [x] End-to-end: klor + curl + httpbin → response body contains the *real* value (`example-gcp-json-blob-please-replace`), not the shadow placeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)