### PR TITLE
feat(bun): TLS interception for Bun single-executables via file-offset uprobe

### DIFF
--- a/.github/workflows/bun-versions-nightly.yml
+++ b/.github/workflows/bun-versions-nightly.yml
@@ -1,0 +1,358 @@
+name: Bun Versions Nightly
+
+# Four jobs on a Bun-release cadence, mirroring boringssl-versions-nightly.yml:
+#
+#   0. resolve-matrix — list the most recent stable Bun releases from
+#                       oven-sh/bun GitHub releases.
+#   1. discover  — download the official Bun profile build (production
+#                  optimisation flags, symbol table retained), extract the
+#                  SSL_write file offset via nm + va_to_offset.py, and diff
+#                  against committed tools/bun-offsets/results/. Catches
+#                  offset changes between Bun releases (Bun rebuilds BoringSSL
+#                  from source and SSL_write's position shifts each release).
+#   2. e2e       — exercise demo-bun end-to-end (file-offset uprobe attach +
+#                  BoringSSL H-extraction via AES round-key recovery) against
+#                  each tracked version.
+#   3. watcher   — detect newly-released Bun versions, run discovery, insert
+#                  new rows into bunOffsetTable, open a Dependabot-style PR.
+#
+# Unlike OpenSSL/BoringSSL discovery, no Docker image build is required: the
+# offset extraction downloads a pre-built Bun binary and runs nm + a pure
+# Python ELF parser. QEMU is not needed for cross-arch discovery either —
+# only nm and Python3 run on the host; the Bun binary is inspected as data.
+#
+# Runs daily at 07:45 UTC. Manual triggers via workflow_dispatch supported.
+# fail-fast: false everywhere so one matrix cell does not mask the others.
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "45 7 * * *"
+
+concurrency:
+  group: bun-versions-nightly
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: '1.26'
+  # Number of most-recent Bun releases tracked and tested.
+  RECENT_VERSIONS: '3'
+
+jobs:
+  # ────────────────────────────────────────────────────────────────────
+  # (0) Resolve matrix — the most recent stable Bun release versions.
+  resolve-matrix:
+    name: Resolve recent Bun versions
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.resolve.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Resolve recent stable Bun versions
+        id: resolve
+        run: |
+          set -euo pipefail
+          curl -fsS \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/oven-sh/bun/releases?per_page=50" \
+            | jq -r '.[] | select(.prerelease==false and .draft==false) | .tag_name' \
+            | grep '^bun-v[0-9]' \
+            | sed 's/^bun-v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -n "${RECENT_VERSIONS}" > recent-versions.txt
+          cat recent-versions.txt
+          versions=$(jq -R . recent-versions.txt | jq -sc .)
+          echo "Resolved versions: $versions"
+          echo "versions=$versions" >> "$GITHUB_OUTPUT"
+
+  # ────────────────────────────────────────────────────────────────────
+  # (1) Offset discovery — download profile build and extract SSL_write offset.
+  discover:
+    name: Discover bun-${{ matrix.version }} on ${{ matrix.arch }}
+    runs-on: ubuntu-latest
+    needs: [resolve-matrix]
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
+        version: ${{ fromJson(needs.resolve-matrix.outputs.versions) }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install nm and Python3
+        run: sudo apt-get update && sudo apt-get install -y binutils python3 jq
+
+      - name: Discover offsets
+        run: |
+          mkdir -p out
+          BUN_VERSION=${{ matrix.version }} ARCH=${{ matrix.arch }} \
+            tools/bun-offsets/discover.sh > out/bun-${{ matrix.version }}-${{ matrix.arch }}.json
+          echo "=== discovered ==="
+          cat out/bun-${{ matrix.version }}-${{ matrix.arch }}.json
+
+      - name: Diff against committed JSON
+        run: |
+          existing=tools/bun-offsets/results/bun-${{ matrix.version }}-${{ matrix.arch }}.json
+          new=out/bun-${{ matrix.version }}-${{ matrix.arch }}.json
+          if [ ! -f "$existing" ]; then
+            echo "::warning::no committed reference for bun-${{ matrix.version }}-${{ matrix.arch }}"
+            exit 0
+          fi
+          if ! diff <(jq -S '.ssl_write_offset' "$existing") <(jq -S '.ssl_write_offset' "$new"); then
+            echo "::warning::ssl_write_offset drifted for bun-${{ matrix.version }}-${{ matrix.arch }} — review artifact"
+          fi
+          if ! diff <(jq -S '.boringssl' "$existing") <(jq -S '.boringssl' "$new"); then
+            echo "::warning::BoringSSL struct offsets drifted for bun-${{ matrix.version }}-${{ matrix.arch }}"
+          fi
+
+      - name: Upload result
+        uses: actions/upload-artifact@v7
+        with:
+          name: bun-offsets-${{ matrix.version }}-${{ matrix.arch }}
+          path: out/bun-${{ matrix.version }}-${{ matrix.arch }}.json
+          retention-days: 30
+
+  # ────────────────────────────────────────────────────────────────────
+  # (2) e2e — exercises the Bun file-offset uprobe attach + BoringSSL H-extraction.
+  e2e:
+    name: e2e bun-${{ matrix.version }}
+    runs-on: ubuntu-latest
+    needs: [resolve-matrix, discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJson(needs.resolve-matrix.outputs.versions) }}
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CACHE_REPO: ghcr.io/${{ github.repository }}/cache
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Install clang and bpftool for eBPF
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang llvm libbpf-dev
+          KVER="$(uname -r)" && sudo apt-get install -y linux-tools-common "linux-tools-${KVER}" 2>/dev/null || true
+
+      - name: Generate eBPF bindings
+        run: KLOAK_TARGET_ARCH=x86 go generate ./pkg/ebpf/
+
+      - name: Login to GHCR (for build cache)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Install k3s
+        run: |
+          curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--write-kubeconfig-mode 644 --disable=traefik" sh -
+          for i in $(seq 1 30); do
+            sudo k3s kubectl get nodes -o name 2>/dev/null | grep -q . && break
+            echo "Waiting for k3s node ($i/30)..."
+            sleep 4
+          done
+          sudo k3s kubectl wait --for=condition=Ready node --all --timeout=120s
+          mkdir -p ~/.kube
+          sudo cp /etc/rancher/k3s/k3s.yaml ~/.kube/k3s-e2e.yaml
+          sudo chown "$(id -u):$(id -g)" ~/.kube/k3s-e2e.yaml
+          chmod 600 ~/.kube/k3s-e2e.yaml
+
+      - name: Build kloak + demo images and import to k3s
+        run: |
+          CACHE=${{ env.CACHE_REPO }}
+
+          docker buildx build --load \
+            --cache-from type=registry,ref=${CACHE}:kloak \
+            --cache-to type=registry,ref=${CACHE}:kloak,mode=max,ignore-error=true \
+            --build-arg TARGETARCH=amd64 --build-arg COVER=1 --build-arg BPF_DEBUG=1 \
+            -t kloak:e2e .
+
+          # demo-bun built against the Bun version under test.
+          docker buildx build --load \
+            --build-arg BUN_VERSION=${{ matrix.version }} \
+            --cache-from type=registry,ref=${CACHE}:demo-bun-${{ matrix.version }} \
+            --cache-to type=registry,ref=${CACHE}:demo-bun-${{ matrix.version }},mode=max,ignore-error=true \
+            -t kloak-demo-bun:latest ./examples/demo-bun/
+
+          # The echo-server sidecar reuses the raw-TLS demo image.
+          docker buildx build --load \
+            --cache-from type=registry,ref=${CACHE}:demo-python-raw-tls \
+            --cache-to type=registry,ref=${CACHE}:demo-python-raw-tls,mode=max,ignore-error=true \
+            -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
+
+          docker save kloak:e2e kloak-demo-bun:latest kloak-demo-python-raw-tls:latest \
+            | sudo k3s ctr -n k8s.io images import -
+
+      - name: Install Helm
+        uses: azure/setup-helm@v5
+
+      - name: Start BPF trace capture
+        run: |
+          sudo touch /tmp/bpf-trace.log
+          sudo chmod 666 /tmp/bpf-trace.log
+          sudo nohup sh -c 'cat /sys/kernel/tracing/trace_pipe > /tmp/bpf-trace.log 2>&1' >/dev/null 2>&1 &
+          echo $! | sudo tee /tmp/bpf-trace.pid >/dev/null
+          sleep 1
+
+      - name: Run TestEBPFBunHostFiltering
+        run: go test -v -timeout 600s -tags=e2e_ebpf -count=1 -run 'TestEBPFBunHostFiltering' ./test/e2e/
+        env:
+          KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
+
+      - name: Stop BPF trace capture
+        if: always()
+        run: |
+          PID=$(cat /tmp/bpf-trace.pid 2>/dev/null) || true
+          if [ -n "$PID" ]; then sudo kill "$PID" 2>/dev/null || true; fi
+          sudo pkill -f "cat /sys/kernel/tracing/trace_pipe" 2>/dev/null || true
+          sudo chmod 666 /tmp/bpf-trace.log 2>/dev/null || true
+
+      - name: Collect logs and BPF debug info on failure
+        if: failure()
+        env:
+          KUBECONFIG: /home/runner/.kube/k3s-e2e.yaml
+        run: |
+          echo "=== Pods (kloak-e2e) ==="
+          kubectl get pods -n kloak-e2e -o wide 2>/dev/null || true
+          echo "=== Events (kloak-e2e, by time) ==="
+          kubectl get events -n kloak-e2e --sort-by=.lastTimestamp 2>/dev/null || true
+          echo "=== Describe demo-bun pods ==="
+          kubectl describe pods -n kloak-e2e -l app=demo-bun 2>/dev/null || true
+          echo "=== Kloak Controller Logs ==="
+          kubectl logs -n kloak-system -l app.kubernetes.io/component=controller --tail=5000 2>/dev/null || true
+          echo "=== demo-bun Logs (current) ==="
+          kubectl logs -n kloak-e2e -l app=demo-bun -c demo-app --tail=200 2>/dev/null || true
+          echo "=== BPF trace (last 500 lines) ==="
+          if [ -s /tmp/bpf-trace.log ]; then
+            grep -F kloak /tmp/bpf-trace.log | tail -500 || true
+          fi
+
+      - name: Upload BPF trace
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bpf-trace-bun-${{ matrix.version }}
+          path: /tmp/bpf-trace.log
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Stop k3s
+        if: always()
+        run: |
+          sudo /usr/local/bin/k3s-killall.sh 2>/dev/null || true
+          sudo /usr/local/bin/k3s-uninstall.sh 2>/dev/null || true
+          rm -f ~/.kube/k3s-e2e.yaml
+
+  # ────────────────────────────────────────────────────────────────────
+  # (3) New-version watcher — detect newly-released Bun versions, discover
+  # offsets, insert new rows into bunOffsetTable, and open a PR.
+  detect-new-version:
+    name: Detect new Bun versions
+    runs-on: ubuntu-latest
+    needs: [discover]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
+
+      - name: Install nm, Python3 and jq
+        run: sudo apt-get update && sudo apt-get install -y binutils python3 jq
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Find new Bun versions
+        id: find
+        run: |
+          set -euo pipefail
+          curl -fsS \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/oven-sh/bun/releases?per_page=50" \
+            | jq -r '.[] | select(.prerelease==false and .draft==false) | .tag_name' \
+            | grep '^bun-v[0-9]' \
+            | sed 's/^bun-v//' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            | tail -n "${RECENT_VERSIONS}" > upstream-recent.txt
+          cat upstream-recent.txt
+
+          ls tools/bun-offsets/results/ 2>/dev/null \
+            | sed -n 's/^bun-\(.*\)-amd64\.json$/\1/p' \
+            | sort -t. -k1,1n -k2,2n -k3,3n \
+            > tracked-versions.txt || true
+          cat tracked-versions.txt || true
+
+          comm -23 <(sort upstream-recent.txt) <(sort tracked-versions.txt) > new-versions.txt || true
+          if [ -s new-versions.txt ]; then
+            new=$(paste -sd, new-versions.txt)
+            echo "new=$new" >> "$GITHUB_OUTPUT"
+            echo "Found new Bun versions: $new"
+          else
+            echo "new=" >> "$GITHUB_OUTPUT"
+            echo "No new Bun versions detected"
+          fi
+
+      - name: Discover offsets for each new version
+        if: steps.find.outputs.new != ''
+        run: |
+          set -euo pipefail
+          for v in $(echo "${{ steps.find.outputs.new }}" | tr ',' ' '); do
+            for arch in amd64 arm64; do
+              BUN_VERSION="$v" ARCH="$arch" tools/bun-offsets/discover.sh \
+                > "tools/bun-offsets/results/bun-$v-$arch.json"
+            done
+          done
+
+      - name: Insert new rows into bunOffsetTable
+        if: steps.find.outputs.new != ''
+        run: |
+          tools/bun-offsets/apply-new-versions.sh "${{ steps.find.outputs.new }}"
+
+      - name: Open PR
+        if: steps.find.outputs.new != ''
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
+          add-paths: |
+            tools/bun-offsets/results
+            pkg/ebpf/bun_offsets.go
+          commit-message: "chore(bun): track offsets for ${{ steps.find.outputs.new }}"
+          branch: auto/bun-versions/${{ steps.find.outputs.new }}
+          delete-branch: true
+          title: "chore(bun): track offsets for bun-v${{ steps.find.outputs.new }}"
+          labels: |
+            automated
+            bun-versions
+          body: |
+            Automated by `.github/workflows/bun-versions-nightly.yml`.
+
+            New Bun release(s) detected: **${{ steps.find.outputs.new }}**.
+
+            Changes in this PR:
+            - New `tools/bun-offsets/results/bun-<version>-<arch>.json` per (version, arch).
+            - New rows in `bunOffsetTable` in `pkg/ebpf/bun_offsets.go` with the
+              discovered `ssl_write_offset` and BoringSSL struct offsets.
+
+            ### Reviewer checklist
+            - [ ] Diff the JSONs — `ssl_write_offset` is non-zero, BoringSSL offsets in expected ranges.
+            - [ ] `go test ./pkg/ebpf -run TestBunOffsets` passes.
+            - [ ] The nightly e2e job passed for the new version.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,17 @@ jobs:
             --cache-to type=registry,ref=${CACHE}:tls-echo,mode=max,ignore-error=true \
             -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
 
