### PR TITLE
fix(ci): use AUTOMATION_PAT for go-versions-nightly auto-PR

### DIFF
--- a/.github/workflows/go-versions-nightly.yml
+++ b/.github/workflows/go-versions-nightly.yml
@@ -248,7 +248,15 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      # The PR edits .github/workflows/go-tls-offsets.yml and this workflow
+      # itself, and GitHub refuses to let the default GITHUB_TOKEN push changes
+      # to workflow files (needs the `workflow` scope, which GITHUB_TOKEN cannot
+      # have). So both the checkout and the PR creation use AUTOMATION_PAT — a
+      # PAT (or GitHub App token) with `repo` + `workflow` scopes, stored as a
+      # repo secret. See the "Open PR" step below.
       - uses: actions/checkout@v7
+        with:
+          token: ${{ secrets.AUTOMATION_PAT }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -318,6 +326,20 @@ jobs:
         if: steps.find.outputs.new != ''
         uses: peter-evans/create-pull-request@v8
         with:
+          # PAT/App token with `repo` + `workflow` scopes. Required because the
+          # PR edits .github/workflows/go-tls-offsets.yml and
+          # .github/workflows/go-versions-nightly.yml, which the default
+          # GITHUB_TOKEN is forbidden from pushing.
+          token: ${{ secrets.AUTOMATION_PAT }}
+          # Only commit the intended artifacts. The "Find new minor versions"
+          # step writes scratch files (upstream-minors.txt, tracked-minors.txt,
+          # new-minors.txt) to the repo root; without this, create-pull-request
+          # sweeps them into the PR via `git add -A`.
+          add-paths: |
+            tools/go-tls-offsets/results
+            pkg/ebpf/go_tls_offsets.go
+            .github/workflows/go-tls-offsets.yml
+            .github/workflows/go-versions-nightly.yml
           commit-message: "chore(go): add offset support for Go ${{ steps.find.outputs.new }}"
           branch: auto/go-versions/${{ steps.find.outputs.new }}
           delete-branch: true
@@ -339,6 +361,3 @@ jobs:
             - [ ] Diff the JSONs — offsets in expected ranges, no `notes:` field set.
             - [ ] `go test ./pkg/ebpf -run TestGoTLSOffsets` passes locally.
             - [ ] Spot-check that the on-demand `go-tls-offsets.yml` workflow's matrix matches.
-
-            Note: this PR is opened by the default `GITHUB_TOKEN`; CI may not auto-trigger on push.
-            Push an empty commit or close-and-reopen the PR to kick the per-PR checks if needed.


### PR DESCRIPTION
## Summary
- The nightly "Go Versions Nightly" workflow's `detect-new-version` job has failed every run since 2026-08-20, when Go 1.27 shipped and finally gave the job a real workflow-file diff to push (`.github/workflows/go-tls-offsets.yml` / `go-versions-nightly.yml`). The default `GITHUB_TOKEN` cannot push commits that touch `.github/workflows/*.yml` (needs the `workflow` scope, which `GITHUB_TOKEN` can never have) — GitHub rejects it server-side: `refusing to allow a GitHub App to create or update workflow ... without 'workflows' permission`.
- Switch checkout + PR creation to `secrets.AUTOMATION_PAT` (already used for exactly this purpose in the OpenSSL/BoringSSL nightly workflows).
- Add `add-paths:` to the `Open PR` step so `create-pull-request`'s `git add -A` doesn't sweep the run's scratch files (`upstream-minors.txt`, `tracked-minors.txt`, `new-minors.txt`) into the auto-PR.
- Drop the now-stale PR-body note about `GITHUB_TOKEN` not auto-triggering CI, since PAT-authored PRs trigger CI normally.

This mirrors PR #251 and #254, which fixed the identical two bugs for the OpenSSL/BoringSSL nightly workflows. `go-versions-nightly.yml` was added in #201, before those two fixes landed, and never got them backported — so it sat latent until Go 1.27 exercised the code path.

## Test plan
- [x] `git diff` reviewed — only `.github/workflows/go-versions-nightly.yml` touched, changes isolated to the `detect-new-version` job.
- [x] YAML validated to parse cleanly.
- [ ] Manually dispatch "Go Versions Nightly" after merge (or wait for the next 06:00 UTC schedule) and confirm the `detect-new-version` job succeeds and opens a clean PR for Go 1.27 with no scratch files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)