### PR TITLE
chore(bun): track offsets for bun-v1.3.12,1.3.13

### DIFF
--- a/pkg/ebpf/bun_offsets.go
+++ b/pkg/ebpf/bun_offsets.go
@@ -33,6 +33,10 @@ var bunOffsetTable = map[string]BunOffsets{
 	// SSL_write VA arm64: 0x3976c40 → file offset 0x3766c40 (58092608)
 	"1.3.14/amd64": {SSLWriteOffset: 63314768, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}},
 	"1.3.14/arm64": {SSLWriteOffset: 58092608, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}},
+	"1.3.12/amd64": {SSLWriteOffset: 78108592, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.3.12 profile build
+	"1.3.12/arm64": {SSLWriteOffset: 76482624, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.3.12 profile build
+	"1.3.13/amd64": {SSLWriteOffset: 79149632, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.3.13 profile build
+	"1.3.13/arm64": {SSLWriteOffset: 77478272, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.3.13 profile build
 }
 
 var bunVersionRe = regexp.MustCompile(`bun/(\d+\.\d+\.\d+)`)

--- a/tools/bun-offsets/results/bun-1.3.12-amd64.json
+++ b/tools/bun-offsets/results/bun-1.3.12-amd64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.12",
+  "arch": "amd64",
+  "chain": "bun",
+  "ssl_write_offset": 78108592,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/results/bun-1.3.12-arm64.json
+++ b/tools/bun-offsets/results/bun-1.3.12-arm64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.12",
+  "arch": "arm64",
+  "chain": "bun",
+  "ssl_write_offset": 76482624,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/results/bun-1.3.13-amd64.json
+++ b/tools/bun-offsets/results/bun-1.3.13-amd64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.13",
+  "arch": "amd64",
+  "chain": "bun",
+  "ssl_write_offset": 79149632,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/results/bun-1.3.13-arm64.json
+++ b/tools/bun-offsets/results/bun-1.3.13-arm64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.3.13",
+  "arch": "arm64",
+  "chain": "bun",
+  "ssl_write_offset": 77478272,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}


### PR DESCRIPTION
Automated by `.github/workflows/bun-versions-nightly.yml`.

New Bun release(s) detected: **1.3.12,1.3.13**.

Changes in this PR:
- New `tools/bun-offsets/results/bun-<version>-<arch>.json` per (version, arch).
- New rows in `bunOffsetTable` in `pkg/ebpf/bun_offsets.go` with the
  discovered `ssl_write_offset` and BoringSSL struct offsets.

### Reviewer checklist
- [ ] Diff the JSONs — `ssl_write_offset` is non-zero, BoringSSL offsets in expected ranges.
- [ ] `go test ./pkg/ebpf -run TestBunOffsets` passes.
- [ ] The nightly e2e job passed for the new version.