### PR TITLE
docs: getkloak.io/hosts is single-value, not comma-separated (#271)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ The binary (`cmd/kloak/main.go`) has two subcommands via cobra:
 ### Labels & Annotations
 
 - `getkloak.io/enabled=true` — enable on secrets (label), pods (annotation), namespaces (label), or workloads (label/annotation)
-- `getkloak.io/hosts=host1,host2` — restrict which hosts a secret can be sent to
+- `getkloak.io/hosts=<host>` — restrict which host a secret can be sent to. Accepts a single hostname, a single IP, or `*` (any). A comma-separated list is **not** supported yet — the validating webhook rejects it and the data plane would treat it as one bogus hostname (see spinningfactory/kloak#102 for multi-host support)
 - `getkloak.io/managed=true` — marks shadow secrets created by Kloak
 
 ## Project Layout


### PR DESCRIPTION
Fixes #271.

`CLAUDE.md` advertised `getkloak.io/hosts=host1,host2`, but comma-separated values are not supported:

- `pkg/webhook/secret_validator.go` (`validateHostsLabel`) **rejects** any value containing a comma.
- `pkg/secrets/parse.go` (`ParseHost`) never splits on commas — it otherwise treats the whole string as a single hostname that never matches a resolved IP, so the secret is never rewritten.

This updates the annotation reference to describe the actual contract — a single hostname, a single IP, or `*` (any) — and links spinningfactory/kloak#102 for multi-host support.

The companion documentation site (kloak-web) had the same false claim in several pages; that is fixed in a separate PR against that repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
