### PR TITLE
chore(openssl): add offset support for OpenSSL 3.6.3,4.0.1

### DIFF
--- a/.github/workflows/openssl-offsets.yml
+++ b/.github/workflows/openssl-offsets.yml
@@ -21,6 +21,8 @@ jobs:
           - "3.2.4"
           - "3.1.7"
           - "3.0.16"
+          - "3.6.3"
+          - "4.0.1"
     steps:
       - uses: actions/checkout@v6
 

--- a/pkg/ebpf/openssl_offsets.go
+++ b/pkg/ebpf/openssl_offsets.go
@@ -63,6 +63,8 @@ var opensslOffsetTable = map[string]TLSOffsets{
 	// moved wbio to 88. Before this field was added, the BPF program
 	// hardcoded 88 — which silently broke every 3.0/3.1 caller.
 
+	"4.0": {SSLToWRL: 3648, WRLToEncCtx: 4128, EncCtxToAlgctx: 168, AlgctxToH: 328, SSLToVersion: 72, SSLToWBIO: 88},
+	"3.6": {SSLToWRL: 3216, WRLToEncCtx: 4128, EncCtxToAlgctx: 176, AlgctxToH: 328, SSLToVersion: 72, SSLToWBIO: 88},
 	// OpenSSL 3.5.x — SSLToWRL grew due to new fields in SSL_CONNECTION.
 	// SSLToVersion=72: ssl_connection_st.version (after 64-byte embedded ssl_st).
 	"3.5": {SSLToWRL: 3208, WRLToEncCtx: 4128, EncCtxToAlgctx: 176, AlgctxToH: 328, SSLToVersion: 72, SSLToWBIO: 88},

--- a/tools/openssl-offsets/results/openssl-3.6.3-amd64.json
+++ b/tools/openssl-offsets/results/openssl-3.6.3-amd64.json
@@ -1,0 +1,30 @@
+{
+  "openssl_version": "OpenSSL 3.6.3 9 Jun 2026",
+  "arch": "x86_64",
+  "chain": "4-hop",
+  "offsets": {
+    "ssl_to_wrl": 3216,
+    "ssl_to_enc_write_ctx": null,
+    "wrl_to_enc_ctx": 4128,
+    "enc_ctx_to_algctx": 176,
+    "algctx_to_gcm": 248,
+    "gcm128_h_offset": 80,
+    "algctx_to_h": 328,
+    "ssl_to_version": 72,
+    "ssl_to_wbio": 88
+  },
+  "sizes": {
+    "SSL_CONNECTION": 5568,
+    "EVP_CIPHER_CTX": 192,
+    "GCM128_CONTEXT": 448,
+    "PROV_GCM_CTX": 704
+  },
+  "kloak_config": {
+    "SSLToWRL": 3216,
+    "WRLToEncCtx": 4128,
+    "EncCtxToAlgctx": 176,
+    "AlgctxToH": 328,
+    "SSLToVersion": 72,
+    "SSLToWBIO": 88
+  }
+}

--- a/tools/openssl-offsets/results/openssl-3.6.3-arm64.json
+++ b/tools/openssl-offsets/results/openssl-3.6.3-arm64.json
@@ -1,0 +1,30 @@
+{
+  "openssl_version": "OpenSSL 3.6.3 9 Jun 2026",
+  "arch": "aarch64",
+  "chain": "4-hop",
+  "offsets": {
+    "ssl_to_wrl": 3216,
+    "ssl_to_enc_write_ctx": null,
+    "wrl_to_enc_ctx": 4128,
+    "enc_ctx_to_algctx": 176,
+    "algctx_to_gcm": 248,
+    "gcm128_h_offset": 80,
+    "algctx_to_h": 328,
+    "ssl_to_version": 72,
+    "ssl_to_wbio": 88
+  },
+  "sizes": {
+    "SSL_CONNECTION": 5568,
+    "EVP_CIPHER_CTX": 192,
+    "GCM128_CONTEXT": 448,
+    "PROV_GCM_CTX": 704
+  },
+  "kloak_config": {
+    "SSLToWRL": 3216,
+    "WRLToEncCtx": 4128,
+    "EncCtxToAlgctx": 176,
+    "AlgctxToH": 328,
+    "SSLToVersion": 72,
+    "SSLToWBIO": 88
+  }
+}

--- a/tools/openssl-offsets/results/openssl-4.0.1-amd64.json
+++ b/tools/openssl-offsets/results/openssl-4.0.1-amd64.json
@@ -1,0 +1,30 @@
+{
+  "openssl_version": "OpenSSL 4.0.1 9 Jun 2026",
+  "arch": "x86_64",
+  "chain": "4-hop",
+  "offsets": {
+    "ssl_to_wrl": 3648,
+    "ssl_to_enc_write_ctx": null,
+    "wrl_to_enc_ctx": 4128,
+    "enc_ctx_to_algctx": 168,
+    "algctx_to_gcm": 248,
+    "gcm128_h_offset": 80,
+    "algctx_to_h": 328,
+    "ssl_to_version": 72,
+    "ssl_to_wbio": 88
+  },
+  "sizes": {
+    "SSL_CONNECTION": 6000,
+    "EVP_CIPHER_CTX": 184,
+    "GCM128_CONTEXT": 448,
+    "PROV_GCM_CTX": 704
+  },
+  "kloak_config": {
+    "SSLToWRL": 3648,
+    "WRLToEncCtx": 4128,
+    "EncCtxToAlgctx": 168,
+    "AlgctxToH": 328,
+    "SSLToVersion": 72,
+    "SSLToWBIO": 88
+  }
+}

--- a/tools/openssl-offsets/results/openssl-4.0.1-arm64.json
+++ b/tools/openssl-offsets/results/openssl-4.0.1-arm64.json
@@ -1,0 +1,30 @@
+{
+  "openssl_version": "OpenSSL 4.0.1 9 Jun 2026",
+  "arch": "aarch64",
+  "chain": "4-hop",
+  "offsets": {
+    "ssl_to_wrl": 3648,
+    "ssl_to_enc_write_ctx": null,
+    "wrl_to_enc_ctx": 4128,
+    "enc_ctx_to_algctx": 168,
+    "algctx_to_gcm": 248,
+    "gcm128_h_offset": 80,
+    "algctx_to_h": 328,
+    "ssl_to_version": 72,
+    "ssl_to_wbio": 88
+  },
+  "sizes": {
+    "SSL_CONNECTION": 6000,
+    "EVP_CIPHER_CTX": 184,
+    "GCM128_CONTEXT": 448,
+    "PROV_GCM_CTX": 704
+  },
+  "kloak_config": {
+    "SSLToWRL": 3648,
+    "WRLToEncCtx": 4128,
+    "EncCtxToAlgctx": 168,
+    "AlgctxToH": 328,
+    "SSLToVersion": 72,
+    "SSLToWBIO": 88
+  }
+}


### PR DESCRIPTION
Automated by `.github/workflows/openssl-versions-nightly.yml`.

New OpenSSL release(s) detected on GitHub: **3.6.3,4.0.1**.

Changes in this PR:
- New `tools/openssl-offsets/results/openssl-<v>-<arch>.json` per (version, arch).
- New `opensslOffsetTable` entries in `pkg/ebpf/openssl_offsets.go`.
- Updated matrix list in `.github/workflows/openssl-offsets.yml`.
- (The nightly's `discover`/`e2e` matrix is resolved dynamically at runtime — no static version list to update there.)

### Reviewer checklist
- [ ] Diff the JSONs — offsets in expected ranges, no null fields.
- [ ] `go test ./pkg/ebpf -run TestOpenSSLOffsets` passes locally.
- [ ] Chain type correct: WRLToEncCtx=0 means 3-hop (OpenSSL ≤3.1), non-zero means 4-hop (3.2+).
- [ ] Spot-check that the on-demand `openssl-offsets.yml` workflow matrix is updated.

Opened with a `workflow`-scoped automation token so the workflow-file
edit can be pushed and per-PR CI triggers normally.