### PR TITLE
ci(nightly): keep auto-version PRs clean (no scratch files, descending table)

### DIFF
--- a/.github/workflows/openssl-versions-nightly.yml
+++ b/.github/workflows/openssl-versions-nightly.yml
@@ -394,6 +394,16 @@ jobs:
           # PR edits .github/workflows/openssl-offsets.yml, which the default
           # GITHUB_TOKEN is forbidden from pushing.
           token: ${{ secrets.AUTOMATION_PAT }}
+          # Only commit the intended artifacts. The "Find new minor versions"
+          # step writes scratch files (upstream-latest.txt, tracked-minors.txt,
+          # new-versions.txt) to the repo root; without this, create-pull-request
+          # sweeps them into the PR. tracked-minors.txt in particular is derived
+          # at runtime from the results/*.json filenames, so it must never be
+          # committed.
+          add-paths: |
+            tools/openssl-offsets/results
+            pkg/ebpf/openssl_offsets.go
+            .github/workflows/openssl-offsets.yml
           commit-message: "chore(openssl): add offset support for OpenSSL ${{ steps.find.outputs.new }}"
           branch: auto/openssl-versions/${{ steps.find.outputs.new }}
           delete-branch: true

--- a/tools/openssl-offsets/apply-new-versions.sh
+++ b/tools/openssl-offsets/apply-new-versions.sh
@@ -7,7 +7,7 @@
 #
 # Reads tools/openssl-offsets/results/openssl-<v>-amd64.json (must exist)
 # and updates:
-#   - pkg/ebpf/openssl_offsets.go         (appends to opensslOffsetTable)
+#   - pkg/ebpf/openssl_offsets.go         (inserts into opensslOffsetTable, newest-first)
 #   - .github/workflows/openssl-offsets.yml  (appends to matrix.openssl)
 #
 # Note: openssl-versions-nightly.yml is NOT updated here — its discover/e2e
@@ -27,7 +27,15 @@ fi
 
 cd "$(dirname "$0")/../.."
 
-IFS=',' read -r -a NEW_VERSIONS <<<"$1"
+IFS=',' read -r -a _RAW_VERSIONS <<<"$1"
+# Process oldest-first: each entry is inserted at the top of the table (above the
+# current newest), so the final order ends up newest-first (descending), matching
+# the table's hand-curated convention. Portable numeric sort (no bash mapfile /
+# GNU `sort -V`, so this also works on the BSD tools shipped on macOS).
+NEW_VERSIONS=()
+while IFS= read -r _v; do
+  [ -n "$_v" ] && NEW_VERSIONS+=("$_v")
+done < <(printf '%s\n' "${_RAW_VERSIONS[@]}" | sort -t. -k1,1n -k2,2n -k3,3n)
 
 OFFSETS_GO="pkg/ebpf/openssl_offsets.go"
 DISCOVERY_YML=".github/workflows/openssl-offsets.yml"
@@ -64,10 +72,14 @@ for v in "${NEW_VERSIONS[@]}"; do
     entry=$(printf '\t"%s": {SSLToWRL: %s, WRLToEncCtx: %s, EncCtxToAlgctx: %s, AlgctxToH: %s, SSLToVersion: %s, SSLToWBIO: %s},' \
       "$major_minor" "$ssl_to_wrl" "$wrl_to_enc" "$enc_to_algctx" "$algctx_to_h" "$ssl_to_ver" "$ssl_to_wbio")
 
-    # Insert immediately before the closing `}` of opensslOffsetTable.
+    # Insert before the first existing entry so new (newer) versions land at the
+    # top of the table, keeping it in descending version order. The leading doc
+    # comments stay above the entries. Falls back to before the closing `}` if
+    # the table somehow has no entries yet.
     awk -v new="$entry" '
       /^var opensslOffsetTable = map\[string\]TLSOffsets\{/ { in_map=1; print; next }
-      in_map && /^\}$/ { print new; print; in_map=0; next }
+      in_map && !done && /^[[:space:]]*"[0-9]+\.[0-9]+":[[:space:]]*\{/ { print new; done=1 }
+      in_map && /^\}$/ { if (!done) { print new; done=1 } in_map=0 }
       { print }
     ' "$OFFSETS_GO" > "$OFFSETS_GO.tmp"
     mv "$OFFSETS_GO.tmp" "$OFFSETS_GO"