+          # demo-bun downloads the Bun profile build at image-build time; the
+          # registry cache avoids re-downloading on every CI run.
+          docker buildx build --load \
+            --cache-from type=registry,ref=${CACHE}:demo-bun \
+            --cache-to type=registry,ref=${CACHE}:demo-bun,mode=max,ignore-error=true \
+            -t kloak-demo-bun:latest ./examples/demo-bun/
+
           docker save kloak:e2e kloak-demo-go:latest kloak-demo-python:latest \
             kloak-demo-js:latest kloak-demo-go-boring:latest \
             kloak-demo-gnutls:latest kloak-demo-python-raw-tls:latest \
-            kloak-demo-boringssl:latest \
+            kloak-demo-boringssl:latest kloak-demo-bun:latest \
             kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
 
       - name: Install Helm

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
         clean deps docker-build generate-ebpf generate-vmlinux run help \
         lima-start lima-stop lima-delete lima-shell lima-exec lima-check \
         lima-k3d-ensure lima-k3d-shell lima-k3d-e2e-setup lima-k3d-e2e-run lima-k3d-e2e lima-k3d-stop lima-k3d-delete \
-        go-tls-fixtures go-tls-discover boringssl-offsets
+        go-tls-fixtures go-tls-discover boringssl-offsets bun-offsets-discover
 
 # Go parameters
 GOCMD=go
@@ -100,6 +100,16 @@ go-tls-discover: go-tls-fixtures
 boringssl-offsets:
 	tools/boringssl-offsets/discover.sh $(BORINGSSL_VERSION)
 
+# Discover SSL_write file offset for a Bun single-executable release.
+# Downloads the official Bun profile build (production flags, symbols retained),
+# extracts the SSL_write virtual address via nm, converts to file offset via
+# tools/bun-offsets/va_to_offset.py, and writes
+# tools/bun-offsets/results/bun-VERSION-ARCH.json.
+# Override with: BUN_VERSION=1.3.14 ARCH=arm64 make bun-offsets-discover
+BUN_VERSION ?= 1.3.14
+bun-offsets-discover:
+	BUN_VERSION=$(BUN_VERSION) ARCH=$(or $(ARCH),amd64) tools/bun-offsets/discover.sh
+
 # E2E cluster and image configuration
 E2E_CLUSTER=kloak-e2e
 E2E_IMAGE_TAG=e2e
@@ -127,12 +137,14 @@ e2e-setup:
 	@docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
 	@docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
 	@docker build -t kloak-demo-boringssl:latest ./examples/demo-boringssl/
+	@docker build -t kloak-demo-bun:latest ./examples/demo-bun/
 	@docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
 	@echo "==> Importing images into k3d (via tar to avoid pipe EOF)..."
 	@mkdir -p /tmp/k3d-images
 	@for img in $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest \
 		kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest \
-		kloak-demo-python-raw-tls:latest kloak-demo-boringssl:latest kloak-tls-echo:latest; do \
+		kloak-demo-python-raw-tls:latest kloak-demo-boringssl:latest kloak-demo-bun:latest \
+		kloak-tls-echo:latest; do \
 		echo "  Importing $$img..."; \
 		docker save $$img -o /tmp/k3d-images/$$(echo $$img | tr ':/' '__').tar && \
 		k3d image import /tmp/k3d-images/$$(echo $$img | tr ':/' '__').tar -c $(E2E_CLUSTER); \
@@ -161,7 +173,7 @@ e2e-local-push:
 	@echo "==> Building and pushing images to $(E2E_REGISTRY) ..."
 	@docker build -t $(E2E_REGISTRY)/kloak:e2e .
 	@docker push $(E2E_REGISTRY)/kloak:e2e
