### PR TITLE
fix(bun-offsets): fix discover.sh binary selection and SIGPIPE

### DIFF
--- a/tools/bun-offsets/discover.sh
+++ b/tools/bun-offsets/discover.sh
@@ -44,12 +44,16 @@ echo "==> Downloading $URL ..." >&2
 curl -fsSL "$URL" -o "$TMPDIR/bun.zip"
 unzip -j "$TMPDIR/bun.zip" -d "$TMPDIR/" >&2
 
-BUN_BIN=$(find "$TMPDIR" -maxdepth 1 -name "bun*" -not -name "*.json" -not -name "*.map" -type f | head -1)
+BUN_BIN=$(find "$TMPDIR" -maxdepth 1 -name "bun*" -not -name "*.json" -not -name "*.zip" -not -name "*.linker-map" -type f | head -1)
 [[ -n "$BUN_BIN" ]] || { echo "ERROR: bun binary not found in zip" >&2; exit 1; }
 chmod +x "$BUN_BIN"
 
 # Extract SSL_write virtual address from the symbol table.
-SSL_VA=$(nm "$BUN_BIN" 2>/dev/null | awk '/[[:space:]][Tt][[:space:]]SSL_write$/ {print "0x"$1; exit}')
+# awk exits as soon as it prints the match, closing the pipe while nm is
+# still writing the rest of a very large symbol table — nm then dies from
+# SIGPIPE (exit 141). That's expected, not a real failure; `|| true` keeps
+# it from tripping `set -e` before the emptiness check below can run.
+SSL_VA=$(nm "$BUN_BIN" 2>/dev/null | awk '/[[:space:]][Tt][[:space:]]SSL_write$/ {print "0x"$1; exit}' || true)
 [[ -n "$SSL_VA" ]] || { echo "ERROR: SSL_write not found in $BUN_BIN — check if this version ships a profile build" >&2; exit 1; }
 echo "==> SSL_write VA: $SSL_VA" >&2
 


### PR DESCRIPTION
## Summary
- `Bun Versions Nightly` has failed silently (exit 1, no error message) every run for the last several days. Root cause: `discover.sh`'s `find` excludes `*.json` and `*.map` to isolate the Bun binary from the zip, but the linker-map file is actually named `bun-profile.linker-map` (suffix `-map`, not `.map`), and `bun.zip` itself isn't excluded either — both still match the `bun*` glob. `find`'s directory order isn't guaranteed, and on the GitHub Actions runners it consistently returns the linker-map file first, so `nm` gets handed a text file, fails with "file format not recognized", and that message is swallowed by the script's `2>/dev/null` before `set -euo pipefail` kills the script.
- Fixing that glob exposes a second, previously-masked bug: `nm ... | awk '{print; exit}'` — `awk` closes the pipe as soon as it finds the match, so `nm` (writing a very large unstripped symbol table) dies from SIGPIPE (exit 141) under `pipefail`. Added `|| true`, matching the guard already present a few lines down on the `pahole` call.

## Test plan
- [x] Reproduced the exact CI failure locally (downloaded the actual `bun-linux-x64-profile.zip`, confirmed `find` picks `bun-profile.linker-map` first, confirmed `nm` on it fails the same way, silently, matching the observed exit code 1)
- [x] Ran the fixed script end-to-end for `bun-1.3.14` on both `amd64` and `arm64` — output matches the committed `tools/bun-offsets/results/*.json` byte-for-byte
- [ ] Nightly workflow passes on `main` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)