--- a/tools/openssl-offsets/apply-new-versions.sh
+++ b/tools/openssl-offsets/apply-new-versions.sh
@@ -73,13 +73,27 @@ for v in "${NEW_VERSIONS[@]}"; do
       "$major_minor" "$ssl_to_wrl" "$wrl_to_enc" "$enc_to_algctx" "$algctx_to_h" "$ssl_to_ver" "$ssl_to_wbio")
 
     # Insert before the first existing entry so new (newer) versions land at the
-    # top of the table, keeping it in descending version order. The leading doc
-    # comments stay above the entries. Falls back to before the closing `}` if
-    # the table somehow has no entries yet.
+    # top of the table, keeping it in descending version order.
+    #
+    # Comments need care: the leading *general* doc comments (separated from the
+    # entries by blank lines) must stay at the top, but a *version-specific*
+    # comment block sitting immediately above the first entry (e.g.
+    # "// OpenSSL 3.5.x — …") documents that entry and must move down with it,
+    # below the newly inserted line. So we buffer comment lines, flush them in
+    # place at each blank line (general blocks), and emit whatever remains
+    # buffered *after* the new entry (the version-specific block). Falls back to
+    # before the closing `}` if the table somehow has no entries yet.
     awk -v new="$entry" '
       /^var opensslOffsetTable = map\[string\]TLSOffsets\{/ { in_map=1; print; next }
-      in_map && !done && /^[[:space:]]*"[0-9]+\.[0-9]+":[[:space:]]*\{/ { print new; done=1 }
-      in_map && /^\}$/ { if (!done) { print new; done=1 } in_map=0 }
+      in_map && !done && /^[[:space:]]*\/\// { comment_buf = comment_buf $0 "\n"; next }
+      in_map && !done && /^[[:space:]]*$/ { printf "%s%s\n", comment_buf, $0; comment_buf=""; next }
+      in_map && !done && /^[[:space:]]*"[0-9]+\.[0-9]+":[[:space:]]*\{/ {
+        print new; printf "%s", comment_buf; comment_buf=""; done=1
+      }
+      in_map && /^\}$/ {
+        if (!done) { printf "%s", comment_buf; comment_buf=""; print new; done=1 }
+        in_map=0
+      }
       { print }
     ' "$OFFSETS_GO" > "$OFFSETS_GO.tmp"
     mv "$OFFSETS_GO.tmp" "$OFFSETS_GO"


### PR DESCRIPTION
## Why

The first successful auto-generated version PR — **#253** (OpenSSL 3.6.3 + 4.0.1, opened once `AUTOMATION_PAT` was in place) — surfaced two defects in the PR-generation automation. Review on #253 flagged both:

1. **Scratch files leaked into the PR** (`tracked-minors.txt`, `upstream-latest.txt`, `new-versions.txt`). The `detect-new-version` job writes these to the repo root, and `create-pull-request` swept them into the commit. `tracked-minors.txt` is especially wrong to commit — it's *derived at runtime* from the `results/*.json` filenames, not a source of truth (the reviewer even mistook it for a config to hand-edit).
2. **New `opensslOffsetTable` entries were appended at the bottom**, breaking the table's descending version order (3.6/4.0 landed below 3.0).

## Fix

- **`add-paths` on the Open-PR step** — only commit the intended artifacts (`results/` JSONs, `openssl_offsets.go`, `openssl-offsets.yml`). Scratch files are no longer committed.
- **`apply-new-versions.sh` inserts before the first existing entry** (below the doc comments) instead of before the closing `}`, and processes versions oldest-first so multiple new versions also end up newest-first. Also replaced the bash-4 `mapfile` / GNU `sort -V` with a portable read-loop + numeric `sort -t.` so the script runs under macOS's BSD tooling too.

## Verification (local, `apply-new-versions.sh "3.6.3,4.0.1"`)

Table key order becomes:
```
4.0, 3.6, 3.5, 3.4, 3.3, 3.2, 3.1, 3.0   # descending, new entries below the doc comments
```
`bash -n` and YAML both validate. (The 3.6/4.0 data itself is **not** in this PR — this only changes the automation; #253 still carries the actual offsets, and re-running it will now produce a clean, ordered PR.)

## Suggested follow-up
After this merges, closing & reopening #253 (or re-running the nightly's watcher) will regenerate it without the scratch files and with ordered table entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)