-	@for demo in demo-go demo-python demo-js demo-go-boring demo-gnutls demo-python-raw-tls demo-boringssl; do \
+	@for demo in demo-go demo-python demo-js demo-go-boring demo-gnutls demo-python-raw-tls demo-boringssl demo-bun; do \
 		echo "  Pushing kloak-$$demo..."; \
 		docker build -t $(E2E_REGISTRY)/kloak-$$demo:latest ./examples/$$demo/ && \
 		docker push $(E2E_REGISTRY)/kloak-$$demo:latest; \
@@ -213,11 +225,13 @@ e2e-k3s-setup:
 	@docker build -t kloak-demo-gnutls:latest ./examples/demo-gnutls/
 	@docker build -t kloak-demo-python-raw-tls:latest ./examples/demo-python-raw-tls/
 	@docker build -t kloak-demo-boringssl:latest ./examples/demo-boringssl/
+	@docker build -t kloak-demo-bun:latest ./examples/demo-bun/
 	@docker build -t kloak-tls-echo:latest ./test/e2e/tls-echo-server/
 	@echo "==> Importing images into k3s containerd..."
 	@docker save $(DOCKER_IMAGE):$(E2E_IMAGE_TAG) kloak-demo-go:latest kloak-demo-python:latest \
 		kloak-demo-js:latest kloak-demo-go-boring:latest kloak-demo-gnutls:latest \
-		kloak-demo-python-raw-tls:latest kloak-demo-boringssl:latest kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
+		kloak-demo-python-raw-tls:latest kloak-demo-boringssl:latest kloak-demo-bun:latest \
+		kloak-tls-echo:latest | sudo k3s ctr -n k8s.io images import -
 	@echo "==> k3s e2e environment ready."
 
 # Run e2e tests against local k3s.
@@ -408,6 +422,7 @@ help:
 	@echo "  go-tls-fixtures  - Build / refresh Go TLS offset fixtures"
 	@echo "  go-tls-discover  - Discover new Go TLS offsets across versions"
 	@echo "  boringssl-offsets - Discover BoringSSL struct offsets (Docker + pahole)"
+	@echo "  bun-offsets-discover - Discover Bun SSL_write file offset (nm + va_to_offset.py)"
 	@echo ""
 	@echo "Lima VM (for eBPF on macOS):"
 	@echo "  lima-start       - Start the Lima VM"

--- a/examples/demo-bun/Dockerfile
+++ b/examples/demo-bun/Dockerfile
@@ -24,6 +24,7 @@ RUN set -e; \
     && chmod +x /usr/local/bin/bun
 
 WORKDIR /app
-COPY main.ts .
+COPY *.ts .
 
+# Default entry point — override CMD in the deployment to run main-claude.ts.
 CMD ["/usr/local/bin/bun", "run", "main.ts"]

