### PR TITLE
ci(nightly): skip e2e for OpenSSL 4.x (SONAME-incompatible with demo base)

### DIFF
--- a/.github/workflows/openssl-versions-nightly.yml
+++ b/.github/workflows/openssl-versions-nightly.yml
@@ -43,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       versions: ${{ steps.resolve.outputs.versions }}
+      e2e_versions: ${{ steps.resolve.outputs.e2e_versions }}
     steps:
       - uses: actions/checkout@v6
 
@@ -76,6 +77,20 @@ jobs:
             | jq -R . | jq -sc .)
           echo "Resolved versions: $versions"
           echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
+          # e2e can only exercise OpenSSL majors whose SONAME matches the demo
+          # image's Python base. demo-python-raw-tls runs on python:3.11-slim-
+          # bookworm, whose _ssl links libssl.so.3 — so it can load any custom
+          # OpenSSL 3.x (forward-compatible within the .so.3 SONAME) but NOT 4.x,
+          # which ships libssl.so.4: the .so.3 symlinks dangle, Python's _ssl
+          # can't load, and the demo pod crash-loops. Offset *discovery* above
+          # is unaffected (it reads struct layout directly), so 4.x still gets
+          # tracked — it just can't be run end-to-end until a 4.x-linked base
+          # image exists. Filter e2e to the 3.x series.
+          # TODO: revisit when a Python base built against OpenSSL 4 is available.
+          e2e_versions=$(printf '%s' "$versions" | jq -c '[.[] | select(test("^3\\."))]')
+          echo "E2E versions (SONAME-compatible with demo base): $e2e_versions"
+          echo "e2e_versions=$e2e_versions" >> "$GITHUB_OUTPUT"
 
   # ────────────────────────────────────────────────────────────────────
   # (1) Offset discovery — same shape as openssl-offsets.yml's matrix,
@@ -147,6 +162,9 @@ jobs:
   # ────────────────────────────────────────────────────────────────────
   # (2) Multi-version e2e — exercises the real BPF rewrite path against a
   # demo-python-raw-tls image built against each supported OpenSSL version.
+  # Uses e2e_versions (3.x only): the demo's bookworm Python base links
+  # libssl.so.3 and cannot load a 4.x (libssl.so.4) build, so those would only
+  # crash-loop. 4.x is still covered by discover above.
   e2e:
     name: e2e OpenSSL ${{ matrix.openssl }}
     runs-on: ubuntu-latest
@@ -154,7 +172,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        openssl: ${{ fromJson(needs.resolve-matrix.outputs.versions) }}
+        openssl: ${{ fromJson(needs.resolve-matrix.outputs.e2e_versions) }}
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
## Why

The OpenSSL Versions Nightly fails **every run on the `e2e OpenSSL 4.0.1` cell**, while all 3.x cells pass ([failing job](https://github.com/spinningfactory/kloak/actions/runs/28231618403/job/83784150715)).

## Root cause

OpenSSL 4.0 bumps the SONAME: `libssl.so.3` → **`libssl.so.4`** (and `libcrypto.so.4`). But the demo image `demo-python-raw-tls` runs on **`python:3.11-slim-bookworm`**, whose `_ssl` links **`libssl.so.3`**. The Dockerfile symlinks `libssl.so.3` → the custom build; for a 4.x build those links **dangle** (the files are `.so.4`), Python's `_ssl` can't load, and both demo containers **CrashLoopBackOff** → the deployment never becomes ready → `TestEBPFRawTLSHostFiltering` times out.

Controller logs confirm it — the 4.0.1 demo container exposes **no libssl at all** (only `libgnutls`):
```
found container TLS libraries {"count": 1, "libs": ["/usr/lib/x86_64-linux-gnu/libgnutls.so.30"]}
Back-off restarting failed container demo-app … echo-server
```

A 3.x-based Python cannot load a 4.x OpenSSL (no forward-compat across a SONAME bump), so **e2e for 4.x is infeasible** until a Python base linked against OpenSSL 4 exists.

## Fix

- Add a `resolve-matrix` output **`e2e_versions`** filtered to the `3.x` series; point only the **e2e** job at it.
- `discover` keeps the full `versions` list, so **4.x offsets are still tracked** (discovery reads struct layout directly — unaffected by the SONAME).

So the nightly goes green, 4.x stays in the offset table, and e2e for 4.x can be re-enabled later (a `TODO` notes this) once a 4.x-linked base image is available.

## Validation
- jq filter: `["3.0.21","3.6.3","4.0.1"]` → `["3.0.21","3.6.3"]` ✓
- YAML validates ✓

## Note (separate, latent)
My earlier #252 system-libssl override would, for a 4.x build, replace the real system `libssl.so.3` with a dangling link — harmless now that 4.x is excluded from the only place the demo is built (e2e), but worth making the Dockerfile symlinks SONAME-aware in a follow-up for manual/local 4.x builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)