### PR TITLE
chore(boringssl): track offsets for 0.20260526.0

### DIFF
--- a/pkg/ebpf/boringssl_offsets.go
+++ b/pkg/ebpf/boringssl_offsets.go
@@ -70,7 +70,7 @@ var boringsslOffsetTable = map[string]BoringSSLOffsets{
 	//   SSLAEADContext.ctx_(8) + EVP_AEAD_CTX.state(8) + key(0) + gcm128_key.aes(272) = 288,
 	//   ssl_st.wbio = 32.
 	// The LP64 struct layout is architecture-independent (same on x86_64).
-	"default": {SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32},
+	"default": {SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}, // verified against 0.20260526.0
 }
 
 // boringSSLMarkers are .rodata strings that uniquely identify a BoringSSL

--- a/tools/boringssl-offsets/results/boringssl-0.20260526.0-amd64.json
+++ b/tools/boringssl-offsets/results/boringssl-0.20260526.0-amd64.json
@@ -1,0 +1,36 @@
+{
+  "library": "BoringSSL",
+  "version": "0.20260526.0",
+  "arch": "x86_64",
+  "chain": "boringssl",
+  "structs": {
+    "ssl": "ssl_st",
+    "s3": "SSL3_STATE",
+    "aead_ctx": "SSLAEADContext",
+    "evp_aead_ctx": "evp_aead_ctx_st",
+    "gcm_key": "gcm128_key_st"
+  },
+  "offsets": {
+    "ssl_to_s3": 48,
+    "ssl_to_wbio": 32,
+    "s3_to_aead_write_ctx": 272,
+    "aead_to_ctx": 8,
+    "ctx_to_state": 8,
+    "aead_gcm_key": 0,
+    "gcm_h_offset": 0,
+    "gcm_aes_offset": 272,
+    "aead_to_h": 16,
+    "aead_to_aeskey": 288,
+    "bio_num_offset": null
+  },
+  "sizes": {
+    "SSL": 168,
+    "SSL3_STATE": 600
+  },
+  "kloak_config": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/boringssl-offsets/results/boringssl-0.20260526.0-arm64.json
+++ b/tools/boringssl-offsets/results/boringssl-0.20260526.0-arm64.json
@@ -1,0 +1,36 @@
+{
+  "library": "BoringSSL",
+  "version": "0.20260526.0",
+  "arch": "aarch64",
+  "chain": "boringssl",
+  "structs": {
+    "ssl": "ssl_st",
+    "s3": "SSL3_STATE",
+    "aead_ctx": "SSLAEADContext",
+    "evp_aead_ctx": "evp_aead_ctx_st",
+    "gcm_key": "gcm128_key_st"
+  },
+  "offsets": {
+    "ssl_to_s3": 48,
+    "ssl_to_wbio": 32,
+    "s3_to_aead_write_ctx": 272,
+    "aead_to_ctx": 8,
+    "ctx_to_state": 8,
+    "aead_gcm_key": 0,
+    "gcm_h_offset": 0,
+    "gcm_aes_offset": 272,
+    "aead_to_h": 16,
+    "aead_to_aeskey": 288,
+    "bio_num_offset": null
+  },
+  "sizes": {
+    "SSL": 168,
+    "SSL3_STATE": 600
+  },
+  "kloak_config": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}


### PR DESCRIPTION
Automated by `.github/workflows/boringssl-versions-nightly.yml`.

New BoringSSL release tag(s) detected: **0.20260526.0**.

Changes in this PR:
- New `tools/boringssl-offsets/results/boringssl-<tag>-<arch>.json` per (tag, arch).
- If offsets drifted from the previous build, the `"default"` row in
  `pkg/ebpf/boringssl_offsets.go` is updated (else results-only).

### Reviewer checklist
- [ ] Diff the JSONs — offsets in expected ranges, no null fields.
- [ ] `go test ./pkg/ebpf -run TestBoringSSLOffsets` passes.
- [ ] If the `"default"` row changed, the struct layout genuinely
      shifted — confirm via the pahole dumps (workflow logs / artifact).