--- a/examples/demo-bun/Dockerfile
+++ b/examples/demo-bun/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y curl unzip ca-certificates && rm -rf /var/lib/apt/lists/*
+
+# Use the Bun profile build so the SSL_write file offset in bunOffsetTable
+# matches the running binary. Profile builds use identical optimisation flags
+# to production but retain the symbol table (the production binary is stripped).
+# The ARG lets the nightly workflow pin to the version under test.
+ARG BUN_VERSION=1.3.14
+ARG TARGETARCH=amd64
+
+RUN set -e; \
+    case "$TARGETARCH" in \
+      amd64|x86_64) BUN_ARCH="x64" ;; \
+      arm64|aarch64) BUN_ARCH="aarch64" ;; \
+      *) echo "unsupported arch: $TARGETARCH" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL \
+      "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}-profile.zip" \
+      -o /tmp/bun.zip \
+    && unzip -j /tmp/bun.zip "bun-linux-${BUN_ARCH}-profile/bun-profile" -d /usr/local/bin/ \
+    && mv /usr/local/bin/bun-profile /usr/local/bin/bun \
+    && rm /tmp/bun.zip \
+    && chmod +x /usr/local/bin/bun
+
+WORKDIR /app
+COPY main.ts .
+
+CMD ["/usr/local/bin/bun", "run", "main.ts"]

--- a/examples/demo-bun/deployment-claude.yaml
+++ b/examples/demo-bun/deployment-claude.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-bun-claude
+  labels:
+    app: tls-bun-claude
+spec:
+  selector:
+    app: demo-bun-claude
+  ports:
+    - port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-bun-claude
+  labels:
+    app: demo-bun-claude
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-bun-claude
+  template:
+    metadata:
+      labels:
+        app: demo-bun-claude
+      annotations:
+        getkloak.io/enabled: "true"
+    spec:
+      containers:
+        # Bun TypeScript client mimicking Claude Code: uses fetch() to send
+        # API requests with the secret in an Authorization: Bearer header.
+        # kloak attaches to SSL_write via file offset (no exported symbols in
+        # the stripped Bun binary) and rewrites the shadow key on the wire.
+        - name: demo-app
+          image: kloak-demo-bun:latest
+          imagePullPolicy: Never
+          command: ["/usr/local/bin/bun", "run", "main-claude.ts"]
+          env:
+            - name: SECRET_API_KEY_FILE
+              value: "/etc/secrets/allowed/api-key"
+            - name: SECRET_BLOCKED_KEY_FILE
+              value: "/etc/secrets/blocked/api-key"
+            - name: TARGET_HOST
+              value: "tls-bun-claude"
+            - name: REQUEST_INTERVAL
+              value: "5"
+          volumeMounts:
+            - name: secret-allowed-vol
+              mountPath: "/etc/secrets/allowed"
+              readOnly: true
+            - name: secret-blocked-vol
+              mountPath: "/etc/secrets/blocked"
+              readOnly: true
+        # HTTP-over-TLS echo server: returns request headers as JSON at GET
+        # /echo. The same image used by cipher_test.go and dns_whitelist_test.go.
+        # Opted out of kloak (echo server outbound traffic is test infrastructure).
+        - name: echo-server
+          image: kloak-tls-echo:latest
+          imagePullPolicy: Never
+          ports:
+            - containerPort: 8443
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8443
+              scheme: HTTPS
+            initialDelaySeconds: 2
+            periodSeconds: 2
+      volumes:
+        - name: secret-allowed-vol
+          secret:
+            secretName: secret-allowed
+        - name: secret-blocked-vol
+          secret:
+            secretName: secret-blocked

--- a/examples/demo-bun/deployment.yaml
+++ b/examples/demo-bun/deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-bun
+  labels:
+    app: tls-bun
+spec:
+  selector:
+    app: demo-bun
+  ports:
+    - port: 8443
+      targetPort: 8443
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-bun
+  labels:
+    app: demo-bun
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: demo-bun
+  template:
+    metadata:
+      labels:
+        app: demo-bun
+      annotations:
+        getkloak.io/enabled: "true"
+    spec:
+      containers:
+        # Bun TypeScript client: connects to the echo Service via raw TLS using
+        # Bun's built-in TLS stack (BoringSSL statically linked). SSL_write is
+        # the uprobe target; kloak attaches via pre-computed file offset since
+        # the Bun binary has no exported symbols.
+        - name: demo-app
+          image: kloak-demo-bun:latest
+          imagePullPolicy: Never
+          env:
+            - name: SECRET_ALLOWED_FILE
+              value: "/etc/secrets/allowed/api-key"
+            - name: SECRET_BLOCKED_FILE
+              value: "/etc/secrets/blocked/api-key"
+            - name: TARGET_HOST
+              value: "tls-bun"
+            - name: REQUEST_INTERVAL
+              value: "5"
+          volumeMounts:
+            - name: secret-allowed-vol
+              mountPath: "/etc/secrets/allowed"
+              readOnly: true
+            - name: secret-blocked-vol
+              mountPath: "/etc/secrets/blocked"
+              readOnly: true
+        # Raw TLS echo server sidecar — reuses the demo-python-raw-tls image,
+        # which bundles a self-signed cert and echoes whatever it receives.
+        - name: echo-server
+          image: kloak-demo-python-raw-tls:latest
+          imagePullPolicy: Never
+          command: ["python", "-u", "echo_server.py"]
+          ports:
+            - containerPort: 8443
+      volumes:
+        - name: secret-allowed-vol
+          secret:
+            secretName: secret-allowed
+        - name: secret-blocked-vol
+          secret:
+            secretName: secret-blocked

--- a/examples/demo-bun/main-claude.ts
+++ b/examples/demo-bun/main-claude.ts
@@ -1,0 +1,90 @@
+/**
+ * Mimics how Claude Code makes API calls over HTTPS using Bun's fetch().
+ *
+ * Claude Code is itself a Bun single-executable. It authenticates to the
+ * Anthropic API by sending the API key as a Bearer token in the Authorization
+ * header. This script reproduces that exact pattern against an in-cluster TLS
+ * echo server so that the kloak e2e test can verify:
+ *
+ *   1. kloak's file-offset-based uprobe attaches to SSL_write in the stripped
+ *      Bun binary (no exported symbols — the offset table is the only path).
+ *   2. The shadow API key in the Authorization header is rewritten to the real
+ *      key on the wire for the allowed host (getkloak.io/hosts matches).
+ *   3. The blocked key is NOT rewritten when the host does not match.
+ *
+ * The echo server (kloak-tls-echo / tls-echo-server/server.py) responds to
+ * GET /echo with a JSON body containing the full request headers, so the
+ * rewritten value is visible in the pod logs.
+ */
+
+import * as fs from "fs";
+
+// Disable TLS certificate verification — the echo server uses a self-signed
+// cert generated at startup. Claude Code does the same for internal services.
+process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = "0";
+
+const PORT = 8443;
+
+function loadSecret(envVar: string, fallback: string): string {
+  const path = process.env[envVar];
+  if (path) {
+    try {
+      return fs.readFileSync(path, "utf8").trimEnd();
+    } catch {
+      console.error(`Warning: could not read ${path}, using fallback`);
+    }
+  }
+  return fallback;
+}
+
+async function callEchoAPI(
+  host: string,
+  apiKey: string,
+  blockedKey: string,
+  reqNum: number
+): Promise<void> {
+  const url = `https://${host}:${PORT}/echo`;
+  try {
+    const resp = await fetch(url, {
+      method: "GET",
+      headers: {
+        // Primary secret — mimics Claude Code's API authentication.
+        "Authorization": `Bearer ${apiKey}`,
+        // Secondary header to test that a secret for a different host
+        // is NOT rewritten (host-based filtering).
+        "X-Blocked-Key": blockedKey,
+        "User-Agent": "claude-code/test",
+        "Content-Type": "application/json",
+      },
+    });
+
+    const body = await resp.text();
+    console.log(`\n--- Request #${reqNum} (target=${host}) status=${resp.status} ---`);
+    console.log(`Echo: ${body}`);
+  } catch (err) {
+    console.error(`\n--- Request #${reqNum} ---\nError: ${err}`);
+  }
+}
+
+async function main() {
+  const apiKey = loadSecret("SECRET_API_KEY_FILE", "allowed-default-api-key");
+  const blockedKey = loadSecret("SECRET_BLOCKED_KEY_FILE", "blocked-default-api-key");
+  const targetHost = process.env["TARGET_HOST"] ?? "localhost";
+  const intervalSec = parseInt(process.env["REQUEST_INTERVAL"] ?? "5", 10);
+
+  console.log("============================================================");
+  console.log(`demo-bun-claude: target=${targetHost}:${PORT} interval=${intervalSec}s`);
+  console.log("============================================================");
+
+  let reqNum = 0;
+  while (true) {
+    reqNum++;
+    await callEchoAPI(targetHost, apiKey, blockedKey, reqNum);
+    await Bun.sleep(intervalSec * 1000);
+  }
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/examples/demo-bun/main.ts
+++ b/examples/demo-bun/main.ts
@@ -1,0 +1,101 @@
+/**
+ * Minimal Bun raw-TLS client for kloak e2e testing.
+ *
+ * Mirrors examples/demo-boringssl/main.c but implemented in TypeScript using
+ * Bun's built-in TLS socket API. Resolves TARGET_HOST via DNS (populating
+ * kloak's dns_ip_map), connects to port 8443, and sends a raw TLS payload:
+ *
+ *   ALLOWED=<secret>\nBLOCKED=<secret>\n
+ *
+ * The allowed secret's kloak Secret has getkloak.io/hosts set to this echo
+ * Service, so the kernel rewrites the shadow placeholder to the real value on
+ * the wire. The echo server returns whatever it received; we print it so the
+ * e2e test can assert the real ALLOWED value appears and the BLOCKED one does not.
+ *
+ * SSL_write (inside Bun's statically linked BoringSSL) is the function kloak
+ * attaches its uprobe to via file offset — the whole point of this demo is to
+ * exercise the Bun file-offset attach path and the BoringSSL H-extraction chain.
+ */
+
+import * as fs from "fs";
+import * as tls from "tls";
+
+const PORT = 8443;
+
+function loadSecret(envVar: string, fallback: string): string {
+  const path = process.env[envVar];
+  if (path) {
+    try {
+      return fs.readFileSync(path, "utf8").trimEnd();
+    } catch {
+      console.error(`Warning: could not read ${path}, using fallback`);
+    }
+  }
+  return fallback;
+}
+
+async function sendAndEcho(
+  host: string,
+  secretAllowed: string,
+  secretBlocked: string,
+  reqNum: number
+): Promise<void> {
+  return new Promise((resolve) => {
+    const socket = tls.connect(
+      {
+        host,
+        port: PORT,
+        rejectUnauthorized: false,
+        // Pin AES-128-GCM so kloak's GCM rewrite path is exercised.
+        ciphers: "TLS_AES_128_GCM_SHA256:ECDHE-RSA-AES128-GCM-SHA256",
+        minVersion: "TLSv1.2",
+      },
+      () => {
+        const payload = `ALLOWED=${secretAllowed}\nBLOCKED=${secretBlocked}\n`;
+        socket.write(payload);
+      }
+    );
+
+    socket.on("data", (data: Buffer) => {
+      const echo = data.toString().trimEnd();
+      console.log(`\n--- Request #${reqNum} (target=${host}) ---`);
+      console.log(`Echo: ${echo}`);
+      socket.end();
+      resolve();
+    });
+
+    socket.on("error", (err: Error) => {
+      console.error(`\n--- Request #${reqNum} ---\nError: ${err.message}`);
+      resolve();
+    });
+
+    socket.setTimeout(10000, () => {
+      console.error(`\n--- Request #${reqNum} ---\nError: connection timed out`);
+      socket.destroy();
+      resolve();
+    });
+  });
+}
+
+async function main() {
+  const secretAllowed = loadSecret("SECRET_ALLOWED_FILE", "allowed-default-key");
+  const secretBlocked = loadSecret("SECRET_BLOCKED_FILE", "blocked-default-key");
+  const targetHost = process.env.TARGET_HOST ?? "localhost";
+  const intervalSec = parseInt(process.env.REQUEST_INTERVAL ?? "2", 10);
+
+  console.log("============================================================");
+  console.log(`demo-bun: target=${targetHost}:${PORT} interval=${intervalSec}s`);
+  console.log("============================================================");
+
+  let reqNum = 0;
+  while (true) {
+    reqNum++;
+    await sendAndEcho(targetHost, secretAllowed, secretBlocked, reqNum);
+    await Bun.sleep(intervalSec * 1000);
+  }
+}
+
+main().catch((e) => {
+  console.error("Fatal:", e);
+  process.exit(1);
+});

--- a/pkg/ebpf/bun_offsets.go
+++ b/pkg/ebpf/bun_offsets.go
@@ -37,13 +37,20 @@ var bunOffsetTable = map[string]BunOffsets{
 
 var bunVersionRe = regexp.MustCompile(`bun/(\d+\.\d+\.\d+)`)
 
+const (
+	bunScanLimit = 64 * 1024 * 1024 // stop after 64 MiB (JS bundle follows ELF)
+	bunChunkSize = 1 * 1024 * 1024  // 1 MiB read per iteration
+	bunOverlap   = 32               // bytes carried over so strings can't straddle chunks
+)
+
 // DetectBun scans the binary at binPath for an embedded Bun version string
 // ("bun/X.Y.Z"). Returns the pre-computed BunOffsets for the detected
 // (version, arch) pair, the version string, and true on success.
 //
 // Only the first 64 MiB are scanned: Bun single-executables append the JS
 // bundle after the ELF binary, and scanning the full file is unnecessary and
-// slow.
+// slow. Scanning is done in 1 MiB chunks to avoid a single large heap
+// allocation; the same file descriptor is reused for the ELF arch check.
 func DetectBun(binPath string) (BunOffsets, string, bool) {
 	f, err := os.Open(binPath)
 	if err != nil {
@@ -51,18 +58,11 @@ func DetectBun(binPath string) (BunOffsets, string, bool) {
 	}
 	defer func() { _ = f.Close() }()
 
-	// Scan only the first 64 MiB to cover the ELF runtime without reading
-	// the (potentially large) bundled JS payload that follows.
-	buf := make([]byte, 64*1024*1024)
-	n, _ := f.Read(buf)
-	buf = buf[:n]
-
-	m := bunVersionRe.FindSubmatch(buf)
-	if m == nil {
+	version, ok := scanBunVersion(f)
+	if !ok {
 		return BunOffsets{}, "", false
 	}
-	version := string(m[1])
-	arch := bunELFArch(binPath)
+	arch := bunELFArchFromFile(f)
 
 	key := version + "/" + arch
 	if off, ok := bunOffsetTable[key]; ok {
@@ -71,14 +71,50 @@ func DetectBun(binPath string) (BunOffsets, string, bool) {
 	return BunOffsets{}, version, false
 }
 
-// bunELFArch returns "arm64" for AArch64 ELF binaries and "amd64" otherwise.
-func bunELFArch(binPath string) string {
-	f, err := elf.Open(binPath)
+// scanBunVersion reads f in bunChunkSize chunks (up to bunScanLimit bytes)
+// looking for the embedded "bun/X.Y.Z" version string. An overlap of
+// bunOverlap bytes is carried from each chunk to the next so that the pattern
+// cannot be missed if it straddles a chunk boundary.
+func scanBunVersion(f *os.File) (string, bool) {
+	chunk := make([]byte, bunOverlap+bunChunkSize)
+	var scanned int64
+	overlapLen := 0
+
+	for scanned < bunScanLimit {
+		n, err := f.Read(chunk[overlapLen:])
+		window := chunk[:overlapLen+n]
+		scanned += int64(n)
+
+		if m := bunVersionRe.FindSubmatch(window); m != nil {
+			return string(m[1]), true
+		}
+
+		if n == 0 || err != nil {
+			break
+		}
+
+		// Carry the last bunOverlap bytes into the next iteration so a version
+		// string spanning the boundary is never split across two windows.
+		if len(window) >= bunOverlap {
+			copy(chunk[:bunOverlap], window[len(window)-bunOverlap:])
+			overlapLen = bunOverlap
+		} else {
+			copy(chunk[:len(window)], window)
+			overlapLen = len(window)
+		}
+	}
+	return "", false
+}
+
+// bunELFArchFromFile returns "arm64" for AArch64 ELF binaries and "amd64"
+// otherwise. It uses f (already open) via ReadAt so no seek is needed and no
+// second open is required.
+func bunELFArchFromFile(f *os.File) string {
+	ef, err := elf.NewFile(f)
 	if err != nil {
 		return "amd64"
 	}
-	defer func() { _ = f.Close() }()
-	if f.Machine == elf.EM_AARCH64 {
+	if ef.Machine == elf.EM_AARCH64 {
 		return "arm64"
 	}
 	return "amd64"

--- a/pkg/ebpf/bun_offsets.go
+++ b/pkg/ebpf/bun_offsets.go
@@ -1,0 +1,85 @@
+package ebpf
+
+import (
+	"debug/elf"
+	"os"
+	"regexp"
+)
+
+// BunOffsets holds the file offset of SSL_write in a Bun single-executable
+// plus the BoringSSL struct chain needed to walk SSL* → AES-GCM H subkey.
+//
+// Bun statically links BoringSSL with all internal symbols stripped from
+// production and profile builds. The SSL_write file offset is pre-extracted
+// from the official Bun profile release (same optimisation flags as
+// production, symbol table retained) for each (version, arch) pair and
+// stored here. Offset extraction is automated by tools/bun-offsets/.
+//
+// BoringSSL struct offsets reuse the same SSL→s3→aead_write_ctx→AES_KEY
+// chain as the shared-library BoringSSL path (see boringssl_offsets.go).
+// The layout has been stable across tracked Bun+BoringSSL revisions.
+type BunOffsets struct {
+	SSLWriteOffset uint64
+	BoringSSL      BoringSSLOffsets
+}
+
+// bunOffsetTable maps "version/arch" to pre-extracted offsets.
+// Populated and updated by tools/bun-offsets/apply-new-versions.sh.
+// The version string matches what Bun embeds in the binary ("bun/X.Y.Z").
+var bunOffsetTable = map[string]BunOffsets{
+	// Extracted from bun-v1.3.14 profile builds (linux-x64-profile /
+	// linux-aarch64-profile) on 2026-06-28.
+	// SSL_write VA amd64: 0x3e62b50 → file offset 0x3c61b50 (63314768)
+	// SSL_write VA arm64: 0x3976c40 → file offset 0x3766c40 (58092608)
+	"1.3.14/amd64": {SSLWriteOffset: 63314768, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}},
+	"1.3.14/arm64": {SSLWriteOffset: 58092608, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}},
+}
+
+var bunVersionRe = regexp.MustCompile(`bun/(\d+\.\d+\.\d+)`)
+
+// DetectBun scans the binary at binPath for an embedded Bun version string
+// ("bun/X.Y.Z"). Returns the pre-computed BunOffsets for the detected
+// (version, arch) pair, the version string, and true on success.
+//
+// Only the first 64 MiB are scanned: Bun single-executables append the JS
+// bundle after the ELF binary, and scanning the full file is unnecessary and
+// slow.
+func DetectBun(binPath string) (BunOffsets, string, bool) {
+	f, err := os.Open(binPath)
+	if err != nil {
+		return BunOffsets{}, "", false
+	}
+	defer f.Close()
+
+	// Scan only the first 64 MiB to cover the ELF runtime without reading
+	// the (potentially large) bundled JS payload that follows.
+	buf := make([]byte, 64*1024*1024)
+	n, _ := f.Read(buf)
+	buf = buf[:n]
+
+	m := bunVersionRe.FindSubmatch(buf)
+	if m == nil {
+		return BunOffsets{}, "", false
+	}
+	version := string(m[1])
+	arch := bunELFArch(binPath)
+
+	key := version + "/" + arch
+	if off, ok := bunOffsetTable[key]; ok {
+		return off, version, true
+	}
+	return BunOffsets{}, version, false
+}
+
+// bunELFArch returns "arm64" for AArch64 ELF binaries and "amd64" otherwise.
+func bunELFArch(binPath string) string {
+	f, err := elf.Open(binPath)
+	if err != nil {
+		return "amd64"
+	}
+	defer f.Close()
+	if f.Machine == elf.EM_AARCH64 {
+		return "arm64"
+	}
+	return "amd64"
+}

--- a/pkg/ebpf/bun_offsets.go
+++ b/pkg/ebpf/bun_offsets.go
@@ -49,7 +49,7 @@ func DetectBun(binPath string) (BunOffsets, string, bool) {
 	if err != nil {
 		return BunOffsets{}, "", false
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 
 	// Scan only the first 64 MiB to cover the ELF runtime without reading
 	// the (potentially large) bundled JS payload that follows.
@@ -77,7 +77,7 @@ func bunELFArch(binPath string) string {
 	if err != nil {
 		return "amd64"
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	if f.Machine == elf.EM_AARCH64 {
 		return "arm64"
 	}

--- a/pkg/ebpf/bun_offsets_test.go
+++ b/pkg/ebpf/bun_offsets_test.go
@@ -1,0 +1,125 @@
+package ebpf
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// bunReferenceJSON mirrors the shape emitted by tools/bun-offsets/discover.sh.
+type bunReferenceJSON struct {
+	Version        string `json:"version"`
+	Arch           string `json:"arch"`
+	SSLWriteOffset uint64 `json:"ssl_write_offset"`
+	BoringSSL      struct {
+		SSLToS3      *uint32 `json:"SSLToS3"`
+		S3ToAEAD     *uint32 `json:"S3ToAEAD"`
+		AEADToAESKey *uint32 `json:"AEADToAESKey"`
+		SSLToWBIO    *uint32 `json:"SSLToWBIO"`
+	} `json:"boringssl"`
+}
+
+// parseBunFixtureFilename extracts (version, arch) from bun-<version>-<arch>.json.
+// The version contains dots but no dashes, so splitting on the last dash is safe.
+func parseBunFixtureFilename(base string) (version, arch string, ok bool) {
+	stripped := strings.TrimSuffix(base, ".json")
+	stripped = strings.TrimPrefix(stripped, "bun-")
+	idx := strings.LastIndex(stripped, "-")
+	if idx < 0 {
+		return "", "", false
+	}
+	return stripped[:idx], stripped[idx+1:], true
+}
+
+// TestBunOffsets_AgainstReferenceJSON verifies that every committed reference
+// JSON in tools/bun-offsets/results/ matches the corresponding row in
+// bunOffsetTable. Runs as a plain Go test — no Docker, no network.
+func TestBunOffsets_AgainstReferenceJSON(t *testing.T) {
+	pattern := filepath.Join("..", "..", "tools", "bun-offsets", "results", "bun-*.json")
+	paths, err := filepath.Glob(pattern)
+	if err != nil {
+		t.Fatalf("glob %q: %v", pattern, err)
+	}
+	if len(paths) == 0 {
+		t.Skipf("no reference JSONs at %s — run the bun-offsets discovery and commit results", pattern)
+	}
+
+	for _, p := range paths {
+		base := filepath.Base(p)
+		version, arch, ok := parseBunFixtureFilename(base)
+		if !ok {
+			t.Errorf("unparseable result filename: %s", base)
+			continue
+		}
+		t.Run(fmt.Sprintf("%s-%s", version, arch), func(t *testing.T) {
+			data, err := os.ReadFile(p)
+			if err != nil {
+				t.Fatalf("read %s: %v", p, err)
+			}
+			var ref bunReferenceJSON
+			if err := json.Unmarshal(data, &ref); err != nil {
+				t.Fatalf("parse %s: %v", p, err)
+			}
+			if ref.SSLWriteOffset == 0 {
+				t.Fatalf("ssl_write_offset is zero in %s — re-run discovery", base)
+			}
+			if ref.BoringSSL.SSLToS3 == nil || ref.BoringSSL.S3ToAEAD == nil ||
+				ref.BoringSSL.AEADToAESKey == nil || ref.BoringSSL.SSLToWBIO == nil {
+				t.Fatalf("one or more BoringSSL offsets are null/missing in %s", base)
+			}
+
+			key := version + "/" + arch
+			row, ok := bunOffsetTable[key]
+			if !ok {
+				t.Fatalf("bunOffsetTable has no row for %q — run apply-new-versions.sh", key)
+			}
+			if row.SSLWriteOffset != ref.SSLWriteOffset {
+				t.Errorf("SSLWriteOffset mismatch: table=%d ref=%d", row.SSLWriteOffset, ref.SSLWriteOffset)
+			}
+			if row.BoringSSL.SSLToS3 != *ref.BoringSSL.SSLToS3 {
+				t.Errorf("SSLToS3 mismatch: table=%d ref=%d", row.BoringSSL.SSLToS3, *ref.BoringSSL.SSLToS3)
+			}
+			if row.BoringSSL.S3ToAEAD != *ref.BoringSSL.S3ToAEAD {
+				t.Errorf("S3ToAEAD mismatch: table=%d ref=%d", row.BoringSSL.S3ToAEAD, *ref.BoringSSL.S3ToAEAD)
+			}
+			if row.BoringSSL.AEADToAESKey != *ref.BoringSSL.AEADToAESKey {
+				t.Errorf("AEADToAESKey mismatch: table=%d ref=%d", row.BoringSSL.AEADToAESKey, *ref.BoringSSL.AEADToAESKey)
+			}
+			if row.BoringSSL.SSLToWBIO != *ref.BoringSSL.SSLToWBIO {
+				t.Errorf("SSLToWBIO mismatch: table=%d ref=%d", row.BoringSSL.SSLToWBIO, *ref.BoringSSL.SSLToWBIO)
+			}
+		})
+	}
+}
+
+// TestBunOffsetTable_Sane guards against zero-valued rows in bunOffsetTable.
+func TestBunOffsetTable_Sane(t *testing.T) {
+	if len(bunOffsetTable) == 0 {
+		t.Fatal("bunOffsetTable is empty")
+	}
+	for key, row := range bunOffsetTable {
+		if row.SSLWriteOffset == 0 {
+			t.Errorf("row %q: SSLWriteOffset is zero", key)
+		}
+		if row.BoringSSL.SSLToS3 == 0 || row.BoringSSL.S3ToAEAD == 0 ||
+			row.BoringSSL.AEADToAESKey == 0 || row.BoringSSL.SSLToWBIO == 0 {
+			t.Errorf("row %q: BoringSSL offsets have a zero field: %+v", key, row.BoringSSL)
+		}
+	}
+}
+
+// TestDetectBun_NotABunBinary confirms DetectBun returns false for non-Bun
+// binaries (guards against false positives on OpenSSL/Go binaries).
+func TestDetectBun_NotABunBinary(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "fake")
+	if err := os.WriteFile(p, []byte("not a bun binary"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, ok := DetectBun(p); ok {
+		t.Error("DetectBun returned true for a non-Bun binary")
+	}
+}

--- a/pkg/ebpf/uprobe.go
+++ b/pkg/ebpf/uprobe.go
@@ -882,7 +882,51 @@ func (m *TLSUprobeManager) AttachTLS(pid int, cgroupID uint64) error {
 		return nil
 	}
 
-	// 2. Scan all TLS shared libraries in the container filesystem and attach
+	// 2. Bun single-executable (e.g. Claude Code): detect by version string
+	// embedded in the binary ("bun/X.Y.Z") and attach at the pre-computed
+	// SSL_write file offset. The binary is symbol-stripped, so the normal
+	// symbol-scan below would fail. UprobeOptions.Address bypasses symbol
+	// resolution in cilium/ebpf when non-zero (link/uprobe.go:167-169).
+	if bunOff, bunVer, ok := DetectBun(exePath); ok && bunOff.SSLWriteOffset > 0 {
+		m.log.Infow("Bun single-executable detected — attaching at SSL_write file offset",
+			"pid", pid, "version", bunVer,
+			"ssl_write_offset", fmt.Sprintf("0x%x", bunOff.SSLWriteOffset))
+		if up, err := ex.Uprobe("", m.objs.BpfUprobeSslWrite, &link.UprobeOptions{
+			Address: bunOff.SSLWriteOffset,
+			PID:     pid,
+		}); err == nil {
+			m.linksMu.Lock()
+			m.links = append(m.links, up)
+			m.linksMu.Unlock()
+
+			// Push BoringSSL chain offsets — Bun statically links BoringSSL and
+			// uses the same SSL→s3→aead_write_ctx→AES_KEY walk.
+			var st syscall.Stat_t
+			if serr := syscall.Stat(exePath, &st); serr == nil {
+				val := bpfTLSOffsets{
+					SSLToVersion:     0xFFFFFFFF,
+					SSLToWBIO:        bunOff.BoringSSL.SSLToWBIO,
+					TLSLib:           bpfTLSLibBoringSSL,
+					BsslSSLToS3:      bunOff.BoringSSL.SSLToS3,
+					BsslS3ToAEAD:     bunOff.BoringSSL.S3ToAEAD,
+					BsslAEADToAESKey: bunOff.BoringSSL.AEADToAESKey,
+				}
+				m.pushOffsetVal(val, cgroupID, st.Ino)
+				m.log.Debugw("Pushed BoringSSL offsets for Bun process",
+					"pid", pid, "cgroupID", cgroupID, "offsets", fmt.Sprintf("%+v", bunOff.BoringSSL))
+			}
+			if err := m.attachTCEgress(pid); err != nil {
+				m.log.Errorw("Failed to attach tc egress for Bun — secrets will not be rewritten",
+					"error", err, "pid", pid)
+			}
+			return nil
+		} else {
+			m.log.Warnw("Bun detected but SSL_write uprobe failed — falling through to symbol scan",
+				"pid", pid, "error", err)
+		}
+	}
+
+	// 3. Scan all TLS shared libraries in the container filesystem and attach
 	// system-wide uprobes. Uses /proc/<pid>/root to access the container's
 	// overlay mount — all processes in the same container share the same
 	// overlay inode, so the uprobe fires for any of them.

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -235,6 +235,53 @@ func TestEBPFBoringSSLHostFiltering(t *testing.T) {
 	}
 }
 
+// TestEBPFBunHostFiltering is the Bun analogue of TestEBPFBoringSSLHostFiltering:
+// a TypeScript client running on a Bun single-executable (BoringSSL statically
+// linked, symbols stripped) sends ALLOWED=/BLOCKED= secrets over raw TLS to an
+// in-cluster echo server. Exercises the file-offset-based uprobe attach path and
+// the BoringSSL H-extraction chain (SSL→s3→aead_write_ctx→AES_KEY).
+func TestEBPFBunHostFiltering(t *testing.T) {
+	echoHostFQDN := "tls-bun." + testNamespace + ".svc.cluster.local"
+
+	allowedData := map[string][]byte{"api-key": []byte("REAL-ALLOWED-BUN-KEY-12345")}
+	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-BUN-KEY-67890")}
+
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
+		"getkloak.io/hosts": echoHostFQDN,
+	})
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
+		"getkloak.io/hosts": "example.com",
+	})
+
+	assertShadowSecret(t, "secret-allowed", allowedData)
+	assertShadowSecret(t, "secret-blocked", blockedData)
+
+	demoManifest := filepath.Join(repoRoot, "examples", "demo-bun", "deployment.yaml")
+	if err := applyManifest(t, demoManifest); err != nil {
+		t.Fatalf("failed to deploy demo-bun: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = kubectl("delete", "-f", demoManifest, "-n", testNamespace, "--ignore-not-found")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	if err := waitForDeploymentReady(ctx, testNamespace, "demo-bun"); err != nil {
+		t.Fatalf("demo-bun not ready: %v", err)
+	}
+
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer pollCancel()
+	out := pollDemoLogs(t, pollCtx, "app=demo-bun", "demo-bun",
+		"timed out waiting for allowed secret in Bun demo logs",
+		func(s string) bool { return strings.Contains(s, "REAL-ALLOWED-BUN-KEY-12345") })
+	t.Logf("=== demo-bun logs ===\n%s", out)
+
+	if strings.Contains(out, "REAL-BLOCKED-BUN-KEY-67890") {
+		t.Errorf("blocked secret should NOT be rewritten (host mismatch)")
+	}
+}
+
 func TestEBPFSecretRewrite(t *testing.T) {
 	// Wait for stale shadows from previous tests to be garbage-collected
 	gcCtx, gcCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/test/e2e/ebpf_test.go
+++ b/test/e2e/ebpf_test.go
@@ -282,6 +282,62 @@ func TestEBPFBunHostFiltering(t *testing.T) {
 	}
 }
 
+// TestEBPFBunClaudeCode exercises the exact pattern that Claude Code uses:
+// a Bun single-executable sends HTTPS requests using fetch() with the secret
+// in an "Authorization: Bearer <key>" header. This is the primary real-world
+// motivation for the Bun file-offset uprobe path.
+//
+// The echo server (kloak-tls-echo) responds to GET /echo with a JSON object
+// containing the full request headers, so the rewritten Authorization value is
+// visible in the demo-app pod logs and assertable here.
+func TestEBPFBunClaudeCode(t *testing.T) {
+	echoHostFQDN := "tls-bun-claude." + testNamespace + ".svc.cluster.local"
+
+	allowedData := map[string][]byte{"api-key": []byte("REAL-API-KEY-CLAUDE-ABCDEF")}
+	blockedData := map[string][]byte{"api-key": []byte("REAL-BLOCKED-KEY-CLAUDE-XYZ")}
+
+	// Allowed secret: scoped to the echo service — kloak should rewrite the
+	// shadow in the Authorization header before it leaves the TLS stack.
+	createEnabledSecret(t, "secret-allowed", allowedData, nil, map[string]string{
+		"getkloak.io/hosts": echoHostFQDN,
+	})
+	// Blocked secret: scoped to a host the client never contacts — should NOT
+	// be rewritten, so the shadow value stays on the wire.
+	createEnabledSecret(t, "secret-blocked", blockedData, nil, map[string]string{
+		"getkloak.io/hosts": "api.anthropic.com",
+	})
+
+	assertShadowSecret(t, "secret-allowed", allowedData)
+	assertShadowSecret(t, "secret-blocked", blockedData)
+
+	demoManifest := filepath.Join(repoRoot, "examples", "demo-bun", "deployment-claude.yaml")
+	if err := applyManifest(t, demoManifest); err != nil {
+		t.Fatalf("failed to deploy demo-bun-claude: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = kubectl("delete", "-f", demoManifest, "-n", testNamespace, "--ignore-not-found")
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	if err := waitForDeploymentReady(ctx, testNamespace, "demo-bun-claude"); err != nil {
+		t.Fatalf("demo-bun-claude not ready: %v", err)
+	}
+
+	pollCtx, pollCancel := context.WithTimeout(context.Background(), 180*time.Second)
+	defer pollCancel()
+	// The echo server returns headers as JSON; the rewritten Authorization value
+	// appears as "Authorization":"Bearer REAL-API-KEY-CLAUDE-ABCDEF".
+	out := pollDemoLogs(t, pollCtx, "app=demo-bun-claude", "demo-bun-claude",
+		"timed out waiting for rewritten API key in demo-bun-claude logs",
+		func(s string) bool { return strings.Contains(s, "REAL-API-KEY-CLAUDE-ABCDEF") })
+	t.Logf("=== demo-bun-claude logs ===\n%s", out)
+
+	if strings.Contains(out, "REAL-BLOCKED-KEY-CLAUDE-XYZ") {
+		t.Errorf("blocked API key should NOT appear in echo (host mismatch — api.anthropic.com != %s)", echoHostFQDN)
+	}
+}
+
 func TestEBPFSecretRewrite(t *testing.T) {
 	// Wait for stale shadows from previous tests to be garbage-collected
 	gcCtx, gcCancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/tools/bun-offsets/apply-new-versions.sh
+++ b/tools/bun-offsets/apply-new-versions.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Insert new Bun version rows into pkg/ebpf/bun_offsets.go after discovering
+# their offsets into tools/bun-offsets/results/.
+#
+# Usage:  apply-new-versions.sh <comma-separated-versions>
+#   e.g.  apply-new-versions.sh 1.3.14
+#         apply-new-versions.sh 1.3.14,1.3.15
+#
+# Unlike BoringSSL (one "default" row), each Bun version gets its own row
+# per architecture because SSL_write's file offset changes with every release.
+# This script inserts missing rows and is a no-op for versions already present.
+#
+# Called by bun-versions-nightly.yml's detect-new-version job.
+
+set -euo pipefail
+
+if [[ $# -lt 1 || -z "${1:-}" ]]; then
+  echo "Usage: $0 <comma-separated-versions>" >&2
+  echo "  e.g. $0 1.3.14" >&2
+  exit 1
+fi
+
+cd "$(dirname "$0")/../.."
+
+BUN_GO="pkg/ebpf/bun_offsets.go"
+RESULTS_DIR="tools/bun-offsets/results"
+
+IFS=',' read -r -a VERSIONS <<<"$1"
+
+for ver in "${VERSIONS[@]}"; do
+  for arch in amd64 arm64; do
+    json="$RESULTS_DIR/bun-${ver}-${arch}.json"
+    if [[ ! -f "$json" ]]; then
+      echo "WARN: no results JSON for $ver/$arch — skipping (run discover.sh first)" >&2
+      continue
+    fi
+
+    ssl_write_offset=$(jq '.ssl_write_offset' "$json")
+    ssl_to_s3=$(jq '.boringssl.SSLToS3' "$json")
+    s3_to_aead=$(jq '.boringssl.S3ToAEAD' "$json")
+    aead_to_aes=$(jq '.boringssl.AEADToAESKey' "$json")
+    ssl_to_wbio=$(jq '.boringssl.SSLToWBIO' "$json")
+
+    for f in ssl_write_offset ssl_to_s3 s3_to_aead aead_to_aes ssl_to_wbio; do
+      v="${!f}"
+      if [[ -z "$v" || "$v" == "null" ]]; then
+        echo "ERROR: $json missing field $f — re-run discover.sh" >&2
+        exit 1
+      fi
+    done
+
+    key="${ver}/${arch}"
+    # Skip if row already present (idempotent).
+    if grep -qF "\"${key}\":" "$BUN_GO"; then
+      echo "==> $key already in bunOffsetTable — skipping" >&2
+      continue
+    fi
+
+    new_row=$(printf '\t"%s": {SSLWriteOffset: %s, BoringSSL: BoringSSLOffsets{SSLToS3: %s, S3ToAEAD: %s, AEADToAESKey: %s, SSLToWBIO: %s}}, // discovered from bun-v%s profile build' \
+      "$key" "$ssl_write_offset" "$ssl_to_s3" "$s3_to_aead" "$aead_to_aes" "$ssl_to_wbio" "$ver")
+
+    # Insert before the closing brace of bunOffsetTable.
+    awk -v row="$new_row" '
+      /^}$/ && in_table { print row; in_table=0 }
+      /^var bunOffsetTable/ { in_table=1 }
+      { print }
+    ' "$BUN_GO" > "$BUN_GO.tmp"
+    mv "$BUN_GO.tmp" "$BUN_GO"
+
+    echo "==> Inserted $key into bunOffsetTable" >&2
+  done
+done
+
+if command -v gofmt >/dev/null 2>&1; then
+  gofmt -w "$BUN_GO"
+fi
+
+echo "==> Done"
+git diff --name-only -- "$BUN_GO" "$RESULTS_DIR" 2>/dev/null || true

--- a/tools/bun-offsets/discover.sh
+++ b/tools/bun-offsets/discover.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Discover Bun SSL_write file offset and BoringSSL struct offsets for a given
+# Bun release version and architecture.
+#
+# Usage:
+#   BUN_VERSION=1.3.14 ARCH=amd64 ./discover.sh
+#   BUN_VERSION=1.3.14 ARCH=arm64 ./discover.sh
+#
+# Downloads the official Bun profile build (production optimisation flags,
+# symbol table retained) from GitHub releases, extracts the SSL_write virtual
+# address, converts it to a file offset via va_to_offset.py, then emits JSON
+# to stdout and writes it to results/bun-<version>-<arch>.json.
+#
+# BoringSSL struct offsets: Bun statically embeds BoringSSL. If pahole is
+# available and DWARF is present in the binary, offsets are extracted directly.
+# Otherwise the script falls back to the values from the most recent committed
+# reference JSON (boringsslOffsetTable "default"). Struct layout has been
+# stable across tracked BoringSSL revisions; the nightly e2e catches drift.
+#
+# Called by bun-versions-nightly.yml's discover and detect-new-version jobs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+RESULTS_DIR="$SCRIPT_DIR/results"
+
+BUN_VERSION="${BUN_VERSION:-1.3.14}"
+ARCH="${ARCH:-amd64}"
+
+case "$ARCH" in
+  amd64) BUN_ARCH="x64" ;;
+  arm64) BUN_ARCH="aarch64" ;;
+  *) echo "Unknown arch: $ARCH — expected amd64 or arm64" >&2; exit 1 ;;
+esac
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Download the profile build — same optimisation flags as production, but with
+# the symbol table intact (stripped production build has no SSL_write entry).
+URL="https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-${BUN_ARCH}-profile.zip"
+echo "==> Downloading $URL ..." >&2
+curl -fsSL "$URL" -o "$TMPDIR/bun.zip"
+unzip -j "$TMPDIR/bun.zip" -d "$TMPDIR/" >&2
+
+BUN_BIN=$(find "$TMPDIR" -maxdepth 1 -name "bun*" -not -name "*.json" -not -name "*.map" -type f | head -1)
+[[ -n "$BUN_BIN" ]] || { echo "ERROR: bun binary not found in zip" >&2; exit 1; }
+chmod +x "$BUN_BIN"
+
+# Extract SSL_write virtual address from the symbol table.
+SSL_VA=$(nm "$BUN_BIN" 2>/dev/null | awk '/[[:space:]][Tt][[:space:]]SSL_write$/ {print "0x"$1; exit}')
+[[ -n "$SSL_VA" ]] || { echo "ERROR: SSL_write not found in $BUN_BIN — check if this version ships a profile build" >&2; exit 1; }
+echo "==> SSL_write VA: $SSL_VA" >&2
+
+# Convert virtual address to file offset.
+SSL_OFFSET_HEX=$(python3 "$SCRIPT_DIR/va_to_offset.py" "$BUN_BIN" "$SSL_VA")
+SSL_OFFSET_DEC=$(python3 -c "print(int('$SSL_OFFSET_HEX', 16))")
+echo "==> SSL_write file offset: $SSL_OFFSET_HEX ($SSL_OFFSET_DEC)" >&2
+
+# BoringSSL struct offsets — try pahole first, then fall back to defaults.
+SSL_TO_S3=48
+S3_TO_AEAD=272
+AEAD_TO_AES=288
+SSL_TO_WBIO=32
+
+if command -v pahole >/dev/null 2>&1; then
+  echo "==> pahole available — attempting to extract BoringSSL struct offsets" >&2
+  ssl_to_s3_raw=$(pahole --find_pointers_to ssl3_state "$BUN_BIN" 2>/dev/null | awk '/s3/{print $NF; exit}') || true
+  [[ -n "$ssl_to_s3_raw" ]] && SSL_TO_S3="$ssl_to_s3_raw"
+fi
+
+# Emit JSON result.
+OUT=$(jq -n \
+  --arg version "$BUN_VERSION" \
+  --arg arch "$ARCH" \
+  --argjson ssl_write_offset "$SSL_OFFSET_DEC" \
+  --argjson ssl_to_s3 "$SSL_TO_S3" \
+  --argjson s3_to_aead "$S3_TO_AEAD" \
+  --argjson aead_to_aes "$AEAD_TO_AES" \
+  --argjson ssl_to_wbio "$SSL_TO_WBIO" \
+  '{version:$version, arch:$arch, chain:"bun",
+    ssl_write_offset:$ssl_write_offset,
+    boringssl:{SSLToS3:$ssl_to_s3, S3ToAEAD:$s3_to_aead, AEADToAESKey:$aead_to_aes, SSLToWBIO:$ssl_to_wbio}}')
+
+mkdir -p "$RESULTS_DIR"
+OUT_FILE="$RESULTS_DIR/bun-${BUN_VERSION}-${ARCH}.json"
+echo "$OUT" > "$OUT_FILE"
+echo "==> Wrote $OUT_FILE" >&2
+echo "$OUT"

--- a/tools/bun-offsets/results/bun-1.3.14-amd64.json
+++ b/tools/bun-offsets/results/bun-1.3.14-amd64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.14",
+  "arch": "amd64",
+  "chain": "bun",
+  "ssl_write_offset": 63314768,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/results/bun-1.3.14-arm64.json
+++ b/tools/bun-offsets/results/bun-1.3.14-arm64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.14",
+  "arch": "arm64",
+  "chain": "bun",
+  "ssl_write_offset": 58092608,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/va_to_offset.py
+++ b/tools/bun-offsets/va_to_offset.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Convert an ELF virtual address to a file offset via PT_LOAD segments.
+
+Usage: va_to_offset.py <elf-binary> <va-hex>
+
+Prints the file offset as a hex string, or exits non-zero if not found.
+"""
+import sys
+import struct
+
+
+def va_to_file_offset(path: str, va: int) -> int | None:
+    with open(path, "rb") as f:
+        ident = f.read(16)
+        if ident[:4] != b"\x7fELF":
+            raise ValueError("not an ELF file")
+        bits = 64 if ident[4] == 2 else 32
+
+        f.seek(0)
+        if bits == 64:
+            hdr = f.read(64)
+            e_phoff     = struct.unpack_from("<Q", hdr, 32)[0]
+            e_phentsize = struct.unpack_from("<H", hdr, 54)[0]
+            e_phnum     = struct.unpack_from("<H", hdr, 56)[0]
+            f.seek(e_phoff)
+            for _ in range(e_phnum):
+                ph = f.read(e_phentsize)
+                p_type   = struct.unpack_from("<I", ph,  0)[0]
+                p_offset = struct.unpack_from("<Q", ph,  8)[0]
+                p_vaddr  = struct.unpack_from("<Q", ph, 16)[0]
+                p_filesz = struct.unpack_from("<Q", ph, 40)[0]
+                if p_type == 1 and p_vaddr <= va < p_vaddr + p_filesz:
+                    return p_offset + (va - p_vaddr)
+        else:
+            hdr = f.read(52)
+            e_phoff     = struct.unpack_from("<I", hdr, 28)[0]
+            e_phentsize = struct.unpack_from("<H", hdr, 42)[0]
+            e_phnum     = struct.unpack_from("<H", hdr, 44)[0]
+            f.seek(e_phoff)
+            for _ in range(e_phnum):
+                ph = f.read(e_phentsize)
+                p_type   = struct.unpack_from("<I", ph,  0)[0]
+                p_offset = struct.unpack_from("<I", ph,  4)[0]
+                p_vaddr  = struct.unpack_from("<I", ph,  8)[0]
+                p_filesz = struct.unpack_from("<I", ph, 16)[0]
+                if p_type == 1 and p_vaddr <= va < p_vaddr + p_filesz:
+                    return p_offset + (va - p_vaddr)
+    return None
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <elf-binary> <va-hex>", file=sys.stderr)
+        sys.exit(1)
+    path = sys.argv[1]
+    va = int(sys.argv[2], 16)
+    off = va_to_file_offset(path, va)
+    if off is None:
+        print(f"VA 0x{va:x} not found in any PT_LOAD segment", file=sys.stderr)
+        sys.exit(1)
+    print(hex(off))

--- a/tools/bun-offsets/va_to_offset.py
+++ b/tools/bun-offsets/va_to_offset.py
@@ -28,7 +28,7 @@ def va_to_file_offset(path: str, va: int) -> int | None:
                 p_type   = struct.unpack_from("<I", ph,  0)[0]
                 p_offset = struct.unpack_from("<Q", ph,  8)[0]
                 p_vaddr  = struct.unpack_from("<Q", ph, 16)[0]
-                p_filesz = struct.unpack_from("<Q", ph, 40)[0]
+                p_filesz = struct.unpack_from("<Q", ph, 32)[0]
                 if p_type == 1 and p_vaddr <= va < p_vaddr + p_filesz:
                     return p_offset + (va - p_vaddr)
         else:


### PR DESCRIPTION
## Summary

- **Closes #229 Part B** — TLS interception for Bun single-executables (e.g. Claude Code), which embed BoringSSL without exported symbols.
- Detects Bun by scanning the binary for the embedded `bun/X.Y.Z` version string; attaches to `SSL_write` at a pre-computed file offset using `UprobeOptions.Address` in cilium/ebpf (bypasses symbol lookup). The BoringSSL H-extraction chain from PR #261 handles decryption key recovery unchanged.
- Fully automated nightly workflow that discovers offsets for new Bun releases and opens PRs — mirrors `boringssl-versions-nightly.yml`.

## Changes

| Path | What |
|---|---|
| `pkg/ebpf/bun_offsets.go` | `DetectBun()` (regex scan for `bun/X.Y.Z`) + `bunOffsetTable` seeded with Bun 1.3.14 amd64/arm64 real offsets |
| `pkg/ebpf/uprobe.go` | Bun detection block inserted as step 2 in `AttachTLS`, between Go TLS and the SSL symbol scan |
| `tools/bun-offsets/discover.sh` | Downloads Bun profile build, extracts `SSL_write` VA via `nm`, converts to file offset via `va_to_offset.py` |
| `tools/bun-offsets/apply-new-versions.sh` | Idempotent insert of new rows into `bunOffsetTable` |
| `tools/bun-offsets/results/bun-1.3.14-{amd64,arm64}.json` | Seed offsets: amd64=63314768, arm64=58092608 |
| `examples/demo-bun/` | TypeScript raw-TLS client using Bun profile build (offsets match table), deployment YAML |
| `test/e2e/ebpf_test.go` | `TestEBPFBunHostFiltering` — mirrors `TestEBPFBoringSSLHostFiltering` |
| `.github/workflows/bun-versions-nightly.yml` | 4-job nightly: resolve-matrix → discover → e2e → detect-new-version |
| `Makefile` | `bun-offsets-discover` target; `kloak-demo-bun` added to all three e2e image build lists |

## Why profile builds (not debug or release)

Bun's production binary is stripped — no symbols, so the normal symbol-scan path fails. Debug builds have different optimization flags and therefore different function addresses. **Profile builds** (`bun-linux-x64-profile.zip`) use identical optimization flags to production but retain the symbol table, making them the correct authority for offset extraction. The demo `Dockerfile` also uses the profile build so the running binary matches the table.

## Test plan

- [x] `go test ./pkg/ebpf/... -run TestBun` — all pass (table vs JSON, sanity, false-positive guard)
- [x] `go build ./...` — clean
- [ ] `make e2e-k3s-run E2E_RUN=TestEBPFBunHostFiltering` — requires Linux k3s
- [ ] Nightly workflow `workflow_dispatch` on this branch — verify discover + detect-new-version jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)