### PR TITLE
fix(ebpf): live-H fallback in bpf_h_extract closes OpenSSL cold-start race

### DIFF
--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -198,6 +198,7 @@ enum {
   DBG_H_EXTRACT_CACHE_MISS,   // bpf_h_extract walked SSL→wrl→enc_ctx but cache had no entry
   DBG_KPROBE_BRIDGE_FROM_PENDING, // kprobe used H carried via xor_pending (libcrypto-hook hot path)
   DBG_KPROBE_WALK_LEGACY,     // kprobe walked SSL→wrl→enc_ctx→algctx→H (BoringSSL/cold-start path)
+  DBG_H_EXTRACT_LIVE_WALK,    // bpf_h_extract derived H live from enc_ctx→algctx→H on cache miss
   DBG_MAX,
 };
 
@@ -1737,12 +1738,57 @@ int bpf_h_extract(void *ctx) {
   key.tgid = tgid;
   key.evp_ctx_ptr = enc_ctx;
   struct evp_h_val *cached = bpf_map_lookup_elem(&evp_h_cache, &key);
-  if (!cached) {
-    // Either the handshake completed before kloak's libcrypto attach
-    // (cold start), or this enc_ctx was rebuilt from a different code
-    // path. SSL_write goes through unmodified for this call.
-    dbg_inc(DBG_H_EXTRACT_CACHE_MISS);
-    return 0;
+
+  // H source: prefer the value captured at EVP_CipherInit_ex time (fast
+  // path). On a cache miss the handshake completed before kloak's libcrypto
+  // uretprobe attached (cold-start race), or the enc_ctx was rebuilt (e.g.
+  // TLS 1.3 KeyUpdate). Letting the write go out unmodified would
+  // permanently break rewriting on a keep-alive connection whose enc_ctx is
+  // never re-initialised under our hook — so instead we derive H live from
+  // the same enc_ctx → algctx → H chain the uretprobe and the kprobe-walk
+  // fallback use. The cache is therefore a pure optimisation, not a
+  // correctness dependency.
+  __u8 ghash_h[16];
+  __u8 cipher_type;
+  if (cached) {
+    __builtin_memcpy(ghash_h, cached->ghash_h, 16);
+    cipher_type = cached->cipher_type;
+    dbg_inc(DBG_H_EXTRACT_CACHE_HIT);
+  } else {
+    __u64 algctx = 0;
+    if (bpf_probe_read_user(&algctx, 8,
+                            (void *)(enc_ctx + offsets->enc_ctx_to_algctx)) < 0 ||
+        !algctx) {
+      dbg_inc(DBG_H_EXTRACT_CACHE_MISS);
+      return 0;
+    }
+    if (bpf_probe_read_user(ghash_h, 16,
+                            (void *)(algctx + offsets->algctx_to_h)) < 0) {
+      dbg_inc(DBG_H_EXTRACT_CACHE_MISS);
+      return 0;
+    }
+    // Non-GCM ciphers (or H not yet populated) read as zero here.
+    __u64 *h64 = (__u64 *)ghash_h;
+    if (h64[0] == 0 && h64[1] == 0) {
+      dbg_inc(DBG_H_EXTRACT_CACHE_MISS);
+      return 0;
+    }
+    // OpenSSL stores H little-endian; GHASH wants big-endian (matches the
+    // uretprobe and kprobe-walk representations).
+    h64[0] = __builtin_bswap64(h64[0]);
+    h64[1] = __builtin_bswap64(h64[1]);
+    cipher_type = KLOAK_CIPHER_AES_GCM;
+
+    // Backfill the cache so subsequent writes on this enc_ctx take the
+    // fast path. nonce_len is resolved per-connection below, so the cached
+    // entry keeps the sentinel.
+    struct evp_h_val backfill;
+    __builtin_memset(&backfill, 0, sizeof(backfill));
+    __builtin_memcpy(backfill.ghash_h, ghash_h, 16);
+    backfill.cipher_type = KLOAK_CIPHER_AES_GCM;
+    backfill.nonce_len = 0xFF;
+    bpf_map_update_elem(&evp_h_cache, &key, &backfill, BPF_ANY);
+    dbg_inc(DBG_H_EXTRACT_LIVE_WALK);
   }
 
   // Determine nonce_len from SSL_CONNECTION.version (per-connection, not
@@ -1757,8 +1803,8 @@ int bpf_h_extract(void *ctx) {
 
   struct tls_conn_state new_conn;
   __builtin_memset(&new_conn, 0, sizeof(new_conn));
-  __builtin_memcpy(new_conn.ghash_h, cached->ghash_h, 16);
-  new_conn.cipher_type = cached->cipher_type;
+  __builtin_memcpy(new_conn.ghash_h, ghash_h, 16);
+  new_conn.cipher_type = cipher_type;
   new_conn.nonce_len = nonce_len;
 
   struct tls_conn_key ck;

--- a/pkg/ebpf/bpf/tls_uprobe.c
+++ b/pkg/ebpf/bpf/tls_uprobe.c
@@ -1748,7 +1748,11 @@ int bpf_h_extract(void *ctx) {
   // the same enc_ctx → algctx → H chain the uretprobe and the kprobe-walk
   // fallback use. The cache is therefore a pure optimisation, not a
   // correctness dependency.
-  __u8 ghash_h[16];
+  // 8-byte-aligned backing store: the zero-check and bswap operate on it as
+  // __u64, so an under-aligned __u8[16] could trip strict-alignment arches or
+  // the BPF verifier.
+  __u64 ghash_h64[2] = {0};
+  __u8 *ghash_h = (__u8 *)ghash_h64;
   __u8 cipher_type;
   if (cached) {
     __builtin_memcpy(ghash_h, cached->ghash_h, 16);
@@ -1768,15 +1772,14 @@ int bpf_h_extract(void *ctx) {
       return 0;
     }
     // Non-GCM ciphers (or H not yet populated) read as zero here.
-    __u64 *h64 = (__u64 *)ghash_h;
-    if (h64[0] == 0 && h64[1] == 0) {
+    if (ghash_h64[0] == 0 && ghash_h64[1] == 0) {
       dbg_inc(DBG_H_EXTRACT_CACHE_MISS);
       return 0;
     }
     // OpenSSL stores H little-endian; GHASH wants big-endian (matches the
     // uretprobe and kprobe-walk representations).
-    h64[0] = __builtin_bswap64(h64[0]);
-    h64[1] = __builtin_bswap64(h64[1]);
+    ghash_h64[0] = __builtin_bswap64(ghash_h64[0]);
+    ghash_h64[1] = __builtin_bswap64(ghash_h64[1]);
     cipher_type = KLOAK_CIPHER_AES_GCM;
 
     // Backfill the cache so subsequent writes on this enc_ctx take the
@@ -1813,7 +1816,7 @@ int bpf_h_extract(void *ctx) {
   ck.ssl_ptr = ssl_ptr;
   bpf_map_update_elem(&tls_conn_state, &ck, &new_conn, BPF_ANY);
 
-  dbg_inc(DBG_H_EXTRACT_CACHE_HIT);
+  // CACHE_HIT / LIVE_WALK already counted above per H source.
   dbg_inc(DBG_XOR_CONN_HIT);
 
   bpf_tail_call(ctx, &prog_array, 1);

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -1630,6 +1630,7 @@ var debugCounterNames = []string{
 	"evp_init_entry", "evp_init_h_ok", "evp_init_h_zero", "evp_init_chain_fail",
 	"h_extract_cache_hit", "h_extract_cache_miss",
 	"kprobe_bridge_from_pending", "kprobe_walk_legacy",
+	"h_extract_live_walk",
 }
 
 // DumpDebugCounters reads and logs all debug counters from the BPF map.


### PR DESCRIPTION
## Problem

The eBPF e2e suite has been intermittently failing, concentrated on the **OpenSSL 3.5.x / 4-hop** demos (`python`, `js`, `raw-tls`, `cipher/4hop`) while the **Go** path and the **OpenSSL 3.0 / 3-hop** path pass. The tell that it's a race, not a deterministic offset bug: when it works it's fast (3hop 5.4s, go 19s) and the offsets/rewrite are provably correct in the same run; when it fails, the rewrite simply never happens and the test waits out its readiness window.

## Root cause — a cold-start race on the libcrypto-hook path

For OpenSSL 3.2+ the controller puts the process on the **libcrypto-hook H-extraction path**. On that path:

1. `bpf_uretprobe_evp_cipher_init` captures the GHASH subkey **H** into `evp_h_cache`, keyed by `(tgid, enc_ctx)` — but it fires **once, during the TLS handshake**.
2. On `SSL_write`, `bpf_h_extract` walked `SSL → wrl → enc_ctx` and then **only looked up the cache**. On a miss it bailed (`return 0`) and the write went out **unmodified** — the rewrite tail-call never ran.

If kloak attached the `EVP_CipherInit_ex` uretprobe *after* the app's handshake (an inherent race between async pod-detect→attach and the app's first HTTPS request), the cache stayed empty for that connection's `enc_ctx`. Since a **keep-alive** connection reuses one `enc_ctx` set up once at handshake, **every** subsequent write missed the cache → the secret was never rewritten for the life of that connection. The existing `STRATEGY_KPROBE_WALK` chain-walk fallback couldn't help because it lives *downstream* of the `bpf_h_extract` gate.

The Go path is immune (it derives H inline); the OpenSSL 3.0 3-hop path doesn't depend on the one-shot cache the same way — which is exactly the observed pass/fail split.

## Fix

On a cache miss, derive **H live** from the same `enc_ctx → algctx → H` chain the uretprobe and the kprobe-walk fallback already use (we already hold `enc_ctx`), then backfill the cache for the fast path. The EVP-init cache becomes a pure **optimisation**, not a correctness dependency.

Bonus: this also handles **TLS 1.3 KeyUpdate** rekeys mid-connection (new H) that a one-shot cache would miss.

Adds `DBG_H_EXTRACT_LIVE_WALK` so the fallback's hit rate is observable in the debug counters.

## Validation

- ✅ eBPF C compiles cleanly via `bpf2go` (`-Wall -Werror`)
- ✅ `go build ./...` and `go vet ./pkg/ebpf/` pass against freshly generated bindings
- The race can only be exercised by the eBPF e2e (needs a kernel) — relying on this PR's CI e2e run. The fix is version-agnostic (no offset changes), so it should also harden 3.2–3.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)