### PR TITLE
fix(e2e): fresh connection per request to de-flake rewrite tests (R2)

### DIFF
--- a/examples/demo-go-boring/main.go
+++ b/examples/demo-go-boring/main.go
@@ -68,6 +68,12 @@ func main() {
 				NextProtos: []string{"http/1.1"},
 			},
 			ForceAttemptHTTP2: false,
+			// Fresh TLS connection per request: if the uprobe attaches after a
+			// reused keep-alive connection is established, that connection's
+			// cipher init was never captured and every later request on it
+			// misses the rewrite. A new connection each time lets a late attach
+			// be picked up on the next request (a primary e2e flake fix).
+			DisableKeepAlives: true,
 			DialContext: (&net.Dialer{
 				Timeout: 10 * time.Second,
 			}).DialContext,

--- a/examples/demo-go/main.go
+++ b/examples/demo-go/main.go
@@ -69,8 +69,20 @@ func main() {
 	fmt.Println("Waiting 10s for Kloak controller to sync...")
 	time.Sleep(10 * time.Second)
 
+	// Disable HTTP keep-alive so every request opens a fresh TLS connection.
+	// Kloak captures the GCM key (H) at the connection's cipher init; if the
+	// uprobe attaches *after* a long-lived keep-alive connection is already
+	// established, that connection is never instrumented and every subsequent
+	// reused request misses the rewrite permanently (a primary e2e flake). A
+	// fresh connection per request means a late attach is picked up on the very
+	// next request instead. ForceAttemptHTTP2 keeps the h2 path the HPACK test
+	// exercises.
 	client := &http.Client{
 		Timeout: 10 * time.Second,
+		Transport: &http.Transport{
+			DisableKeepAlives: true,
+			ForceAttemptHTTP2: true,
+		},
 	}
 
 	requestCount := 0

--- a/examples/demo-js/app.js
+++ b/examples/demo-js/app.js
@@ -36,6 +36,11 @@ function makeRequest(url, headers) {
       path: opts.pathname + opts.search,
       method: "GET",
       headers,
+      // Fresh TLS connection per request (no socket pooling). If the uprobe
+      // attaches after a reused connection's cipher init, every later request
+      // on that socket misses the rewrite permanently — a primary e2e flake.
+      // A new connection each time lets a late attach be picked up next request.
+      agent: false,
     };
 
     const req = https.request(reqOpts, (res) => {
@@ -78,14 +83,14 @@ async function main() {
   );
   console.log("=".repeat(60));
 
-  // Brief delay for kloak controller to attach uprobes before the first
-  // TLS connection. Node's https.globalAgent defaults to keepAlive=true
-  // (and we send Connection: keep-alive explicitly below), so all
-  // subsequent requests reuse the very first connection's SSL_CTX. If
-  // we lose the attach race against that first connection, every later
-  // request misses the rewrite — observable in CI as the kprobe_walk
-  // counter staying frozen while the demo cycles 100+ requests.
-  // Mirrors the startup delay in examples/demo-go/main.go.
+  // Brief delay for the kloak controller to attach uprobes before the first
+  // TLS connection. This used to be load-bearing: with connection pooling, all
+  // requests reused the first connection's SSL_CTX, so losing the attach race
+  // against that first connection meant every later request missed the rewrite
+  // permanently (kprobe_walk frozen while the demo cycled 100+ requests). We
+  // now open a fresh connection per request (agent: false + Connection: close
+  // in makeRequest), so a late attach is picked up on the next request and this
+  // delay is only a minor head-start. Mirrors examples/demo-go/main.go.
   console.log("Waiting 10s for Kloak controller to sync...");
   await new Promise((r) => setTimeout(r, 10000));
 
@@ -103,7 +108,7 @@ async function main() {
         "User-Agent": "node-demo/1.0.0",
         "Accept-Encoding": "gzip, deflate",
         Accept: "*/*",
-        Connection: "keep-alive",
+        Connection: "close",
       };
 
       const { status, body } = await makeRequest(targetURL, headers);


### PR DESCRIPTION
## Why

Data-driven follow-up to the flakiness investigation. I mined the **last ~20 retry-to-green CI runs** (runs that failed then passed on a re-run) and pulled the failing attempts' logs. The flaky tests cluster clearly:

| Test | Flaky runs | External dep? |
|------|-----------:|---------------|
| `TestEBPFSecretRewrite/js` | 9 | httpbin |
| `TestEBPFSecretRewrite/python` | 6 | httpbin |
| **`TestEBPFRawTLSHostFiltering`** | **6** | **none (in-cluster)** |
| `TestCipherSuites` (/4hop) | 6 | none (in-cluster) |
| `TestEBPFSecretRewrite/go` | 3 | httpbin |

Crucially, the in-cluster tests flake just as much as the httpbin ones, so the dominant cause is **not** the external dependency — it's a **uprobe attach race (R2)**.

## Root cause (documented in demo-js's own comment)

kloak captures the GCM key (H) at a connection's **cipher init**. With HTTP **keep-alive**, the client reuses the first connection for every request. If the uprobe attaches *after* that first connection is established, the connection is never instrumented — and every reused request misses the rewrite **permanently** (`kprobe_walk` stays frozen while the demo cycles 100+ requests). The `"Waiting 10s for Kloak controller to sync"` sleeps are a fragile attempt to win that race; on a loaded runner they lose it and the test times out.

## Fix

Open a **fresh TLS connection per request** in the connection-reusing demos, so a late attach is captured on the very next request instead of being missed forever:

- **demo-go** — `Transport{DisableKeepAlives: true, ForceAttemptHTTP2: true}` (keeps the h2 path `TestEBPFHttp2HpackOverPadding` exercises)
- **demo-go-boring** — `DisableKeepAlives: true` on its existing HTTP/1.1 transport
- **demo-js** — `agent: false` + `Connection: close` (was explicitly `keep-alive`)

`demo-python` / `demo-python-raw-tls` already use a fresh connection per request (the `requests` lib creates a new session per call; the raw-TLS demo opens a new socket), so they need no change. The startup sleeps are left as a minor head-start but are no longer load-bearing.

## Validation

`go build` passes for both Go demos; `node --check` passes for the JS demo. The eBPF behavior is verified by the E2E job in CI.

## Scope

This targets the **readiness/attach race (R2)**. The separate **external httpbin.org dependency (R1)** — replacing it with an in-cluster go-httpbin — is a planned follow-up that will remove the read-timeout failures on the httpbin-dependent subtests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)