### PR TITLE
chore(bun): track offsets for bun-v1.4.1

### DIFF
--- a/pkg/ebpf/bun_offsets.go
+++ b/pkg/ebpf/bun_offsets.go
@@ -39,6 +39,8 @@ var bunOffsetTable = map[string]BunOffsets{
 	"1.3.13/arm64": {SSLWriteOffset: 77478272, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.3.13 profile build
 	"1.4.0/amd64":  {SSLWriteOffset: 35821600, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.4.0 profile build
 	"1.4.0/arm64":  {SSLWriteOffset: 34985344, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.4.0 profile build
+	"1.4.1/amd64":  {SSLWriteOffset: 41201600, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.4.1 profile build
+	"1.4.1/arm64":  {SSLWriteOffset: 40102080, BoringSSL: BoringSSLOffsets{SSLToS3: 48, S3ToAEAD: 272, AEADToAESKey: 288, SSLToWBIO: 32}}, // discovered from bun-v1.4.1 profile build
 }
 
 var bunVersionRe = regexp.MustCompile(`bun/(\d+\.\d+\.\d+)`)

--- a/tools/bun-offsets/results/bun-1.4.1-amd64.json
+++ b/tools/bun-offsets/results/bun-1.4.1-amd64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.4.1",
+  "arch": "amd64",
+  "chain": "bun",
+  "ssl_write_offset": 41201600,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}

--- a/tools/bun-offsets/results/bun-1.4.1-arm64.json
+++ b/tools/bun-offsets/results/bun-1.4.1-arm64.json
@@ -1,0 +1,12 @@
+{
+  "version": "1.4.1",
+  "arch": "arm64",
+  "chain": "bun",
+  "ssl_write_offset": 40102080,
+  "boringssl": {
+    "SSLToS3": 48,
+    "S3ToAEAD": 272,
+    "AEADToAESKey": 288,
+    "SSLToWBIO": 32
+  }
+}


### PR DESCRIPTION
Automated by `.github/workflows/bun-versions-nightly.yml`.

New Bun release(s) detected: **1.4.1**.

Changes in this PR:
- New `tools/bun-offsets/results/bun-<version>-<arch>.json` per (version, arch).
- New rows in `bunOffsetTable` in `pkg/ebpf/bun_offsets.go` with the
  discovered `ssl_write_offset` and BoringSSL struct offsets.

### Reviewer checklist
- [ ] Diff the JSONs — `ssl_write_offset` is non-zero, BoringSSL offsets in expected ranges.
- [ ] `go test ./pkg/ebpf -run TestBunOffsets` passes.
- [ ] The nightly e2e job passed for the new version.