### PR TITLE
chore(go): add offset support for Go 1.27

### DIFF
--- a/.github/workflows/go-tls-offsets.yml
+++ b/.github/workflows/go-tls-offsets.yml
@@ -34,7 +34,7 @@ jobs:
         # but a workflow matrix can't dynamically resolve at parse time. The
         # nightly `go-versions-nightly.yml` workflow (PR 3) detects new
         # versions and opens an auto-PR that updates this list.
-        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26"]
+        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26", "1.27"]
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/go-versions-nightly.yml
+++ b/.github/workflows/go-versions-nightly.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [linux/amd64, linux/arm64]
-        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26"]
+        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26", "1.27"]
     steps:
       - uses: actions/checkout@v7
 
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26"]
+        go: ["1.20", "1.21", "1.22", "1.23", "1.24", "1.25", "1.26", "1.27"]
     permissions:
       contents: read
       packages: write

--- a/pkg/ebpf/go_tls_offsets.go
+++ b/pkg/ebpf/go_tls_offsets.go
@@ -78,6 +78,7 @@ var goTLSOffsetTableBase = map[string]goTLSOffsetEntry{
 	"1.24": {ConnToCipher: 576, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 	"1.25": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 	"1.26": {ConnToCipher: 560, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
+	"1.27": {ConnToCipher: 584, AEADIfaceOff: 24, PDBase: 728, ConnVersOff: 72},
 }
 
 // goTLSOffsetsForArch converts a base entry to arch-specific GoTLSOffsets

--- a/tools/go-tls-offsets/results/go-1.27-amd64.json
+++ b/tools/go-tls-offsets/results/go-1.27-amd64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.27.1",
+  "arch": "amd64",
+  "conn_to_cipher": 584,
+  "aead_iface_off": 24,
+  "h2_hi_off": 736,
+  "h2_lo_off": 728,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 544,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}

--- a/tools/go-tls-offsets/results/go-1.27-arm64.json
+++ b/tools/go-tls-offsets/results/go-1.27-arm64.json
@@ -1,0 +1,16 @@
+{
+  "go_version": "go1.27.1",
+  "arch": "arm64",
+  "conn_to_cipher": 584,
+  "aead_iface_off": 24,
+  "h2_hi_off": 728,
+  "h2_lo_off": 736,
+  "conn_vers_off": 72,
+  "raw": {
+    "conn_out": 544,
+    "cipher_off": 32,
+    "aead_off": 16,
+    "product_table": 504,
+    "pd_base": 728
+  }
+}


### PR DESCRIPTION
Automated by `.github/workflows/go-versions-nightly.yml`.

New Go release(s) detected on go.dev: **1.27**.

Changes in this PR:
- New `tools/go-tls-offsets/results/go-<v>-<arch>.json` per (version, arch).
- New `goTLSOffsetTableBase` entries in `pkg/ebpf/go_tls_offsets.go`.
- Updated matrix lists in `.github/workflows/go-tls-offsets.yml` and `.github/workflows/go-versions-nightly.yml`.

### Reviewer checklist
- [ ] Diff the JSONs — offsets in expected ranges, no `notes:` field set.
- [ ] `go test ./pkg/ebpf -run TestGoTLSOffsets` passes locally.
- [ ] Spot-check that the on-demand `go-tls-offsets.yml` workflow's matrix matches.