### PR TITLE
fix(controller): regenerate shadow on same-length, different-Huffman secret rotation (#269)

### DIFF
--- a/pkg/controller/secret_reconciler.go
+++ b/pkg/controller/secret_reconciler.go
@@ -131,11 +131,19 @@ func (r *SecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		originalLen := len(originalBytes)
 		var shadowValue string
 
-		// Try to reuse existing UUID
+		// Try to reuse existing UUID. Reuse is only safe when the existing
+		// shadow's HPACK Huffman bit length still equals the real value's:
+		// generateShadowValue mints a shadow whose Huffman bit length matches
+		// the real exactly, and pkg/ebpf/sync.go relies on that equality for
+		// the HTTP/2 rewrite (an unequal shadow either skips the h2 map entry —
+		// leaking the placeholder upstream — or over-pads with EOS bits, which
+		// strict HPACK decoders reset). A same-length secret rotation to a value
+		// with different Huffman density must therefore regenerate, not reuse.
 		if shadowExists && len(existingShadow.Data[key]) > 0 {
 			existingVal := string(existingShadow.Data[key])
 			if strings.HasPrefix(existingVal, secrets.ValuePrefix) {
-				if len(existingVal) == originalLen {
+				if len(existingVal) == originalLen &&
+					secrets.HuffmanBits(existingVal) == secrets.HuffmanBits(originalValue) {
 					if !gen.Collides(existingVal, secretID) {
 						// Check it doesn't collide with other keys in this same secret
 						if prefix := existingVal[:secrets.ShadowPrefixLen]; !isPrefixUsed(shadowsInBatch, prefix) {

--- a/pkg/controller/secret_reconciler_test.go
+++ b/pkg/controller/secret_reconciler_test.go
@@ -201,6 +201,88 @@ func TestSecretReconciler_UpdateShadow(t *testing.T) {
 	}
 }
 
+// TestSecretReconciler_RotateSameLengthDifferentHuffman is the regression test
+// for #269. Rotating a secret to a NEW value of the SAME byte length but a
+// DIFFERENT HPACK Huffman bit length must regenerate the shadow, not reuse it.
+// generateShadowValue mints a shadow whose Huffman bit length equals the real's
+// exactly, and pkg/ebpf/sync.go relies on that equality for the HTTP/2 rewrite;
+// reusing a shadow minted for the old value would leave HuffmanBits(shadow) !=
+// HuffmanBits(real), which either skips the h2 map entry (placeholder leaks
+// upstream) or over-pads with EOS bits (strict HPACK decoders reset the stream).
+func TestSecretReconciler_RotateSameLengthDifferentHuffman(t *testing.T) {
+	// Both values are 16 bytes and shadowable, but differ in Huffman bit
+	// length (90 vs 111 bits), so a same-length rotation between them must
+	// force regeneration rather than shadow reuse.
+	const v1 = "1234567890abcdef"
+	const v2 = "ABCDEFGHIJKLMNOP"
+	if len(v1) != len(v2) {
+		t.Fatalf("test values must be the same length: %d vs %d", len(v1), len(v2))
+	}
+	if secrets.HuffmanBits(v1) == secrets.HuffmanBits(v2) {
+		t.Fatalf("test values must have different Huffman bit lengths; both are %d", secrets.HuffmanBits(v1))
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rotating-secret",
+			Namespace: "default",
+			Labels:    map[string]string{AnnotationSecretEnabled: "true"},
+			UID:       "rotating-uid",
+		},
+		Data: map[string][]byte{"key": []byte(v1)},
+	}
+
+	r, c := newSecretReconciler(secret)
+	ctx := context.Background()
+	req := ctrl.Request{NamespacedName: types.NamespacedName{Name: "rotating-secret", Namespace: "default"}}
+
+	// First reconcile — mints a shadow matched to v1's Huffman length.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	shadow1 := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "rotating-secret-kloak", Namespace: "default"}, shadow1); err != nil {
+		t.Fatal(err)
+	}
+	firstShadow := string(shadow1.Data["key"])
+	if secrets.HuffmanBits(firstShadow) != secrets.HuffmanBits(v1) {
+		t.Fatalf("initial shadow Huffman bits %d != v1 Huffman bits %d",
+			secrets.HuffmanBits(firstShadow), secrets.HuffmanBits(v1))
+	}
+
+	// Rotate to a same-length value with a different Huffman density.
+	if err := c.Get(ctx, types.NamespacedName{Name: "rotating-secret", Namespace: "default"}, secret); err != nil {
+		t.Fatal(err)
+	}
+	secret.Data["key"] = []byte(v2)
+	if err := c.Update(ctx, secret); err != nil {
+		t.Fatal(err)
+	}
+
+	// Second reconcile — must regenerate so the shadow tracks v2's Huffman length.
+	if _, err := r.Reconcile(ctx, req); err != nil {
+		t.Fatal(err)
+	}
+	shadow2 := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: "rotating-secret-kloak", Namespace: "default"}, shadow2); err != nil {
+		t.Fatal(err)
+	}
+	secondShadow := string(shadow2.Data["key"])
+
+	// The core invariant the HTTP/2 rewrite depends on.
+	if secrets.HuffmanBits(secondShadow) != secrets.HuffmanBits(v2) {
+		t.Errorf("after rotation shadow Huffman bits %d != v2 Huffman bits %d (shadow was not regenerated to match the new value)",
+			secrets.HuffmanBits(secondShadow), secrets.HuffmanBits(v2))
+	}
+	// The old shadow could not have satisfied v2's invariant, so it must change.
+	if secondShadow == firstShadow {
+		t.Errorf("shadow was reused across a different-Huffman-density rotation: %q", secondShadow)
+	}
+	if len(secondShadow) != len(v2) {
+		t.Errorf("shadow length %d != new value length %d", len(secondShadow), len(v2))
+	}
+}
+
 func TestSecretReconciler_HostsLabel(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Fixes #269.

## Problem

When a `getkloak.io/enabled` Secret is rotated to a **new value of the same byte length**, the reconciler reused the existing shadow and the **HTTP/2 (HPACK Huffman) rewrite silently broke** — the app either transmitted the literal `kl::<uuid>` placeholder to the real upstream (no substitution → 401) or the h2 stream was reset by the peer. The HTTP/1.1 plaintext path was unaffected, which is why plaintext-path tests didn't catch it.

## Root cause

`SecretReconciler.Reconcile` decided shadow reuse using only a byte-length check:

```go
if len(existingVal) == originalLen { ... shadowValue = existingVal }
```

`generateShadowValue` mints a shadow whose HPACK Huffman **bit** length equals the real value's exactly, and `pkg/ebpf/sync.go` relies on that equality for the HTTP/2 rewrite. A same-length rotation to a value with different Huffman density kept a shadow whose Huffman length no longer matched, so in `sync.go`:

- **higher** new density → the h2 Huffman map entry is skipped → lookup misses at runtime → **no rewrite**, placeholder leaks upstream;
- **lower** new density → `huffReal` is padded with `0xFF` EOS bytes → EOS padding >7 bits violates RFC 7541 §5.2 → strict HPACK decoders (nghttp2, AWS ALB) **reset the stream**.

The validating webhook couldn't catch this: it runs `CanShadow` on the new value in isolation and has no knowledge that the reconciler would reuse the old shadow.

## Fix

Require `secrets.HuffmanBits(existingVal) == secrets.HuffmanBits(originalValue)` before reusing an existing shadow; otherwise fall through to `gen.Generate` so a fresh, Huffman-matched shadow is minted.

## Test

Adds `TestSecretReconciler_RotateSameLengthDifferentHuffman`: rotates a 16-byte value (90 Huffman bits) to another 16-byte value (111 Huffman bits) and asserts the shadow is regenerated so its Huffman bit length tracks the new value. Verified the test **fails without the fix**:

```
secret_reconciler_test.go:274: after rotation shadow Huffman bits 90 != v2 Huffman bits 111 (shadow was not regenerated to match the new value)
secret_reconciler_test.go:279: shadow was reused across a different-Huffman-density rotation: "kl::77iad1t00e0c"
--- FAIL: TestSecretReconciler_RotateSameLengthDifferentHuffman
```

`go vet` and `go test ./pkg/controller/ ./pkg/secrets/ ./pkg/webhook/` pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
