### PR TITLE
fix(boringssl-offsets): resolve SSLImpl/Bio struct names post 0.20260803.0 refactor

### DIFF
--- a/tools/boringssl-offsets/extract_offsets.sh
+++ b/tools/boringssl-offsets/extract_offsets.sh
@@ -61,19 +61,26 @@ SSL_OBJ=$(find "$BUILD_DIR" -name 'ssl_lib.cc.o' -o -name 'ssl_lib.c.o' 2>/dev/n
 T13_OBJ=$(find "$BUILD_DIR" -name 'tls13_enc.cc.o' -o -name 'tls_record.cc.o' 2>/dev/null | head -1)
 CRYPTO_OBJ=$(find "$BUILD_DIR" -name 'gcm.c.o' -o -name 'gcm.cc.o' -o -name 'e_aes.c.o' -o -name 'cipher_extra.c.o' 2>/dev/null | head -1)
 [ -z "$CRYPTO_OBJ" ] && CRYPTO_OBJ=$(find "$BUILD_DIR" -path '*crypto*' -name '*.o' 2>/dev/null | head -1)
+BIO_OBJ=$(find "$BUILD_DIR" -name 'bio.cc.o' -o -name 'bio.c.o' 2>/dev/null | head -1)
 
 echo "=== BoringSSL Offset Discovery ===" >&2
 echo "Version: $VERSION  Arch: $ARCH" >&2
 echo "SSL object:    $SSL_OBJ" >&2
 echo "TLS13 object:  $T13_OBJ" >&2
 echo "Crypto object: $CRYPTO_OBJ" >&2
+echo "BIO object:    $BIO_OBJ" >&2
 
 # SSL* -> s3
-r=$(get_offset_multi "$SSL_OBJ" "s3" "ssl_st" "bssl::SSL" "SSL")
+# BoringSSL 0.20260803.0+ refactored the C shim: `ssl_st` became a 1-byte
+# opaque shell (DECLARE_OPAQUE_STRUCT) and the real fields moved to
+# bssl::SSLImpl, which derives from it. The empty base contributes zero
+# bytes, so the numeric offsets are unchanged — only the DWARF name moved.
+# Candidates are tried in order, so older tags still resolve via ssl_st.
+r=$(get_offset_multi "$SSL_OBJ" "s3" "ssl_st" "SSLImpl" "bssl::SSL" "SSL")
 SSL_TO_S3="${r%%|*}"; SSL_STRUCT="${r##*|}"
 
 # SSL* -> wbio (socket fd recovery)
-r=$(get_offset_multi "$SSL_OBJ" "wbio" "ssl_st" "bssl::SSL" "SSL")
+r=$(get_offset_multi "$SSL_OBJ" "wbio" "ssl_st" "SSLImpl" "bssl::SSL" "SSL")
 SSL_TO_WBIO="${r%%|*}"
 
 # SSL3_STATE -> aead_write_ctx
@@ -124,8 +131,12 @@ if [ -n "$AEAD_TO_CTX" ] && [ -n "$CTX_TO_STATE" ] && [ -n "$AEAD_GCM_KEY" ] && 
     AEAD_TO_AESKEY=$((AEAD_TO_CTX + CTX_TO_STATE + AEAD_GCM_KEY + GCM_AES_OFF))
 fi
 
-# BIO -> num (socket fd)
-r=$(get_offset_multi "$SSL_OBJ" "num" "bio_st" "bssl::BIO" "BIO")
+# BIO -> num (socket fd). The same 0.20260803.0+ refactor renamed the real BIO
+# struct to bssl::Bio (opaque `bio_st` shell), and the definition only lands
+# in bio.cc.o's DWARF — ssl_lib/gcm TUs reference BIO only as an opaque
+# pointer, which is why this never resolved pre-refactor.
+r=$(get_offset_multi "$BIO_OBJ" "num" "bio_st" "Bio" "bssl::BIO" "BIO")
+[ -z "${r%%|*}" ] && r=$(get_offset_multi "$SSL_OBJ" "num" "bio_st" "bssl::BIO" "BIO")
 [ -z "${r%%|*}" ] && r=$(get_offset_multi "$CRYPTO_OBJ" "num" "bio_st" "BIO")
 BIO_NUM="${r%%|*}"
 


### PR DESCRIPTION
## Problem

`boringssl-versions-nightly.yml` has been failing at `detect-new-version` since Aug 16:

```
ERROR: tools/boringssl-offsets/results/boringssl-0.20260813.0-amd64.json missing field ssl_to_s3 — re-run discovery
```

## Root cause

BoringSSL upstream (between `0.20260616.0` and `0.20260803.0`) refactored its C/C++ type shims via `DECLARE_OPAQUE_STRUCT`:

- `struct ssl_st` became a 1-byte opaque shell; the real fields (`s3`, `wbio`, …) moved to `class bssl::SSLImpl : public ssl_st`
- Same for `struct bio_st` → `class bssl::Bio`

`extract_offsets.sh`'s pahole candidate lists (`ssl_st`/`bssl::SSL`/`SSL`) no longer match, so discovery for the new tags emits `ssl_to_s3: null`, and `apply-new-versions.sh` correctly refuses to sync the default row.

**Why e2e still passed:** the empty base class contributes zero bytes (EBO), so `SSLImpl`'s field layout is byte-identical to the old `ssl_st` — `s3@48`, `wbio@32`, size 168. No runtime drift; the `"default"` row stays correct. The failure was purely struct-name matching in the discovery tooling.

## Fix

- Add `SSLImpl` to the `s3`/`wbio` pahole candidate lists (older tags still resolve via `ssl_st` first)
- Fix `bio_num` (null in every committed JSON so far): add the `Bio` candidate and search a `bio.cc.o` TU — the BIO definition never landed in ssl_lib/gcm objects' DWARF

## Verification

Built discovery images locally (native arm64; layout is LP64-arch-independent) for both tags:

| | ssl_to_s3 | ssl_to_wbio | sizeof SSL | bio_num |
|---|---|---|---|---|
| 0.20260813.0 (via `SSLImpl`) | 48 | 32 | 168 | 40 |
| 0.20260616.0 (via `ssl_st`) | 48 | 32 | 168 | 40 |

Identical to committed references. Once merged, the next nightly re-detects tags `0.20260803.0`/`0.20260813.0`, generates valid JSONs, and opens the results-only auto-PR (the `"default"` row values are unchanged).

## Follow-up

`tools/bun-offsets/discover.sh` greps `--find_pointers_to ssl3_state` and will need similar treatment when Bun re-vendors a refactored BoringSSL.